### PR TITLE
chore(deps): upgrade kubo 0.41.0 -> 0.42.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
                 "cz-conventional-changelog": "3.3.0",
                 "fs-extra": "11.3.4",
                 "husky": "9.1.7",
-                "kubo": "0.41.0",
+                "kubo": "0.42.0",
                 "lint-staged": "16.2.7",
                 "npm-run-all": "4.1.5",
                 "playwright": "1.56.1",
@@ -11016,9 +11016,9 @@
             }
         },
         "node_modules/kubo": {
-            "version": "0.41.0",
-            "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.41.0.tgz",
-            "integrity": "sha512-r6t8kZ9/mgvtjZz/DTVE7fw206rcTAw8KrpQBmpc83lOZLxEmKG4m2KsNLHVENNtrSs/jj8FOi+9v9DHLiHrww==",
+            "version": "0.42.0",
+            "resolved": "https://registry.npmjs.org/kubo/-/kubo-0.42.0.tgz",
+            "integrity": "sha512-980G+BC9sLKJZIjaJ2hI6sWMkYP55Fo00BRcBaoIZ0uPUUuiHu7u69ZTSsWTyBA6MbkLPAWCgbCD9jh3GWN2yA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
         "cz-conventional-changelog": "3.3.0",
         "fs-extra": "11.3.4",
         "husky": "9.1.7",
-        "kubo": "0.41.0",
+        "kubo": "0.42.0",
         "lint-staged": "16.2.7",
         "npm-run-all": "4.1.5",
         "playwright": "1.56.1",


### PR DESCRIPTION
## What

Upgrade the bundled kubo (go-ipfs) binary from **0.41.0 → 0.42.0** (`package.json` devDependency, used by the test server and as the reference node).

`kubo-rpc-client` is intentionally left at **6.1.0** — the RPC API is stable across these kubo versions, and bumping to 7.0.0 is a separate major upgrade with its own breaking changes (out of scope here).

## Changelog review vs. how pkc-js uses kubo

I went through the [v0.42 changelog](https://github.com/ipfs/kubo/blob/master/docs/changelogs/v0.42.md) item by item against our integration points:

| Change in 0.42 | Impact on pkc-js |
|---|---|
| Daemon **refuses to start when `Provide.DHT.Interval=0`** without explicit `Provide.Enabled` | **None.** We set `Provide.DHT.SweepEnabled=false` (`setup-kubo-address-rewriter-and-http-router.ts`), not `Interval=0`. Verified empirically: a daemon configured exactly like pkc-js (custom `Routing` + `Provide.DHT.SweepEnabled=false`) reaches "Daemon is ready" with no error. |
| `ipfs routing provide` CLI **deprecated** (to be removed in a future release) in favor of `ipfs provide once` | **Works, but flag for follow-up.** `retryKuboIpfsAddAndProvide` in `util.ts` calls the `routing.provide` RPC endpoint, which still exists and functions in 0.42. We should migrate to the new provide API before it is removed. |
| Prometheus `otel_scope_info` metric removed | **None.** pkc-js does not scrape Prometheus. |
| Progress bars hidden when stderr is piped | **None.** We consume kubo via the RPC client; the test server doesn't parse `ipfs add`/`get` progress. |
| New `ipfs diag healthy` subcommand | **None.** Unused. |
| Graceful shutdown before SIGTERM/SIGINT; new `Internal.ShutdownTimeout` | **None** (defaults fine). We send `/shutdown` via RPC; the test server kills the process. |
| New optional configs (`Provide.DHT.SendProviderRecordTimeout`, `Migration.DownloadSources`) | **None.** Defaults are fine. |
| ERROR logs when swarm listeners are blocked by `Swarm.AddrFilters` | **None.** Log noise only. |

## Verification

- `npm install` pulls kubo 0.42.0 (`ipfs version` → `0.42.0`).
- Manually inited a repo with the 0.42 binary, applied pkc-js's config (`Routing.Type=custom`, `Provide.DHT.SweepEnabled=false`), and confirmed the daemon boots cleanly to "Daemon is ready".
- Confirmed `routing.provide` (deprecated CLI, live RPC endpoint) still resolves.

## Follow-up (not in this PR)

- Migrate `retryKuboIpfsAddAndProvide` off the deprecated `routing.provide` to `provide once` before kubo removes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->