### PR TITLE
chore: resolve Dependabot dev dependency alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pkcprotocol/pkc-js",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pkcprotocol/pkc-js",
-            "version": "0.0.14",
+            "version": "0.0.15",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@enhances/with-resolvers": "0.0.5",
@@ -12646,9 +12646,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -14615,16 +14615,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/own-keys": {
@@ -18742,16 +18732,13 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
+            "integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
             "engines": {
-                "node": ">=0.6.0"
+                "node": ">=14.14"
             }
         },
         "node_modules/tmpl": {
@@ -19523,13 +19510,6 @@
             "engines": {
                 "node": ">=20.0.0"
             }
-        },
-        "node_modules/wait-on/node_modules/lodash": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/walk-up-path": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -208,8 +208,10 @@
         "{src,test,config}/**/*.{js,ts}": "prettier --write --config config/prettier.config.js"
     },
     "overrides": {
+        "lodash": "4.18.1",
         "release-it": {
             "undici": "^7.24.7"
-        }
+        },
+        "tmp": "0.2.4"
     }
 }


### PR DESCRIPTION
## Summary
- add targeted npm overrides for transitive dev-only `lodash` and `tmp`
- regenerate `package-lock.json` to clear the current Dependabot alerts
- keep the change scoped to dependency metadata only

## Testing
- npm audit --package-lock-only
- not run: project build or test suites (no source changes)