### PR TITLE
feat(community): add features.noReplyLinks to block replies with links

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ CommunityFeatures { // any boolean that changes the functionality of the communi
   noVideoReplies?: boolean // block only replies with video links
   noImageReplies?: boolean // block only replies with image links
   noAudioReplies?: boolean // block only replies with audio links
+  noReplyLinks?: boolean // block all replies that have a link field set
   noSpoilerReplies?: boolean // author can't set spoiler = true on replies
   noNestedReplies?: boolean // no nested replies, like old school forums and 4chan. Maximum depth is 1
   safeForWork?: boolean // informational flag indicating this community is safe for work

--- a/src/community/schema.ts
+++ b/src/community/schema.ts
@@ -50,6 +50,7 @@ export const CommunityFeaturesSchema = z.looseObject({
     noVideoReplies: z.boolean().optional(), // Block only replies with video links
     noSpoilerReplies: z.boolean().optional(), // Author can't set spoiler = true on replies
     noImageReplies: z.boolean().optional(), // Block only replies with image links
+    noReplyLinks: z.boolean().optional(), // Block all replies that have a link field set
     noPolls: z.boolean().optional(), // Not impllemented
     noCrossposts: z.boolean().optional(), // Not implemented
     noNestedReplies: z.boolean().optional(), // No nested replies, like old school forums and 4chan. Maximum depth is 1

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -271,6 +271,7 @@ export enum messages {
     ERR_REPLY_HAS_LINK_THAT_IS_VIDEO = "This community does not allow replies with video links",
     ERR_COMMENT_HAS_LINK_THAT_IS_AUDIO = "This community does not allow comments with audio links",
     ERR_REPLY_HAS_LINK_THAT_IS_AUDIO = "This community does not allow replies with audio links",
+    ERR_REPLY_HAS_LINK = "This community does not allow replies with links",
     ERR_COMMENT_CONTENT_CONTAINS_MARKDOWN_AUDIO = "This community does not allow embedding audio in markdown content",
     ERR_REPLY_HAS_SPOILER_ENABLED = "This community does not allow authors to mark replies as spoilers",
     ERR_NESTED_REPLIES_NOT_ALLOWED = "This community does not allow nested replies (depth > 1)",

--- a/src/runtime/node/community/local-community/publication-validation.ts
+++ b/src/runtime/node/community/local-community/publication-validation.ts
@@ -326,6 +326,9 @@ async function checkCommentPublication(
     )
         return messages.ERR_REPLY_HAS_LINK_THAT_IS_VIDEO;
 
+    // noReplyLinks - block all replies that have a link field set
+    if (community.features?.noReplyLinks && commentPublication.parentCid && commentPublication.link) return messages.ERR_REPLY_HAS_LINK;
+
     // noAudio - block ALL comments with audio links
     if (community.features?.noAudio && commentPublication.link && isLinkOfAudio(commentPublication.link))
         return messages.ERR_COMMENT_HAS_LINK_THAT_IS_AUDIO;

--- a/test/node/community/features/noReplyLinks.community.features.test.ts
+++ b/test/node/community/features/noReplyLinks.community.features.test.ts
@@ -1,0 +1,97 @@
+import {
+    mockPKC,
+    createSubWithNoChallenge,
+    generateMockPost,
+    generateMockComment,
+    publishWithExpectedResult,
+    mockPKCNoDataPathWithOnlyKuboClient,
+    resolveWhenConditionIsTrue,
+    publishRandomPost
+} from "../../../../dist/node/test/test-util.js";
+import { messages } from "../../../../dist/node/errors.js";
+import { describe, it, beforeAll, afterAll } from "vitest";
+import type { PKC } from "../../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { RpcLocalCommunity } from "../../../../dist/node/community/rpc-local-community.js";
+import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
+import type { CommentIpfsWithCidDefined } from "../../../../dist/node/publications/comment/types.js";
+
+describe.concurrent(`community.features.noReplyLinks`, async () => {
+    let pkc: PKC;
+    let remotePKC: PKC;
+    let community: LocalCommunity | RpcLocalCommunity;
+    let publishedPost: Comment;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        remotePKC = await mockPKCNoDataPathWithOnlyKuboClient();
+        community = await createSubWithNoChallenge({}, pkc);
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+
+        // Publish a post first (before enabling the feature)
+        publishedPost = await publishRandomPost({ communityAddress: community.address, pkc: remotePKC });
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+        await remotePKC.destroy();
+    });
+
+    it.sequential(`Feature is updated correctly in props`, async () => {
+        expect(community.features).to.be.undefined;
+        await community.edit({ features: { ...community.features, noReplyLinks: true } });
+        expect(community.features?.noReplyLinks).to.be.true;
+
+        const remoteCommunity = await remotePKC.getCommunity({ address: community.address });
+        await remoteCommunity.update();
+        await resolveWhenConditionIsTrue({
+            toUpdate: remoteCommunity,
+            predicate: async () => remoteCommunity.features?.noReplyLinks === true
+        });
+        expect(remoteCommunity.features?.noReplyLinks).to.be.true;
+        await remoteCommunity.stop();
+    });
+
+    it(`Can publish a post with link (noReplyLinks only blocks replies)`, async () => {
+        const post = await generateMockPost({
+            communityAddress: community.address,
+            pkc: remotePKC,
+            postProps: {
+                link: "https://example.com/article",
+                content: "Just text"
+            }
+        });
+        await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+    });
+
+    it(`Can't publish a reply with a non-media link`, async () => {
+        const reply = await generateMockComment(publishedPost as CommentIpfsWithCidDefined, remotePKC, false, {
+            link: "https://example.com/article"
+        });
+        await publishWithExpectedResult({
+            publication: reply,
+            expectedChallengeSuccess: false,
+            expectedReason: messages.ERR_REPLY_HAS_LINK
+        });
+    });
+
+    it(`Can't publish a reply with a media link`, async () => {
+        const reply = await generateMockComment(publishedPost as CommentIpfsWithCidDefined, remotePKC, false, {
+            link: "https://example.com/photo.jpg"
+        });
+        await publishWithExpectedResult({
+            publication: reply,
+            expectedChallengeSuccess: false,
+            expectedReason: messages.ERR_REPLY_HAS_LINK
+        });
+    });
+
+    it(`Can publish a reply without a link`, async () => {
+        const reply = await generateMockComment(publishedPost as CommentIpfsWithCidDefined, remotePKC, false, {
+            content: "Just text reply"
+        });
+        await publishWithExpectedResult({ publication: reply, expectedChallengeSuccess: true });
+    });
+});


### PR DESCRIPTION
## Summary

Adds a new community feature flag `noReplyLinks` that rejects **any reply whose `link` field is set** (media or not). Posts are unaffected.

### Why
The existing media flags (`noImageReplies` / `noVideoReplies` / `noAudioReplies`) only block replies whose `link` is media; a plain article URL in `link` slips through. There was `requireReplyLink` (force a link) but no flag to *forbid* one. The generic `publication-match` challenge can't express it either — it succeeds when the regex matches (allow-if-match), and an absent property is treated as a match failure, so a "no link" pattern would also reject linkless replies.

### Changes
- **schema** (`src/community/schema.ts`): `noReplyLinks` boolean in `CommunityFeaturesSchema`
- **errors** (`src/errors.ts`): `ERR_REPLY_HAS_LINK`
- **validation** (`src/runtime/node/community/local-community/publication-validation.ts`): in `checkCommentPublication`, reject a reply (has `parentCid`) with any `link`
- **README**: document the flag
- **test** (`test/node/community/features/noReplyLinks.community.features.test.ts`): post-with-link allowed; reply with media link and non-media link both rejected with `ERR_REPLY_HAS_LINK`; linkless reply allowed

### Verification
- `npm run build` — passes
- `npx tsc --project test/tsconfig.json --noEmit` — passes
- New test passes (5/5) via `node test/run-test-config.js --pkc-config "local-kubo-rpc,remote-pkc-rpc" test/node/community/features/noReplyLinks.community.features.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Communities can now enable the optional `noReplyLinks` feature to prevent members from posting replies with external or media links, while allowing link inclusion in original posts. This provides moderators with enhanced control over reply thread quality and helps manage discussion focus by preventing link sharing in comments while maintaining flexibility for primary post content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->