### PR TITLE
refactor(publication): single-object param for publishChallengeAnswers

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ PubsubSignature {
   - [`startedstatechange`](#startedstatechange)
 - [Comment API](#comment-api)
   - [`comment.publish()`](#commentpublish)
-  - [`comment.publishChallengeAnswers()`](#commentpublishchallengeanswerschallengeanswers)
+  - [`comment.publishChallengeAnswers()`](#commentpublishchallengeanswers-challengeanswers)
   - [`comment.update()`](#commentupdate)
   - [`comment.stop()`](#commentstop)
   - `comment.author`
@@ -854,7 +854,7 @@ const createCommunityEditOptions = {communityName: 'news.bso', communityEdit: {t
 const communityEdit = await pkc.createCommunityEdit(createCommunityEditOptions)
 communityEdit.on('challenge', async (challengeMessage) => {
   const challengeAnswers = await askUserForChallengeAnswers(challengeMessage.challenges)
-  communityEdit.publishChallengeAnswers(challengeAnswers)
+  communityEdit.publishChallengeAnswers({ challengeAnswers })
 })
 communityEdit.on('challengeverification', console.log)
 await communityEdit.publish()
@@ -913,7 +913,7 @@ An object which may have the following keys:
 const comment = await pkc.createComment(createCommentOptions)
 comment.on('challenge', async (challengeMessage) => {
   const challengeAnswers = await askUserForChallengeAnswers(challengeMessage.challenges)
-  comment.publishChallengeAnswers(challengeAnswers)
+  comment.publishChallengeAnswers({ challengeAnswers })
 })
 comment.on('challengeverification', console.log)
 await comment.publish()
@@ -991,7 +991,7 @@ An object which may have the following keys:
 const commentEdit = await pkc.createCommentEdit(createCommentEditOptions)
 commentEdit.on('challenge', async (challengeMessage) => {
   const challengeAnswers = await askUserForChallengeAnswers(challengeMessage.challenges)
-  commentEdit.publishChallengeAnswers(challengeAnswers)
+  commentEdit.publishChallengeAnswers({ challengeAnswers })
 })
 commentEdit.on('challengeverification', console.log)
 await commentEdit.publish()
@@ -1062,7 +1062,7 @@ An object which may have the following keys:
 const commentModeration = await pkc.createCommentModeration(createCommentModerationOptions)
 commentModeration.on('challenge', async (challengeMessage) => {
   const challengeAnswers = await askUserForChallengeAnswers(challengeMessage.challenges)
-  commentModeration.publishChallengeAnswers(challengeAnswers)
+  commentModeration.publishChallengeAnswers({ challengeAnswers })
 })
 commentModeration.on('challengeverification', console.log)
 await commentModeration.publish()
@@ -1115,7 +1115,7 @@ An object which may have the following keys:
 const vote = await pkc.createVote(createVoteOptions)
 vote.on('challenge', async (challengeMessage) => {
   const challengeAnswers = await askUserForChallengeAnswers(challengeMessage.challenges)
-  vote.publishChallengeAnswers(challengeAnswers)
+  vote.publishChallengeAnswers({ challengeAnswers })
 })
 vote.on('challengeverification', console.log)
 await vote.publish()
@@ -1399,13 +1399,13 @@ The comment API for publishing a comment as an author, or getting comment update
 const comment = await pkc.createComment(commentObject)
 comment.on('challenge', async (challengeMessage) => {
   const challengeAnswers = await askUserForChallengeAnswers(challengeMessage.challenges)
-  comment.publishChallengeAnswers(challengeAnswers)
+  comment.publishChallengeAnswers({ challengeAnswers })
 })
 comment.on('challengeverification', console.log)
 await comment.publish()
 ```
 
-### `comment.publishChallengeAnswers(challengeAnswers)`
+### `comment.publishChallengeAnswers({ challengeAnswers })`
 
 > Publish your answers to the challenges e.g. the captcha answers.
 
@@ -1421,7 +1421,7 @@ await comment.publish()
 const comment = await pkc.createComment(commentObject)
 comment.on('challenge', async (challengeMessage) => {
   const challengeAnswers = await askUserForChallengeAnswers(challengeMessage.challenges)
-  comment.publishChallengeAnswers(challengeAnswers)
+  comment.publishChallengeAnswers({ challengeAnswers })
 })
 comment.on('challengeverification', console.log)
 await comment.publish()
@@ -1512,7 +1512,7 @@ Object is of the form:
 const comment = await pkc.createComment(commentObject)
 comment.on('challenge', async (challengeMessage) => {
   const challengeAnswers = await askUserForChallengeAnswers(challengeMessage.challenges)
-  comment.publishChallengeAnswers(challengeAnswers)
+  comment.publishChallengeAnswers({ challengeAnswers })
 })
 comment.on('challengeverification', console.log)
 await comment.publish()
@@ -1541,7 +1541,7 @@ Object is of the form:
 const comment = await pkc.createComment(commentObject)
 comment.on('challenge', async (challengeMessage) => {
   const challengeAnswers = await askUserForChallengeAnswers(challengeMessage.challenges)
-  comment.publishChallengeAnswers(challengeAnswers)
+  comment.publishChallengeAnswers({ challengeAnswers })
 })
 comment.on('challengeverification', (challengeVerification) => console.log('published post cid is', challengeVerification?.publication?.cid))
 await comment.publish()

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -538,7 +538,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
         else this._clientsManager.updateKuboRpcPubsubState(pubsubState, keyOrUrl);
     }
 
-    async publishChallengeAnswers(challengeAnswers: DecryptedChallengeAnswerMessageType["challengeAnswers"]) {
+    async publishChallengeAnswers({ challengeAnswers }: { challengeAnswers: DecryptedChallengeAnswerMessageType["challengeAnswers"] }) {
         const log = Logger("pkc-js:publication:publishChallengeAnswers");
 
         const toEncryptAnswers = parseDecryptedChallengeAnswerWithPKCErrorIfItFails(<DecryptedChallengeAnswer>{

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -1509,7 +1509,7 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
 
         await this._getPKCInstance(); // to await for settings change
 
-        await publication.publishChallengeAnswers(decryptedChallengeAnswers.challengeAnswers);
+        await publication.publishChallengeAnswers({ challengeAnswers: decryptedChallengeAnswers.challengeAnswers });
 
         return { success: true };
     }

--- a/src/test/test-util.ts
+++ b/src/test/test-util.ts
@@ -1052,7 +1052,7 @@ export async function generatePostToAnswerMathQuestion(props: Partial<CreateComm
     const mockPost = await generateMockPost({ communityAddress: props.communityAddress, pkc, postProps: props });
     mockPost.removeAllListeners("challenge");
     mockPost.once("challenge", (challengeMessage) => {
-        mockPost.publishChallengeAnswers(["2"]);
+        mockPost.publishChallengeAnswers({ challengeAnswers: ["2"] });
     });
 
     return mockPost;

--- a/test/node-and-browser/publications/comment/clients/rpc.clients.test.ts
+++ b/test/node-and-browser/publications/comment/clients/rpc.clients.test.ts
@@ -48,7 +48,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-pkc-rpc"] 
             mockPost.clients.pkcRpcClients[rpcUrl].on("statechange", (newState: string) => actualStates.push(newState));
 
             mockPost.once("challenge", async (challengeMsg) => {
-                await mockPost.publishChallengeAnswers(["2"]); // hardcode answer here
+                await mockPost.publishChallengeAnswers({ challengeAnswers: ["2"] }); // hardcode answer here
             });
 
             await publishWithExpectedResult({ publication: mockPost, expectedChallengeSuccess: true });

--- a/test/node-and-browser/publications/comment/publish/publishingstate.comment.test.ts
+++ b/test/node-and-browser/publications/comment/publish/publishingstate.comment.test.ts
@@ -234,7 +234,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
             mockPost.once("challenge", async (challengeMsg) => {
                 expect(challengeMsg?.challenges[0]?.challenge).to.be.a("string");
-                await mockPost.publishChallengeAnswers(["12345"]); // Wrong answer here
+                await mockPost.publishChallengeAnswers({ challengeAnswers: ["12345"] }); // Wrong answer here
             });
 
             await publishWithExpectedResult({ publication: mockPost, expectedChallengeSuccess: false });

--- a/test/node-and-browser/publications/comment/publish/pubsub.test.ts
+++ b/test/node-and-browser/publications/comment/publish/pubsub.test.ts
@@ -172,7 +172,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc"]
 
                 mockPost.on("challenge", async (challenge) => {
                     challengesReceived.push(challenge);
-                    await mockPost.publishChallengeAnswers(["2"]);
+                    await mockPost.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await publishWithExpectedResult({ publication: mockPost, expectedChallengeSuccess: true });

--- a/test/node-and-browser/pubsub-msgs/challenge.test.ts
+++ b/test/node-and-browser/pubsub-msgs/challenge.test.ts
@@ -56,7 +56,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             });
             mockPost.removeAllListeners();
             mockPost.once("challenge", (challengeMessage: unknown) => {
-                mockPost.publishChallengeAnswers(["3"]); // wrong answer
+                mockPost.publishChallengeAnswers({ challengeAnswers: ["3"] }); // wrong answer
             });
             let challengeverification: { challengeErrors: Record<number, string>; challengeSuccess: boolean } | undefined;
             mockPost.once("challengeverification", (msg) => {

--- a/test/node-and-browser/pubsub-msgs/properties.pubsub.test.ts
+++ b/test/node-and-browser/pubsub-msgs/properties.pubsub.test.ts
@@ -205,7 +205,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             const challengeVerificationPromise = new Promise<ChallengeVerification>((resolve) =>
                 comment.once("challengeverification", resolve as (msg: unknown) => void)
             );
-            await comment.publishChallengeAnswers(["12345"]); // wrong answer here
+            await comment.publishChallengeAnswers({ challengeAnswers: ["12345"] }); // wrong answer here
             const challengeVerifcation = await challengeVerificationPromise;
             expect(challengeVerifcation.challengeRequestId.constructor.name).to.equal("Uint8Array");
             expect(challengeVerifcation.challengeRequestId.length).to.equal(38);

--- a/test/node-and-browser/signatures/pubsub.messages.test.ts
+++ b/test/node-and-browser/signatures/pubsub.messages.test.ts
@@ -366,7 +366,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             comment.removeAllListeners();
             await comment.publish();
 
-            comment.once("challenge", () => comment.publishChallengeAnswers(["2"]));
+            comment.once("challenge", () => comment.publishChallengeAnswers({ challengeAnswers: ["2"] }));
 
             const challengeAnswerPubsubMsg = await new Promise<DecryptedChallengeAnswerMessageType>((resolve) =>
                 comment.once("challengeanswer", resolve)
@@ -450,7 +450,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                 comment._clientsManager.pubsubPublishOnProvider =
                     (async () => {}) as typeof comment._clientsManager.pubsubPublishOnProvider; // Disable publishing
 
-                await comment.publishChallengeAnswers(["test hello"]);
+                await comment.publishChallengeAnswers({ challengeAnswers: ["test hello"] });
                 // comment._challengeAnswer should be defined now
 
                 const challengeAnswersPubsubMessage = Object.values(comment._challengeExchanges).find(

--- a/test/node/community/challenges/path.challenge.test.ts
+++ b/test/node/community/challenges/path.challenge.test.ts
@@ -109,7 +109,7 @@ describeSkipIfRpc.concurrent(`community.settings.challenges with path`, async ()
         mockPost.once("challenge", async (msg: DecryptedChallengeMessageType) => {
             challengeReceived = true;
             challengeData = msg;
-            await mockPost.publishChallengeAnswers(["London"]);
+            await mockPost.publishChallengeAnswers({ challengeAnswers: ["London"] });
         });
 
         await publishWithExpectedResult({ publication: mockPost, expectedChallengeSuccess: false }); // Should fail due to wrong answer

--- a/test/node/community/challenges/pseudonymity-challenge-exclusion.test.ts
+++ b/test/node/community/challenges/pseudonymity-challenge-exclusion.test.ts
@@ -93,7 +93,7 @@ async function publishPostWithChallengeAnswer(
     });
 
     post.once("challenge", async (challengeMessage: DecryptedChallengeMessageType) => {
-        await post.publishChallengeAnswers([challengeAnswer]);
+        await post.publishChallengeAnswers({ challengeAnswers: [challengeAnswer] });
     });
 
     await post.publish();
@@ -128,7 +128,7 @@ async function publishPostAndTrackChallenge(
     let challengeReceived = false;
     post.once("challenge", async () => {
         challengeReceived = true;
-        await post.publishChallengeAnswers([opts?.challengeAnswer ?? "2"]);
+        await post.publishChallengeAnswers({ challengeAnswers: [opts?.challengeAnswer ?? "2"] });
     });
 
     await post.publish();
@@ -163,7 +163,7 @@ async function publishReplyWithChallengeAnswer(
     });
 
     reply.once("challenge", async (challengeMessage: DecryptedChallengeMessageType) => {
-        await reply.publishChallengeAnswers([challengeAnswer]);
+        await reply.publishChallengeAnswers({ challengeAnswers: [challengeAnswer] });
     });
 
     await reply.publish();
@@ -196,7 +196,7 @@ async function publishVoteWithChallengeAnswer(
     });
 
     vote.once("challenge", async (challengeMessage: DecryptedChallengeMessageType) => {
-        await vote.publishChallengeAnswers([challengeAnswer]);
+        await vote.publishChallengeAnswers({ challengeAnswers: [challengeAnswer] });
     });
 
     await vote.publish();
@@ -269,7 +269,7 @@ describeSkipIfRpc("Challenge exclusion with pseudonymity mode", () => {
 
                 post.once("challenge", async (challengeMessage: DecryptedChallengeMessageType) => {
                     challengeReceived = true;
-                    await post.publishChallengeAnswers(["2"]);
+                    await post.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await post.publish();
@@ -339,7 +339,7 @@ describeSkipIfRpc("Challenge exclusion with pseudonymity mode", () => {
                 secondPost.once("challenge", async (challengeMessage: DecryptedChallengeMessageType) => {
                     challengeReceived = true;
                     // Answer anyway in case we're wrong
-                    await secondPost.publishChallengeAnswers(["2"]);
+                    await secondPost.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await secondPost.publish();
@@ -424,7 +424,7 @@ describeSkipIfRpc("Challenge exclusion with pseudonymity mode", () => {
 
                 post4.once("challenge", async () => {
                     challengeReceived = true;
-                    await post4.publishChallengeAnswers(["2"]);
+                    await post4.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await post4.publish();
@@ -491,7 +491,7 @@ describeSkipIfRpc("Challenge exclusion with pseudonymity mode", () => {
 
                 post2.once("challenge", async () => {
                     challengeReceived = true;
-                    await post2.publishChallengeAnswers(["2"]);
+                    await post2.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await post2.publish();
@@ -545,7 +545,7 @@ describeSkipIfRpc("Challenge exclusion with pseudonymity mode", () => {
 
                 secondPost.once("challenge", async () => {
                     challengeReceived = true;
-                    await secondPost.publishChallengeAnswers(["2"]);
+                    await secondPost.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await secondPost.publish();
@@ -641,7 +641,7 @@ describeSkipIfRpc("Challenge exclusion with pseudonymity mode", () => {
 
                 secondPost.once("challenge", async () => {
                     challengeReceived = true;
-                    await secondPost.publishChallengeAnswers(["2"]);
+                    await secondPost.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await secondPost.publish();
@@ -721,7 +721,7 @@ describeSkipIfRpc("Challenge exclusion with pseudonymity mode", () => {
 
                 reply3.once("challenge", async () => {
                     challengeReceived = true;
-                    await reply3.publishChallengeAnswers(["2"]);
+                    await reply3.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await reply3.publish();
@@ -818,7 +818,7 @@ describeSkipIfRpc("Challenge exclusion with pseudonymity mode", () => {
 
                 secondPost.once("challenge", async () => {
                     challengeReceived = true;
-                    await secondPost.publishChallengeAnswers(["2"]);
+                    await secondPost.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await secondPost.publish();
@@ -904,7 +904,7 @@ describeSkipIfRpc("Challenge exclusion with pseudonymity mode", () => {
 
                 post3.once("challenge", async () => {
                     challengeReceived = true;
-                    await post3.publishChallengeAnswers(["2"]);
+                    await post3.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await post3.publish();
@@ -984,7 +984,7 @@ describeSkipIfRpc("Challenge exclusion with pseudonymity mode", () => {
                 });
 
                 post3.once("challenge", async () => {
-                    await post3.publishChallengeAnswers(["2"]);
+                    await post3.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await post3.publish();
@@ -1070,7 +1070,7 @@ describeSkipIfRpc("Challenge exclusion with pseudonymity mode", () => {
                 });
 
                 reply3.once("challenge", async () => {
-                    await reply3.publishChallengeAnswers(["2"]);
+                    await reply3.publishChallengeAnswers({ challengeAnswers: ["2"] });
                 });
 
                 await reply3.publish();

--- a/test/node/community/db.community.test.ts
+++ b/test/node/community/db.community.test.ts
@@ -125,7 +125,7 @@ describeSkipIfRpc.sequential(`DB importing`, async () => {
 
         const mockPost: Comment = await generateMockPost({ communityAddress: community.address, pkc: tempPKC });
         mockPost.once("challenge", async () => {
-            await mockPost.publishChallengeAnswers(["2"]); // hardcode answer here
+            await mockPost.publishChallengeAnswers({ challengeAnswers: ["2"] }); // hardcode answer here
         });
 
         await publishWithExpectedResult({ publication: mockPost, expectedChallengeSuccess: true });
@@ -180,7 +180,7 @@ describeSkipIfRpc.sequential(`DB importing`, async () => {
 
         // const mockPost = await generateMockPost({ communityAddress: community.address, pkc: tempPKC });
         // mockPost.once("challenge", async (challengeMsg) => {
-        //     await mockPost.publishChallengeAnswers(["2"]); // hardcode answer here
+        //     await mockPost.publishChallengeAnswers({ challengeAnswers: ["2"] }); // hardcode answer here
         // });
 
         // await publishWithExpectedResult({ publication: mockPost, expectedChallengeSuccess: true });

--- a/test/node/community/misc.community.test.ts
+++ b/test/node/community/misc.community.test.ts
@@ -335,7 +335,7 @@ describe.concurrent(`community.clients (Local)`, async () => {
 
             const post = await generateMockPost({ communityAddress: mockSub.address, pkc: pkc });
             post.once("challenge", async () => {
-                await post.publishChallengeAnswers(["2"]);
+                await post.publishChallengeAnswers({ challengeAnswers: ["2"] });
             });
             await post.publish();
 
@@ -465,7 +465,7 @@ describe.concurrent(`community.clients (Local)`, async () => {
             const mockPost = await generateMockPost({ communityAddress: community.address, pkc: pkc });
 
             mockPost.once("challenge", async () => {
-                await mockPost.publishChallengeAnswers(["2"]);
+                await mockPost.publishChallengeAnswers({ challengeAnswers: ["2"] });
             });
 
             await publishWithExpectedResult({ publication: mockPost, expectedChallengeSuccess: true });

--- a/test/node/community/modqueue/modqueue.community.test.ts
+++ b/test/node/community/modqueue/modqueue.community.test.ts
@@ -82,7 +82,7 @@ describe(`Pending approval modqueue functionality`, async () => {
             // it should fail because vote is not applicable for pendingApproval AND it published the wrong answers
             const vote = await generateMockVote(regularPublishedComment as CommentIpfsWithCidDefined, 1, pkc);
 
-            vote.once("challenge", async () => await vote.publishChallengeAnswers(["1234 " + Math.random()])); // wrong answers
+            vote.once("challenge", async () => await vote.publishChallengeAnswers({ challengeAnswers: ["1234 " + Math.random()] })); // wrong answers
 
             const challengeVerificationPromise = new Promise<DecryptedChallengeVerificationMessageType>((resolve) =>
                 vote.once("challengeverification", resolve)
@@ -104,7 +104,7 @@ describe(`Pending approval modqueue functionality`, async () => {
                 content: "text to edit on pending comment",
                 signer: regularPublishedComment.signer
             });
-            edit.once("challenge", async () => await edit.publishChallengeAnswers(["1234 " + Math.random()])); // wrong answers
+            edit.once("challenge", async () => await edit.publishChallengeAnswers({ challengeAnswers: ["1234 " + Math.random()] })); // wrong answers
 
             const challengeVerificationPromise = new Promise<DecryptedChallengeVerificationMessageType>((resolve) =>
                 edit.once("challengeverification", resolve)

--- a/test/node/community/pubsub-msgs/properties.pubsub.test.ts
+++ b/test/node/community/pubsub-msgs/properties.pubsub.test.ts
@@ -158,7 +158,7 @@ describe.sequential("Validate props of community Pubsub messages", async () => {
 
         // Set up to answer with a wrong answer
         comment.once("challenge", async () => {
-            await comment.publishChallengeAnswers(["12345"]); // wrong answer here
+            await comment.publishChallengeAnswers({ challengeAnswers: ["12345"] }); // wrong answer here
         });
 
         const challengeVerificationPromise = new Promise<DecryptedChallengeVerificationMessageType>((resolve) =>


### PR DESCRIPTION
## What

Convert `publication.publishChallengeAnswers` from a positional `challengeAnswers` array argument to a single object parameter `{ challengeAnswers }`, matching the codebase single-object-param convention.

Before:
```ts
await comment.publishChallengeAnswers(["2"])
```
After:
```ts
await comment.publishChallengeAnswers({ challengeAnswers: ["2"] })
```

## Changes

- `src/publications/publication.ts` — method signature destructures `{ challengeAnswers }`; body unchanged.
- `src/rpc/src/index.ts` — RPC server handler calls the publication method with the object form. The RPC **wire param** (`{subscriptionId, challengeAnswers}`) and its schema are unchanged.
- `src/test/test-util.ts` and all `test/` call sites updated to the object form.
- `README.md` — examples, API heading, and TOC anchor updated.

No schema/zod changes — validation already operates on `{ challengeAnswers }`.

## Verification

- `npm run build` passes (node + browser).
- `npx tsc --project test/tsconfig.json --noEmit` passes.

Closes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `publishChallengeAnswers` method signature has been updated. The method now accepts an options object containing the `challengeAnswers` property instead of passing the array directly. This change applies across all publication types including comments, edits, votes, and moderation operations. Update calls to: `publishChallengeAnswers({ challengeAnswers })`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->