### PR TITLE
fix(community): retry MFS files.stat on transient Kubo connection errors

### DIFF
--- a/src/runtime/node/community/local-community/cleanup.ts
+++ b/src/runtime/node/community/local-community/cleanup.ts
@@ -1,6 +1,6 @@
 import pLimit from "p-limit";
 import Logger from "../../../../logger.js";
-import { genToArray, removeMfsFilesSafely } from "../../../../util.js";
+import { genToArray, removeMfsFilesSafely, statMfsPathSafely } from "../../../../util.js";
 import type { DbRepliesSortEntry } from "../../../../publications/comment/types.js";
 import type { PurgedCommentTableRows } from "../db-handler-types.js";
 import type { LocalCommunity } from "../local-community.js";
@@ -108,7 +108,8 @@ export async function repinCommentUpdateIfNeeded(community: LocalCommunity) {
     // Most of the time we run this function, the comment updates are already written to ipfs rpeo
     const kuboRpc = community._clientsManager.getDefaultKuboRpcClient();
     try {
-        await kuboRpc._client.files.stat(`/${community.address}`, { hash: true });
+        // Retries on transient Kubo connection errors so a daemon blip doesn't fail community.start().
+        await statMfsPathSafely({ kuboRpcClient: kuboRpc, path: `/${community.address}`, statOptions: { hash: true }, log });
         return; // if the directory of this community exists, we assume all the comment updates are there
     } catch (e) {
         if (!(<Error>e).message.includes("file does not exist")) throw e;

--- a/src/runtime/node/community/local-community/ipns-publishing.ts
+++ b/src/runtime/node/community/local-community/ipns-publishing.ts
@@ -3,7 +3,13 @@ import * as remeda from "remeda";
 import * as cborg from "cborg";
 import { sha256 } from "js-sha256";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
-import { getIpnsRecordInLocalKuboNode, removeBlocksFromKuboNode, retryKuboIpfsAddAndProvide, timestamp } from "../../../../util.js";
+import {
+    getIpnsRecordInLocalKuboNode,
+    removeBlocksFromKuboNode,
+    retryKuboIpfsAddAndProvide,
+    statMfsPathSafely,
+    timestamp
+} from "../../../../util.js";
 import env from "../../../../version.js";
 import { PKCError } from "../../../../pkc-error.js";
 import { STORAGE_KEYS } from "../../../../constants.js";
@@ -22,10 +28,11 @@ import { providePubsubTopicRoutingCidsIfNeeded } from "./pubsub.js";
 
 export async function calculateNewPostUpdates(community: LocalCommunity): Promise<CommunityIpfsType["postUpdates"]> {
     const postUpdates: CommunityIpfsType["postUpdates"] = {};
-    const kuboRpcClient = community._clientsManager.getDefaultKuboRpcClient()._client;
+    const kuboRpcClient = community._clientsManager.getDefaultKuboRpcClient();
     for (const timeBucket of community._postUpdatesBuckets) {
         try {
-            const statRes = await kuboRpcClient.files.stat(`/${community.address}/postUpdates/${timeBucket}`);
+            // Retries on transient Kubo connection errors so a daemon blip doesn't silently drop a bucket.
+            const statRes = await statMfsPathSafely({ kuboRpcClient, path: `/${community.address}/postUpdates/${timeBucket}` });
             if (statRes.blocks !== 0) postUpdates[String(timeBucket)] = String(statRes.cid);
         } catch {}
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,6 +16,8 @@ import type {
     BlockPutOptions,
     BlockRmOptions,
     FilesRmOptions,
+    FilesStatOptions,
+    FilesStatResult,
     FilesWriteOptions,
     PinAddOptions,
     RoutingProvideOptions
@@ -972,6 +974,51 @@ export async function removeMfsFilesSafely({
 
                 if (operation.retry(error as Error)) return;
 
+                reject(operation.mainError() || error);
+            }
+        });
+    });
+}
+
+// Wrap an MFS `files.stat` call with retry on transient Kubo RPC connection failures
+// (e.g. `fetch failed` / ETIMEDOUT / ECONNREFUSED while the daemon is briefly restarting).
+// Without this, a momentary blip during community.start() throws straight out and fails the start.
+// A `"file does not exist"` rejection is the legitimate "MFS path absent" signal, so it is rethrown
+// immediately without retrying — callers branch on it.
+export async function statMfsPathSafely({
+    kuboRpcClient,
+    path,
+    statOptions,
+    log,
+    inputNumOfRetries
+}: {
+    kuboRpcClient: PKC["clients"]["kuboRpcClients"][string];
+    path: string;
+    statOptions?: FilesStatOptions;
+    log?: Logger;
+    inputNumOfRetries?: number;
+}): Promise<FilesStatResult> {
+    const logger = log ?? Logger("pkc-js:util:statMfsPathSafely");
+    const numOfRetries = inputNumOfRetries ?? 3;
+
+    return new Promise<FilesStatResult>((resolve, reject) => {
+        const operation = retry.operation({
+            retries: numOfRetries,
+            factor: 2,
+            minTimeout: 1000
+        });
+
+        operation.attempt(async (currentAttempt) => {
+            try {
+                resolve(await kuboRpcClient._client.files.stat(path, statOptions));
+            } catch (error) {
+                // "file does not exist" is the expected "MFS path absent" signal — don't retry it.
+                if ((error as Error).message?.includes("file does not exist")) {
+                    reject(error);
+                    return;
+                }
+                logger.error(`Failed attempt ${currentAttempt}/${numOfRetries + 1} to stat MFS path ${path}:`, error);
+                if (operation.retry(error as Error)) return;
                 reject(operation.mainError() || error);
             }
         });

--- a/test/node/community/local-community/cleanup.test.ts
+++ b/test/node/community/local-community/cleanup.test.ts
@@ -146,6 +146,53 @@ describe("cleanup: purgeDisapprovedCommentsOlderThan", () => {
     });
 });
 
+describe("cleanup: repinCommentUpdateIfNeeded", () => {
+    // Regression: a transient Kubo RPC connection blip (daemon briefly restarting) used to
+    // throw straight out of community.start(). The files.stat call must now retry on connection
+    // errors (`fetch failed` / ETIMEDOUT / ECONNREFUSED) instead of failing start().
+    it("retries files.stat on a transient Kubo connection error and still succeeds", async () => {
+        const connectionErr = new TypeError("fetch failed"); // mimics undici ETIMEDOUT/ECONNREFUSED wrapper
+        const statSpy = vi.fn().mockRejectedValueOnce(connectionErr).mockResolvedValueOnce({ cid: "QmCommunityDir", blocks: 1 });
+        const forceUpdateOnAllComments = vi.fn();
+        const community = {
+            address: "community.bso",
+            lastCommentCid: "QmLastComment",
+            _clientsManager: { getDefaultKuboRpcClient: () => ({ _client: { files: { stat: statSpy } } }) },
+            _dbHandler: { forceUpdateOnAllComments }
+        } as unknown as LocalCommunity;
+
+        vi.useFakeTimers();
+        try {
+            const promise = repinCommentUpdateIfNeeded(community);
+            await vi.advanceTimersByTimeAsync(5000); // let the retry backoff fire
+            await promise;
+        } finally {
+            vi.useRealTimers();
+        }
+
+        // stat was retried (2 calls), the dir was found on the 2nd attempt, so no forced re-publish.
+        expect(statSpy).toHaveBeenCalledTimes(2);
+        expect(forceUpdateOnAllComments).not.toHaveBeenCalled();
+    });
+
+    it("does NOT retry a 'file does not exist' stat (it is the legitimate empty-dir signal)", async () => {
+        const notExistErr = new Error("file does not exist");
+        const statSpy = vi.fn().mockRejectedValue(notExistErr);
+        const forceUpdateOnAllComments = vi.fn();
+        const community = {
+            address: "community.bso",
+            lastCommentCid: undefined, // no comment updates -> early return without forcing republish
+            _clientsManager: { getDefaultKuboRpcClient: () => ({ _client: { files: { stat: statSpy } } }) },
+            _dbHandler: { forceUpdateOnAllComments }
+        } as unknown as LocalCommunity;
+
+        await repinCommentUpdateIfNeeded(community);
+
+        expect(statSpy).toHaveBeenCalledTimes(1); // not retried
+        expect(forceUpdateOnAllComments).not.toHaveBeenCalled();
+    });
+});
+
 describe("cleanup: cleanUpIpfsRepoRarely", () => {
     it("skips GC when not forced and random gate doesn't fire", async () => {
         const getDefaultKuboRpcClient = vi.fn();


### PR DESCRIPTION
## Problem

CI run on `master` failed with a single test error in `loading.update.test.ts` during `community.start()`:

```
TypeError: fetch failed
 ❯ Object.stat              kubo-rpc-client/.../files/stat.js
 ❯ repinCommentUpdateIfNeeded  src/runtime/node/community/local-community/cleanup.ts:111
 ❯ start                    src/runtime/node/community/local-community/lifecycle.ts:137
```

The underlying cause was a **transient** Kubo RPC connection blip — the local daemon was briefly unreachable:

```
connect ETIMEDOUT   127.0.0.1:15001   (IPv4)
connect ECONNREFUSED ::1:15001         (IPv6)
```

At the same instant, dozens of concurrent IPFS operations across other test files got the identical `fetch failed`, but they **recovered via their existing retry** (`Failed attempt 1/4 …`) or swallowed it as "Minor Error, not a big deal". The `files.stat` in `repinCommentUpdateIfNeeded` had **no retry** — its `try/catch` only handled `"file does not exist"` and rethrew everything else, so the blip propagated straight out of `start()` and failed the test.

The same unprotected `files.stat` exists in `calculateNewPostUpdates` ([ipns-publishing.ts](../blob/master/src/runtime/node/community/local-community/ipns-publishing.ts)), where its `catch {}` silently swallowed connection errors — a blip there could drop a `postUpdates` bucket from the published community record.

## Fix

- Add `statMfsPathSafely()` in `src/util.ts`, mirroring the existing `removeMfsFilesSafely` retry pattern (`retry.operation`, 3 retries, factor 2). It retries on transient/connection errors but **rethrows `"file does not exist"` immediately** so callers can still branch on the legitimate "MFS path absent" signal.
- Route both stat calls (`cleanup.ts` and `ipns-publishing.ts`) through it.

## Tests (test-first)

Two unit tests in `cleanup.test.ts`, verified red against unmodified `src/` first:
1. `files.stat` throws `fetch failed` once then succeeds → `start()` path completes, stat called twice (fake timers, no real backoff wait).
2. `"file does not exist"` is **not** retried → stat called once.

Verified: `npm run build` clean, test type-check clean, cleanup test 11/11 green, and `start.community.test.ts` (hammers `community.start()`) 19 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience to transient connection failures during community data directory operations. The system now automatically retries on temporary errors while properly handling cases where directories are legitimately unavailable.

* **Tests**
  * Added test coverage for retry behavior on transient connection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->