### PR TITLE
feat(test-runner): auto-log stdout/stderr/per-test to .tmp/

### DIFF
--- a/test/run-test-config.js
+++ b/test/run-test-config.js
@@ -274,15 +274,39 @@ console.log("========================================");
 console.log(`Running tests in ${environment} environment`);
 
 const logPrefix = getLastOption(options, "log-prefix");
-const stdoutLogPath =
+let stdoutLogPath =
     resolveMaybePath(getLastOption(options, "stdout-log")) ?? (logPrefix ? resolveMaybePath(`${logPrefix}.stdout.log`) : undefined);
-const stderrLogPath =
+let stderrLogPath =
     resolveMaybePath(getLastOption(options, "stderr-log")) ?? (logPrefix ? resolveMaybePath(`${logPrefix}.stderr.log`) : undefined);
 
-const perTestLogDir = resolveMaybePath(getLastOption(options, "per-test-logs"));
+let perTestLogDir = resolveMaybePath(getLastOption(options, "per-test-logs"));
+
+// Default log destinations: mirror the test server's auto-logging pattern so
+// a bare `node test/run-test-config.js …` invocation still leaves logs on
+// disk for later inspection.
+if (!stdoutLogPath && !stderrLogPath && !perTestLogDir) {
+    const timestamp = new Date()
+        .toISOString()
+        .replace(/[:.]/g, "-")
+        .replace(/-\d{3}Z$/, "Z");
+    const configLabel = pkcConfigs ? pkcConfigs.replace(/,/g, "-") : "default";
+    const baseName = `test-run-${environment}-${configLabel}-${timestamp}`;
+    stdoutLogPath = resolveMaybePath(`.tmp/${baseName}.stdout.log`);
+    stderrLogPath = resolveMaybePath(`.tmp/${baseName}.stderr.log`);
+    perTestLogDir = resolveMaybePath(`.tmp/${baseName}-per-test`);
+}
+
 if (perTestLogDir) {
     env.PER_TEST_LOG_DIR = perTestLogDir;
 }
+
+const printLogCaptureSummary = () => {
+    if (!stdoutLogPath && !stderrLogPath && !perTestLogDir) return;
+    console.log("\nLog files:");
+    if (stdoutLogPath) console.log(`  stdout:    ${stdoutLogPath}`);
+    if (stderrLogPath) console.log(`  stderr:    ${stderrLogPath}`);
+    if (perTestLogDir) console.log(`  per-test:  ${perTestLogDir}/`);
+};
 
 if (options.has("mocha-spec")) {
     console.warn("The --mocha-spec flag is deprecated. Pass test paths as positional arguments instead.");
@@ -398,10 +422,11 @@ const runNodeTests = () => {
 
     console.log("Vitest CLI:", vitestCli);
     console.log("Vitest arguments:", vitestArgs.join(" "));
-    if (stdoutLogPath || stderrLogPath) {
+    if (stdoutLogPath || stderrLogPath || perTestLogDir) {
         console.log("Log capture:", {
             stdout: stdoutLogPath ?? "console only",
-            stderr: stderrLogPath ?? "console only"
+            stderr: stderrLogPath ?? "console only",
+            perTestLogs: perTestLogDir ?? "disabled"
         });
     }
 
@@ -464,6 +489,7 @@ const runNodeTests = () => {
             }
         }
 
+        printLogCaptureSummary();
         process.exit(code);
     };
 
@@ -562,6 +588,7 @@ const runBrowserTests = () => {
 
     vitestProcess.on("exit", (code) => {
         process.off("exit", terminateBrowserRunner);
+        printLogCaptureSummary();
         process.exit(code);
     });
 };


### PR DESCRIPTION
## Summary
- When `node test/run-test-config.js …` is invoked without `--stdout-log` / `--stderr-log` / `--log-prefix` / `--per-test-logs`, default to writing to `.tmp/test-run-{env}-{config}-{timestamp}.{stdout,stderr}.log` and a matching `-per-test/` directory. Mirrors the test server's auto-logging pattern.
- Resolved log paths are printed both at startup (existing `Log capture:` block) and on exit (new `Log files:` block) so they're easy to find after a run.

## Test plan
- [ ] Run `node test/run-test-config.js --pkc-config "local-kubo-rpc,remote-pkc-rpc" test/node/<some_test>.test.ts` without log flags; verify `.tmp/test-run-*.stdout.log`, `.tmp/test-run-*.stderr.log` and `.tmp/test-run-*-per-test/` are populated.
- [ ] Verify the `Log files:` summary prints at the end of the run.
- [ ] Run with explicit `--stdout-log .tmp/out.log --stderr-log .tmp/err.log` and confirm the auto-default does not kick in.
- [ ] Confirm Ctrl-C still flushes logs (this relies on the fix already merged in #97).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added per-test log directory capture and reporting capabilities.
  * Introduced automatic log path generation with timestamped filenames when no explicit paths are provided.
  * Added summary display of log file locations for easier access.
  * Enhanced logging visibility in test runner console output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pkcprotocol/pkc-js/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->