### PR TITLE
fix(modqueue): include challenge-supplied commentUpdate.reason in pending-approval page

### DIFF
--- a/src/runtime/node/community/page-generator.ts
+++ b/src/runtime/node/community/page-generator.ts
@@ -428,7 +428,12 @@ export class PageGenerator {
 
     async _bundleLatestCommentUpdateWithQueuedComments(queuedComment: CommentsTableRow): Promise<ModQueueCommentInPage> {
         const communityAuthor = this._community._dbHandler.queryCommunityAuthor(queuedComment.authorSignerAddress);
+        // Spread the challenge-supplied commentUpdate fields (e.g. `reason`) persisted at storage time
+        // so the mod-queue page matches the live challengeverification sent to the publisher. Base
+        // fields are spread last so they win. signCommentUpdateForChallengeVerification derives
+        // signedPropertyNames from the actual keys, so extras like `reason` are signed automatically.
         const commentUpdateOfVerificationNoSignature = <Omit<ModQueueCommentInPage["commentUpdate"], "signature">>cleanUpBeforePublishing({
+            ...(queuedComment.challengeCommentUpdate ?? {}),
             author: { community: communityAuthor },
             cid: queuedComment.cid,
             protocolVersion: env.PROTOCOL_VERSION,

--- a/test/node/community/challenges/challenge-reason-regular-page.community.test.ts
+++ b/test/node/community/challenges/challenge-reason-regular-page.community.test.ts
@@ -1,0 +1,105 @@
+// End-to-end coverage for challenge-supplied commentUpdate.reason on a REGULAR (non-pending,
+// non-mod-queue) comment, and the precedence when a moderator later sets a reason.
+//
+// A challenge can return { success: true, commentUpdate: { reason } } (without pendingApproval).
+// The reason is persisted (comments.challengeCommentUpdate) and must surface on the served regular
+// CommentUpdate (via comment.update()), signed. When a moderator subsequently publishes a
+// commentModeration with its own reason, the moderator reason must win (db-handler
+// queryCalculatedCommentUpdate: moderatorReason?.reason ?? challengeReason). See issue #110 / PR #111.
+
+import {
+    mockPKC,
+    mockGatewayPKC,
+    publishRandomPost,
+    publishWithExpectedResult,
+    resolveWhenConditionIsTrue
+} from "../../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { RpcLocalCommunity } from "../../../../dist/node/community/rpc-local-community.js";
+import type { SignerType } from "../../../../dist/node/signer/types.js";
+import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
+import type { ChallengeResult } from "../../../../dist/node/community/types.js";
+
+const CHALLENGE_REASON = "flagged by automated review";
+const MOD_REASON = "reviewed by a human moderator";
+
+// A challenge that succeeds immediately (no pendingApproval) while attaching a moderation reason.
+const createReasonChallengeFactory = () => () => ({
+    type: "text/plain" as const,
+    getChallenge: async (): Promise<ChallengeResult> => {
+        // ChallengeResult only types { success }; production challenges attach a commentUpdate. Widen
+        // via a non-literal local so the extra optional field is structurally assignable.
+        const result: ChallengeResult & { commentUpdate?: { reason: string } } = {
+            success: true,
+            commentUpdate: { reason: CHALLENGE_REASON }
+        };
+        return result;
+    }
+});
+
+// LocalCommunity-only: registers an in-process challenge factory the RPC server can't see.
+describeSkipIfRpc("challenge-supplied commentUpdate.reason on a regular comment", async () => {
+    let pkc: PKCType;
+    let remotePKC: PKCType;
+    let community: LocalCommunity | RpcLocalCommunity;
+    let modSigner: SignerType;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        remotePKC = await mockGatewayPKC();
+        pkc.settings = { challenges: { "reason-challenge": createReasonChallengeFactory() } };
+
+        community = (await pkc.createCommunity()) as LocalCommunity | RpcLocalCommunity;
+        community.setMaxListeners(100);
+        modSigner = await pkc.createSigner();
+        await community.edit({
+            settings: {
+                challenges: [
+                    {
+                        name: "reason-challenge",
+                        // no pendingApproval: the comment publishes as a regular comment
+                        exclude: [{ role: ["moderator", "admin", "owner"] }]
+                    }
+                ]
+            },
+            roles: { [modSigner.address]: { role: "moderator" } }
+        });
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+        await remotePKC.destroy();
+    });
+
+    it("serves the challenge reason on the regular commentUpdate, then a mod reason overrides it", async () => {
+        // Published by a non-mod author, so the challenge runs and attaches the reason.
+        const post = (await publishRandomPost({ communityAddress: community.address, pkc: remotePKC })) as Comment;
+
+        await post.update();
+        await resolveWhenConditionIsTrue({ toUpdate: post, predicate: async () => typeof post.raw.commentUpdate?.reason === "string" });
+
+        // The served regular CommentUpdate carries and signs the challenge-supplied reason.
+        expect(post.raw.commentUpdate!.reason).to.equal(CHALLENGE_REASON);
+        expect(post.raw.commentUpdate!.signature.signedPropertyNames).to.include("reason");
+
+        // A moderator publishes its own reason; it must win over the challenge's.
+        const commentMod = await remotePKC.createCommentModeration({
+            commentModeration: { pinned: true, reason: MOD_REASON },
+            commentCid: post.cid!,
+            signer: modSigner,
+            communityAddress: community.address
+        });
+        await publishWithExpectedResult({ publication: commentMod, expectedChallengeSuccess: true });
+
+        await resolveWhenConditionIsTrue({ toUpdate: post, predicate: async () => post.raw.commentUpdate?.reason === MOD_REASON });
+        expect(post.raw.commentUpdate!.reason).to.equal(MOD_REASON);
+
+        await post.stop();
+    });
+});

--- a/test/node/community/modqueue/reason.modqueue.community.test.ts
+++ b/test/node/community/modqueue/reason.modqueue.community.test.ts
@@ -1,0 +1,97 @@
+// Regression test: a challenge that returns { success: true, commentUpdate: { reason } } (as
+// @bitsocial/ai-moderation-challenge does on its "review" branch) attaches a moderation reason to a
+// pending-approval comment. The reason is correctly signed and delivered to the publisher in the
+// live challengeverification, but it must ALSO appear in the stored pending-approval mod-queue page
+// that mods fetch from community.modQueue.pageCids.pendingApproval. See issue #110.
+
+import { mockPKC, mockGatewayPKC, publishCommentToModQueue, resolveWhenConditionIsTrue } from "../../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { RpcLocalCommunity } from "../../../../dist/node/community/rpc-local-community.js";
+import type { DecryptedChallengeVerificationMessageType } from "../../../../dist/node/pubsub-messages/types.js";
+import type { ChallengeResult } from "../../../../dist/node/community/types.js";
+
+const REASON_FROM_CHALLENGE = "fortune check is missing";
+
+// A challenge that sends the comment to pending approval while attaching a moderation reason,
+// exactly like @bitsocial/ai-moderation-challenge does on its "review" branch.
+const createReasonChallengeFactory = () => () => ({
+    type: "text/plain" as const,
+    getChallenge: async (): Promise<ChallengeResult> => {
+        // ChallengeResult only types { success }, but production challenges attach a commentUpdate.
+        // Use a widened (non-literal) local so the extra optional field is structurally assignable to
+        // the declared union without an excess-property error.
+        const result: ChallengeResult & { commentUpdate?: { reason: string } } = {
+            success: true,
+            commentUpdate: { reason: REASON_FROM_CHALLENGE }
+        };
+        return result;
+    }
+});
+
+// LocalCommunity-only: registers a custom in-process challenge factory on the local PKC, which the
+// RPC server process cannot see.
+describeSkipIfRpc("commentUpdate.reason from a challenge in the pending-approval mod-queue page", async () => {
+    let pkc: PKCType;
+    let remotePKC: PKCType;
+    let community: LocalCommunity | RpcLocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        remotePKC = await mockGatewayPKC();
+        pkc.settings = { challenges: { "reason-challenge": createReasonChallengeFactory() } };
+
+        community = (await pkc.createCommunity()) as LocalCommunity | RpcLocalCommunity;
+        community.setMaxListeners(100);
+        await community.edit({
+            settings: {
+                challenges: [
+                    {
+                        name: "reason-challenge",
+                        pendingApproval: true,
+                        exclude: [{ role: ["moderator", "admin", "owner"] }]
+                    }
+                ]
+            }
+        });
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+        await remotePKC.destroy();
+    });
+
+    it("includes the challenge-supplied reason in both the live verification and the mod-queue page", async () => {
+        const { comment, challengeVerification } = await publishCommentToModQueue({
+            community,
+            pkc: remotePKC,
+            commentProps: { challengeRequest: { challengeAnswers: ["x"] } }
+        });
+
+        const cv = challengeVerification as DecryptedChallengeVerificationMessageType;
+
+        // Sanity: the already-working live-verification path carries the signed reason.
+        expect(comment.pendingApproval).to.be.true;
+        expect(cv.commentUpdate!.pendingApproval).to.be.true;
+        expect((cv.commentUpdate as { reason?: string }).reason).to.equal(REASON_FROM_CHALLENGE);
+
+        // The bug: the regenerated pending-approval mod-queue page must also carry the signed reason.
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => Boolean(community.modQueue.pageCids?.pendingApproval)
+        });
+        const rawPage = JSON.parse((await pkc.fetchCid({ cid: community.modQueue.pageCids!.pendingApproval! })).content) as {
+            comments: { comment: { cid?: string }; commentUpdate: { reason?: string; signature: { signedPropertyNames: string[] } } }[];
+        };
+
+        const pageEntry = rawPage.comments.find((c) => c.commentUpdate && c.comment);
+        expect(pageEntry, "pending comment should be present in the mod-queue page").to.exist;
+        expect(pageEntry!.commentUpdate.reason).to.equal(REASON_FROM_CHALLENGE);
+        expect(pageEntry!.commentUpdate.signature.signedPropertyNames).to.include("reason");
+    });
+});


### PR DESCRIPTION
Closes #110.

## Problem

A community challenge can return `{ success: true, commentUpdate: { reason } }` (e.g. `@bitsocial/ai-moderation-challenge` on its `review` branch) to attach a moderation reason when a comment goes to pending approval. The reason is persisted (`comments.challengeCommentUpdate`) and signed into the **live challengeverification** delivered to the publisher — but it was **missing from the stored pending-approval mod-queue page** that mods fetch from `community.modQueue.pageCids.pendingApproval`.

Observed in production (pkc-js 0.0.38): the publisher's `onChallengeVerification` had `commentUpdate.reason = "fortune check is missing"` (signed), while the fetched mod-queue page's `commentUpdate` had keys only `[author, cid, pendingApproval, protocolVersion, signature]` — no reason.

## Root cause

`PageGenerator._bundleLatestCommentUpdateWithQueuedComments` (`src/runtime/node/community/page-generator.ts`) rebuilt the page commentUpdate from only `{ author, cid, protocolVersion, pendingApproval }`, ignoring `queuedComment.challengeCommentUpdate` even though the full `CommentsTableRow` (with that column) was available.

## Fix

Spread `queuedComment.challengeCommentUpdate` into the commentUpdate before signing (base fields last so they win), mirroring `storePublicationAndEncryptForChallengeVerification`. Signing already derives `signedPropertyNames` from the actual object keys, so `reason` is signed and client-verified automatically. The mod-queue page schema already permits the extra key (`CommentUpdateForChallengeVerificationSchema.loose()`), so no schema/signing changes were needed.

## Test

New `test/node/community/modqueue/reason.modqueue.community.test.ts`: registers an in-process challenge returning `{ success: true, commentUpdate: { reason } }` with `pendingApproval: true`, publishes a comment, then fetches the pending-approval page and asserts the page comment's `commentUpdate.reason` is present and signed. Verified red against unmodified `src/`, green after the fix. The existing `pendingapproval.modqueue.community.test.ts` suite (88 tests) still passes — the change is inert when no `challengeCommentUpdate` is stored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Moderation reasons provided by challenge verifications are now correctly preserved and included in the stored pending-approval mod-queue entries and signatures.

* **Tests**
  * Added end-to-end tests verifying that challenge-supplied moderation reasons persist in pending-approval pages and that moderator overrides take precedence on regular comment pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->