### PR TITLE
fix(challenges): persist aggregatedComment extras through DB roundtrip

### DIFF
--- a/src/runtime/node/community/local-community/publication-store.ts
+++ b/src/runtime/node/community/local-community/publication-store.ts
@@ -12,7 +12,7 @@ import {
     CommentEditPubsubMessagePublicationSchema,
     CommentEditPubsubMessagePublicationWithFlexibleAuthorSchema
 } from "../../../../publications/comment-edit/schema.js";
-import { CommentIpfsSchema, CommentPubsubMessagePublicationSchema } from "../../../../publications/comment/schema.js";
+import { CommentIpfsSchema } from "../../../../publications/comment/schema.js";
 import { CommentModerationPubsubMessagePublicationSchema } from "../../../../publications/comment-moderation/schema.js";
 import { VotePubsubMessagePublicationSchema } from "../../../../publications/vote/schema.js";
 import { addAllCidsUnderPurgedCommentToBeRemoved, rmUnneededMfsPaths } from "./cleanup.js";
@@ -468,13 +468,18 @@ export async function storeComment(
         pendingApproval
     };
 
+    // Diff against the literal that was actually hashed into commentCid (commentIpfs), not
+    // commentPubsub. Any non-schema key that reached the CID-bound bytes — including
+    // challengeAggregate.aggregatedComment extras spread on top of commentPubsub above — must
+    // round-trip through extraProps so deriveCommentIpfsFromCommentTableRow can reconstruct the
+    // original CID for page generation.
     const unknownProps = remeda
-        .difference(remeda.keys.strict(commentPubsub), remeda.keys.strict(CommentPubsubMessagePublicationSchema.shape))
+        .difference(remeda.keys.strict(commentIpfs), remeda.keys.strict(CommentIpfsSchema.shape))
         .filter((key) => (key as string) !== "communityAddress"); // communityAddress is excluded because it's been converted to communityPublicKey/communityName above
 
     if (unknownProps.length > 0) {
         log("Found extra props on Comment", unknownProps, "Will be adding them to extraProps column");
-        commentRow.extraProps = remeda.pick(commentPubsub, unknownProps);
+        commentRow.extraProps = remeda.pick(commentIpfs, unknownProps);
     }
     if (challengeAggregate?.aggregatedCommentUpdate && Object.keys(challengeAggregate.aggregatedCommentUpdate).length > 0) {
         commentRow.challengeCommentUpdate = challengeAggregate.aggregatedCommentUpdate;

--- a/test/node/community/challenges/aggregated-comment-extras.community.test.ts
+++ b/test/node/community/challenges/aggregated-comment-extras.community.test.ts
@@ -1,0 +1,89 @@
+// Repro for the bug where a challenge returning `{ success: true, comment: { someKey: ... } }`
+// (aggregatedComment) lands in the IPFS-bound bytes (and the stored CID) but is then dropped
+// from the comment row's extraProps. Rebuilding the comment from the DB via
+// deriveCommentIpfsFromCommentTableRow yields different bytes, so its hash no longer matches
+// the stored cid, and remote verifiers fail with ERR_COMMENT_UPDATE_DIFFERENT_CID_THAN_COMMENT
+// when validating any page that embeds the comment.
+//
+// Live incident this reproduces: community 12D3KooWNFgjQWX2EUEs7pixdjkWSLh21EZ9NeYnV8iMaCyYhLGJ
+// installed @bitsocial/flags-challenge which writes `comment["5chan"] = {...assertion}`.
+
+import { mockPKC, generateMockPost, publishWithExpectedResult, resolveWhenConditionIsTrue } from "../../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
+import { it, beforeAll, afterAll, expect } from "vitest";
+import { stringify as deterministicStringify } from "safe-stable-stringify";
+import { calculateIpfsCidV0 } from "../../../../dist/node/util.js";
+import { deriveCommentIpfsFromCommentTableRow } from "../../../../dist/node/runtime/node/util.js";
+import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
+import type {
+    ChallengeFileInput,
+    ChallengeResultInput,
+    GetChallengeArgsInput,
+    CommunityChallengeSetting
+} from "../../../../dist/node/community/types.js";
+
+const flagAssertion = {
+    type: "country",
+    code: "FR",
+    text: "flag:country:FR",
+    issuer: "flags.5chan.app",
+    issuedAt: 1779600000,
+    signature: { type: "ed25519", signature: "deadbeef", publicKey: "issuerPubKey", signedPropertyNames: ["type", "code"] }
+};
+
+// Mirrors @bitsocial/flags-challenge: success returns a `comment` map keyed by a namespace.
+const flagAttachChallenge = (_: { challengeSettings: CommunityChallengeSetting }): ChallengeFileInput => {
+    const type = "text/plain";
+    const getChallenge = async (_args: GetChallengeArgsInput): Promise<ChallengeResultInput> => ({
+        success: true,
+        comment: { "5chan": flagAssertion }
+    });
+    return { getChallenge, type, description: "Always succeeds and attaches a 5chan flag assertion to the comment" };
+};
+
+// Skipped under RPC: registers an in-process challenge factory via pkc.settings.challenges
+// (RPC clients cannot install challenge code on the remote community).
+describeSkipIfRpc("aggregatedComment extras must round-trip through DB into the rebuilt CommentIpfs", async () => {
+    let pkc: PKCType;
+    let community: LocalCommunity;
+    let post: Comment;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        pkc.settings.challenges = { "flag-attach": flagAttachChallenge };
+        community = (await pkc.createCommunity()) as LocalCommunity;
+        community.setMaxListeners(100);
+        await community.edit({ settings: { challenges: [{ name: "flag-attach" }] } });
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+
+        post = await generateMockPost({ communityAddress: community.address, pkc });
+        await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("rebuilt CommentIpfs from the DB row hashes back to the stored cid (aggregatedComment keys preserved)", async () => {
+        const row = community._dbHandler.queryComment(post.cid!);
+        expect(row).to.exist;
+
+        const rebuilt = deriveCommentIpfsFromCommentTableRow(row!);
+
+        // Author must see the challenge-added namespace key on the comment they read back.
+        expect((rebuilt as Record<string, unknown>)["5chan"]).to.deep.equal(flagAssertion);
+
+        // Page generation re-derives the comment via this same path and embeds it in
+        // commentUpdate.replies.pages.best.comments[].comment. Remote verifiers hash that
+        // payload and compare against commentUpdate.cid. If the rebuilt bytes do not hash
+        // back to the stored cid, every page that embeds this comment fails verification
+        // with ERR_COMMENT_UPDATE_DIFFERENT_CID_THAN_COMMENT (surfaced as
+        // ERR_COMMENT_UPDATE_SIGNATURE_IS_INVALID).
+        const recomputedCid = await calculateIpfsCidV0(deterministicStringify(rebuilt)!);
+        expect(recomputedCid).to.equal(row!.cid);
+    });
+});


### PR DESCRIPTION
Closes #103.

## Summary

- Repro test under `test/node/community/challenges/` registers a flag-style challenge that returns `{ success: true, comment: { "5chan": {...} } }` (mirrors `@bitsocial/flags-challenge`), publishes a post, then asserts that `deriveCommentIpfsFromCommentTableRow` of the DB row preserves the namespace key and re-hashes to the stored cid. Fails on master with `expected undefined to deeply equal {...}`.
- Fix in `src/runtime/node/community/local-community/publication-store.ts` diffs `unknownProps` against the hashed literal (`commentIpfs` vs `CommentIpfsSchema.shape`) instead of `commentPubsub` vs `CommentPubsubMessagePublicationSchema.shape`. The challenge-added keys land in `extraProps` and round-trip through `deriveCommentIpfsFromCommentTableRow` for page generation. `validateChallengeResultExtras` already prevents challenges from setting any key in `CommentSignedPropertyNames`, so the broader diff cannot pick up a signed field and corrupt the author signature.

## Why this matters

A live community running 0.0.37 installed `@bitsocial/flags-challenge` (which writes `comment["<namespace>"] = {...assertion}`). After a handful of "test flag" replies, the community went into a permanent failed-sync loop with `ERR_COMMENT_UPDATE_DIFFERENT_CID_THAN_COMMENT` (surfaced as `ERR_COMMENT_UPDATE_SIGNATURE_IS_INVALID`) because the rebuilt CommentIpfs in each page no longer hashed back to the stored cid. The `aggregatedCommentUpdate` path (stored verbatim in the `challengeCommentUpdate` column) is unaffected.

## Test plan

- [x] `node test/run-test-config.js --pkc-config local-kubo-rpc test/node/community/challenges/aggregated-comment-extras.community.test.ts` — fails on prior commit, passes after the fix.
- [x] `node test/run-test-config.js --pkc-config local-kubo-rpc test/challenges/result-extras.test.ts test/node/community/challengeCommentUpdate.db.community.test.ts test/node/community/modqueue/pendingapproval.modqueue.community.test.ts test/node/community/parsing.db.community.test.ts test/node/community/queryComment.quotedCids.db.community.test.ts test/node/community/challenges/path.challenge.test.ts test/node/community/challenges/challenges.subpath.test.ts` — 130/130 pass.
- [x] `npm run build` clean.
- [x] `npx tsc --project test/tsconfig.json` clean.

## Out of scope (follow-ups)

- `bitsocial community list` failing the whole table on one bad community — downstream concern in `@bitsocial/bitsocial-cli`.
- Already-corrupted DB rows on nodes that ran 0.0.37 with such a challenge need a one-off migration that re-derives the cid and prunes mismatches.
- `storeCommentEdit` / `storeCommentModeration` / `storeVote` are currently safe but would acquire the same pattern if `aggregatedCommentEdit` / `aggregatedVote` are ever added.
- `challengeCommentUpdate` JSON column has no parsing test in `test/node/community/parsing.db.community.test.ts` per the AGENTS.md SHOULD rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where extra data from challenge responses wasn't properly preserved in stored comments, which could cause CID mismatches during remote verification.

* **Tests**
  * Added integration test verifying correct storage and retrieval of challenge-provided comment extras.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pkcprotocol/pkc-js/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->