### PR TITLE
feat(community): add exportCommunityModLogs to expose CommentModerations (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ PubsubSignature {
   - [`community.stop()`](#communitystop)
   - [`community.update()`](#communityupdate)
   - `community.delete()`
+  - [`community.exportCommunityModLogs(opts?)`](#communityexportcommunitymodlogsopts)
   - `community.address`
   - `community.shortAddress`
   - `community.roles`
@@ -1289,6 +1290,46 @@ community.on('update', (updatedCommunityInstance) => {
   community.stop()
 })
 community.update()
+```
+
+### `community.exportCommunityModLogs(opts?)`
+
+> Read the community moderation log — the `commentModeration` records (removals, approvals, locks, spoilers, pins, bans, flairs, etc.) stored in your local community database. Only usable if the community database corresponding to `community.address` exists locally (ie. you are the community owner); a read-only `RemoteCommunity` throws `ERR_COMMUNITY_NOT_LOCAL`. Works whether the community is started or stopped.
+
+#### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| opts | `ExportCommunityModLogsOptions` or `undefined` | Optional filters and ordering |
+
+##### ExportCommunityModLogsOptions
+
+An object which may have the following keys:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| startTimestamp | `number` or `undefined` | Only include moderations with `timestamp >= startTimestamp` (unix seconds) |
+| endTimestamp | `number` or `undefined` | Only include moderations with `timestamp <= endTimestamp` (unix seconds) |
+| commentCid | `string` or `undefined` | Only include moderations targeting this comment CID |
+| limit | `number` or `undefined` | Maximum number of rows to return. Omit to return all matching rows |
+| order | `'ASC'` or `'DESC'` or `undefined` | Sort by `timestamp`. Defaults to `'DESC'` (newest first) |
+
+#### Returns
+
+`Promise<{ moderations: CommentModerationTableRow[] }>` — the matching moderation rows, with JSON columns (`signature`, `author`, `commentModeration`, `extraProps`) parsed into objects. The `{ moderations }` wrapper leaves room to add totals/pagination later without breaking callers.
+
+#### Example
+
+```js
+const community = await pkc.createCommunity({ address: '12D3KooW...' })
+// newest 100 moderation actions targeting a specific comment
+const { moderations } = await community.exportCommunityModLogs({
+  commentCid: 'Qm...',
+  limit: 100
+})
+for (const mod of moderations) {
+  console.log(mod.timestamp, mod.modSignerAddress, mod.commentModeration)
+}
 ```
 
 ## Community Events

--- a/README.md
+++ b/README.md
@@ -1311,7 +1311,7 @@ An object which may have the following keys:
 | startTimestamp | `number` or `undefined` | Only include moderations with `timestamp >= startTimestamp` (unix seconds) |
 | endTimestamp | `number` or `undefined` | Only include moderations with `timestamp <= endTimestamp` (unix seconds) |
 | commentCid | `string` or `undefined` | Only include moderations targeting this comment CID |
-| limit | `number` or `undefined` | Maximum number of rows to return. Omit to return all matching rows |
+| limit | `number` or `undefined` | Maximum number of rows to return. Must be a positive integer (`>= 1`) when provided. Omit to return all matching rows |
 | order | `'ASC'` or `'DESC'` or `undefined` | Sort by `timestamp`. Defaults to `'DESC'` (newest first) |
 
 #### Returns

--- a/src/clients/rpc-client/pkc-rpc-client.ts
+++ b/src/clients/rpc-client/pkc-rpc-client.ts
@@ -39,7 +39,9 @@ import type {
     RpcFetchCidResult,
     ExportCommunityRpcParam,
     CancelExportRpcParam,
-    RpcExportCommunityResult
+    RpcExportCommunityResult,
+    ExportCommunityModLogsRpcParam,
+    RpcExportCommunityModLogsResult
 } from "./types.js";
 import {
     parseRpcCommunityIdentifierParam,
@@ -55,7 +57,9 @@ import {
     parseRpcSubscriptionIdResult,
     parseRpcExportCommunityParam,
     parseRpcCancelExportParam,
-    parseRpcExportCommunityResult
+    parseRpcExportCommunityResult,
+    parseRpcExportCommunityModLogsParam,
+    parseRpcExportCommunityModLogsResult
 } from "./rpc-schema-util.js";
 
 const log = Logger("pkc-js:PKCRpcClient");
@@ -498,6 +502,11 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
     async exportCommunity(args: ExportCommunityRpcParam): Promise<RpcExportCommunityResult> {
         const parsedArgs = parseRpcExportCommunityParam(args);
         return parseRpcExportCommunityResult(await this._webSocketClient.call("exportCommunity", [parsedArgs]));
+    }
+
+    async exportCommunityModLogs(args: ExportCommunityModLogsRpcParam): Promise<RpcExportCommunityModLogsResult> {
+        const parsedArgs = parseRpcExportCommunityModLogsParam(args);
+        return parseRpcExportCommunityModLogsResult(await this._webSocketClient.call("exportCommunityModLogs", [parsedArgs]));
     }
 
     async exportsSubscribe(args: CommunityIdentifierRpcParam): Promise<RpcSubscriptionIdResult> {

--- a/src/clients/rpc-client/rpc-schema-util.ts
+++ b/src/clients/rpc-client/rpc-schema-util.ts
@@ -15,7 +15,9 @@ import {
     RpcExportCommunityParamSchema,
     RpcCancelExportParamSchema,
     RpcExportCommunityResultSchema,
-    RpcExportschangeResultSchema
+    RpcExportschangeResultSchema,
+    RpcExportCommunityModLogsParamSchema,
+    RpcExportCommunityModLogsResultSchema
 } from "./schema.js";
 
 // Param parsers — all use .loose() so newer clients can send extra fields
@@ -40,3 +42,7 @@ export const parseRpcExportCommunityParam = (params: unknown) => RpcExportCommun
 export const parseRpcCancelExportParam = (params: unknown) => RpcCancelExportParamSchema.loose().parse(params);
 export const parseRpcExportCommunityResult = (result: unknown) => RpcExportCommunityResultSchema.loose().parse(result);
 export const parseRpcExportschangeResult = (result: unknown) => RpcExportschangeResultSchema.loose().parse(result);
+
+// community.exportCommunityModLogs() — wire param/result parsers
+export const parseRpcExportCommunityModLogsParam = (params: unknown) => RpcExportCommunityModLogsParamSchema.loose().parse(params);
+export const parseRpcExportCommunityModLogsResult = (result: unknown) => RpcExportCommunityModLogsResultSchema.loose().parse(result);

--- a/src/clients/rpc-client/schema.ts
+++ b/src/clients/rpc-client/schema.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { CommentIpfsSchema, CommentUpdateSchema } from "../../publications/comment/schema.js";
 import { AuthorAddressSchema, ChallengeAnswersSchema, CidStringSchema } from "../../schema/schema.js";
-import { CommunityEditOptionsSchema, CommunityExportRecordsSchema } from "../../community/schema.js";
+import { CommunityEditOptionsSchema, CommunityExportRecordsSchema, ExportCommunityModLogsOptionsSchema } from "../../community/schema.js";
+import { CommentModerationsTableRowSchema } from "../../publications/comment-moderation/schema.js";
 import { NameResolveCacheOptionsSchema } from "../../schema.js";
 import type { EncodedDecryptedChallengeVerificationMessageType } from "../../pubsub-messages/types.js";
 export const SubscriptionIdSchema = z.number().positive().int();
@@ -79,3 +80,13 @@ export const RpcCancelExportParamSchema = z.object({ exportId: z.string().uuid()
 export const RpcExportCommunityResultSchema = z.object({ exportId: z.string().uuid() });
 
 export const RpcExportschangeResultSchema = z.object({ records: CommunityExportRecordsSchema });
+
+// community.exportCommunityModLogs() — wire params and results
+export const RpcExportCommunityModLogsParamSchema = ExportCommunityModLogsOptionsSchema.extend({
+    name: z.string().min(1).optional(),
+    publicKey: z.string().min(1).optional()
+}).refine((args) => args.name || args.publicKey, "At least one of name or publicKey must be provided");
+
+export const RpcExportCommunityModLogsResultSchema = z.object({
+    moderations: z.array(CommentModerationsTableRowSchema.loose()) // .loose() element preserves extraProps / future fields
+});

--- a/src/clients/rpc-client/types.ts
+++ b/src/clients/rpc-client/types.ts
@@ -15,7 +15,9 @@ import {
     RpcExportCommunityParamSchema,
     RpcCancelExportParamSchema,
     RpcExportCommunityResultSchema,
-    RpcExportschangeResultSchema
+    RpcExportschangeResultSchema,
+    RpcExportCommunityModLogsParamSchema,
+    RpcExportCommunityModLogsResultSchema
 } from "./schema.js";
 import type { PageIpfs, ModQueuePageIpfs } from "../../pages/types.js";
 import type { PageRuntimeFields } from "../../pages/util.js";
@@ -31,6 +33,7 @@ export type EditCommunityRpcParam = z.infer<typeof RpcEditCommunityParamSchema>;
 export type PublishChallengeAnswersRpcParam = z.infer<typeof RpcPublishChallengeAnswersParamSchema>;
 export type ExportCommunityRpcParam = z.infer<typeof RpcExportCommunityParamSchema>;
 export type CancelExportRpcParam = z.infer<typeof RpcCancelExportParamSchema>;
+export type ExportCommunityModLogsRpcParam = z.infer<typeof RpcExportCommunityModLogsParamSchema>;
 
 // Result types (shared between RPC client and server)
 export type RpcResolveAuthorNameResult = z.infer<typeof RpcResolveAuthorNameResultSchema>;
@@ -39,6 +42,7 @@ export type RpcSuccessResult = z.infer<typeof RpcSuccessResultSchema>;
 export type RpcSubscriptionIdResult = z.infer<typeof RpcSubscriptionIdResultSchema>;
 export type RpcExportCommunityResult = z.infer<typeof RpcExportCommunityResultSchema>;
 export type RpcExportschangeResult = z.infer<typeof RpcExportschangeResultSchema>;
+export type RpcExportCommunityModLogsResult = z.infer<typeof RpcExportCommunityModLogsResultSchema>;
 
 // Re-export existing complex types used as RPC return values
 export type { RpcInternalCommunityRecordBeforeFirstUpdateType, RpcLocalCommunityUpdateResultType } from "../../community/types.js";

--- a/src/community/remote-community.ts
+++ b/src/community/remote-community.ts
@@ -29,8 +29,10 @@ import type {
     CommunityEventArgs,
     CommunityEvents,
     CommunityExportRecord,
-    ExportCommunityUserOptions
+    ExportCommunityUserOptions,
+    ExportCommunityModLogsOptions
 } from "./types.js";
+import type { CommentModerationTableRow } from "../publications/comment-moderation/types.js";
 import * as remeda from "remeda";
 import { ModQueuePages, PostsPages } from "../pages/pages.js";
 import type { PostsPagesTypeIpfs } from "../pages/types.js";
@@ -820,6 +822,13 @@ export class RemoteCommunity extends TypedEmitter<CommunityEvents> implements Om
     }
 
     async export(options?: ExportCommunityUserOptions): Promise<{ exportId: string }> {
+        throw new PKCError("ERR_COMMUNITY_NOT_LOCAL", { address: this.address });
+    }
+
+    // Read the community moderation log (commentModeration records). Overridden by LocalCommunity
+    // (direct DB read) and RpcLocalCommunity (RPC call). The base rejects because a read-only
+    // RemoteCommunity has no community DB to read mod logs from.
+    async exportCommunityModLogs(opts?: ExportCommunityModLogsOptions): Promise<{ moderations: CommentModerationTableRow[] }> {
         throw new PKCError("ERR_COMMUNITY_NOT_LOCAL", { address: this.address });
     }
 }

--- a/src/community/rpc-local-community.ts
+++ b/src/community/rpc-local-community.ts
@@ -8,8 +8,10 @@ import type {
     CommunityExportRecord,
     CommunityIpfsType,
     CommunityStartedState,
-    ExportCommunityUserOptions
+    ExportCommunityUserOptions,
+    ExportCommunityModLogsOptions
 } from "./types.js";
+import type { CommentModerationTableRow } from "../publications/comment-moderation/types.js";
 import { RpcRemoteCommunity } from "./rpc-remote-community.js";
 import { z } from "zod";
 import { messages } from "../errors.js";
@@ -389,6 +391,10 @@ export class RpcLocalCommunity extends RpcRemoteCommunity {
             }
         }
         return { exportId };
+    }
+
+    override async exportCommunityModLogs(opts?: ExportCommunityModLogsOptions): Promise<{ moderations: CommentModerationTableRow[] }> {
+        return this._pkc._pkcRpcClient!.exportCommunityModLogs({ name: this.name, publicKey: this.publicKey, ...opts });
     }
 
     async _attachExportsSubscription(): Promise<void> {

--- a/src/community/schema.ts
+++ b/src/community/schema.ts
@@ -349,6 +349,16 @@ export const ExportCommunityUserOptionsSchema = z
     })
     .strict();
 
+// community.exportCommunityModLogs()
+
+export const ExportCommunityModLogsOptionsSchema = z.object({
+    startTimestamp: z.number().int().optional(),
+    endTimestamp: z.number().int().optional(),
+    commentCid: z.string().min(1).optional(),
+    limit: z.number().int().nonnegative().optional(),
+    order: z.enum(["ASC", "DESC"]).optional() // default "DESC" (newest first), ordered by timestamp
+});
+
 export const CommunityExportRecordErrorSchema = z
     .object({
         code: z.string(),

--- a/src/community/schema.ts
+++ b/src/community/schema.ts
@@ -355,7 +355,7 @@ export const ExportCommunityModLogsOptionsSchema = z.object({
     startTimestamp: z.number().int().optional(),
     endTimestamp: z.number().int().optional(),
     commentCid: z.string().min(1).optional(),
-    limit: z.number().int().nonnegative().optional(),
+    limit: z.number().int().positive().optional(), // omit for unlimited; must be >= 1 when provided
     order: z.enum(["ASC", "DESC"]).optional() // default "DESC" (newest first), ordered by timestamp
 });
 

--- a/src/community/types.ts
+++ b/src/community/types.ts
@@ -24,6 +24,7 @@ import {
     CommunitySignedPropertyNames,
     CommunityRoleNames,
     ExportCommunityUserOptionsSchema,
+    ExportCommunityModLogsOptionsSchema,
     CommunityExportRecordSchema
 } from "./schema.js";
 import { RpcLocalCommunity } from "./rpc-local-community.js";
@@ -236,6 +237,7 @@ export interface CommunityEvents {
 }
 
 export type ExportCommunityUserOptions = z.infer<typeof ExportCommunityUserOptionsSchema>;
+export type ExportCommunityModLogsOptions = z.infer<typeof ExportCommunityModLogsOptionsSchema>;
 export type CommunityExportRecord = z.infer<typeof CommunityExportRecordSchema>;
 
 // Create a helper type to extract the parameters of each event

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -86,7 +86,8 @@ import {
     parseRpcPublishChallengeAnswersParam,
     parseRpcUnsubscribeParam,
     parseRpcExportCommunityParam,
-    parseRpcCancelExportParam
+    parseRpcCancelExportParam,
+    parseRpcExportCommunityModLogsParam
 } from "../../clients/rpc-client/rpc-schema-util.js";
 import type {
     CommunityIdentifierRpcParam,
@@ -97,7 +98,8 @@ import type {
     RpcCommentPageResult,
     RpcCommunityPageResult,
     RpcLocalCommunityUpdateResultType,
-    RpcExportCommunityResult
+    RpcExportCommunityResult,
+    RpcExportCommunityModLogsResult
 } from "../../clients/rpc-client/types.js";
 import type { CommunityExportRecord } from "../../community/types.js";
 import { findStartedCommunity } from "../../pkc/tracked-instance-registry-util.js";
@@ -292,6 +294,7 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
         this.rpcWebsocketsRegister("exportCommunity", this.exportCommunity.bind(this));
         this.rpcWebsocketsRegister("exportsSubscribe", this.exportsSubscribe.bind(this));
         this.rpcWebsocketsRegister("cancelExport", this.cancelExport.bind(this));
+        this.rpcWebsocketsRegister("exportCommunityModLogs", this.exportCommunityModLogs.bind(this));
 
         hideClassPrivateProps(this);
     }
@@ -1623,6 +1626,22 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
             throw new PKCError("ERR_PRIVATE_KEY_EXPORT_NOT_ALLOWED", {});
         const community = await this._resolveLocalCommunityForExport(parsedArgs);
         return community.export({ includePrivateKey: parsedArgs.includePrivateKey });
+    }
+
+    async exportCommunityModLogs(params: any): Promise<RpcExportCommunityModLogsResult> {
+        // No private-key gate like exportCommunity: comment moderations are public, signed,
+        // pubsub-published data. Resolve the owned community the same way editCommunity does.
+        const { name, publicKey, startTimestamp, endTimestamp, commentCid, limit, order } = parseRpcExportCommunityModLogsParam(params[0]);
+        const address = this._findCommunityAddress({ name, publicKey });
+        if (!address) throw new PKCError("ERR_COMMUNITY_NOT_FOUND", { name, publicKey });
+        let community: LocalCommunity;
+        if (this._startedCommunities[address] instanceof LocalCommunity) community = <LocalCommunity>this._startedCommunities[address];
+        else {
+            const created = await (await this._getPKCInstance()).createCommunity({ address });
+            if (!(created instanceof LocalCommunity)) throw new PKCError("ERR_COMMUNITY_NOT_LOCAL", { address });
+            community = created;
+        }
+        return community.exportCommunityModLogs({ startTimestamp, endTimestamp, commentCid, limit, order });
     }
 
     async exportsSubscribe(params: any, connectionId: string): Promise<RpcSubscriptionIdResult> {

--- a/src/runtime/node/community/db-handler.ts
+++ b/src/runtime/node/community/db-handler.ts
@@ -21,7 +21,8 @@ import type { PageOptions } from "./page-generator.js";
 import type {
     InternalCommunityRecordAfterFirstUpdateType,
     InternalCommunityRecordBeforeFirstUpdateType,
-    CommunityStats
+    CommunityStats,
+    ExportCommunityModLogsOptions
 } from "../../../community/types.js";
 import { LocalCommunity } from "./local-community.js";
 import { isDefaultChallengeStructure } from "./local-community/defaults.js";
@@ -65,6 +66,7 @@ import {
     parseCommentsTableRow,
     parsePrefixedComment,
     parseVoteRow,
+    parseCommentModerationRow,
     type PrefixedCommentRow
 } from "./db-row-parser.js";
 import { ZodError } from "zod";
@@ -142,6 +144,11 @@ export class DbHandler {
     private _parseVoteRow(row: unknown): VotesTableRow {
         const parsed = parseVoteRow(row);
         return removeNullUndefinedValues(parsed) as VotesTableRow;
+    }
+
+    private _parseCommentModerationRow(row: unknown): CommentModerationTableRow {
+        const parsed = parseCommentModerationRow(row);
+        return removeNullUndefinedValues(parsed) as CommentModerationTableRow;
     }
 
     async initDbConfigIfNeeded() {
@@ -2705,6 +2712,32 @@ export class DbHandler {
         if (banAuthor?.banExpiresAt) aggregateAuthor.banExpiresAt = banAuthor.banExpiresAt;
         if (authorFlairsByMod?.flairs) aggregateAuthor.flairs = authorFlairsByMod.flairs;
         return aggregateAuthor;
+    }
+
+    queryAllCommentModerations(opts?: ExportCommunityModLogsOptions): CommentModerationTableRow[] {
+        const conditions: string[] = [];
+        const params: (string | number)[] = [];
+        if (opts?.startTimestamp !== undefined) {
+            conditions.push(`timestamp >= ?`);
+            params.push(opts.startTimestamp);
+        }
+        if (opts?.endTimestamp !== undefined) {
+            conditions.push(`timestamp <= ?`);
+            params.push(opts.endTimestamp);
+        }
+        if (opts?.commentCid !== undefined) {
+            conditions.push(`commentCid = ?`);
+            params.push(opts.commentCid);
+        }
+        const whereClause = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+        const direction = opts?.order === "ASC" ? "ASC" : "DESC"; // explicit map so only ASC/DESC reach the SQL
+        let sql = `SELECT * FROM ${TABLES.COMMENT_MODERATIONS} ${whereClause} ORDER BY timestamp ${direction}, rowid ${direction}`;
+        if (opts?.limit !== undefined) {
+            sql += ` LIMIT ?`;
+            params.push(opts.limit);
+        }
+        const results = this._db.prepare(sql).all(...params) as Record<string, unknown>[];
+        return results.map((r) => this._parseCommentModerationRow(r));
     }
 
     queryAuthorPublicationCounts(authorSignerAddress: string): { postCount: number; replyCount: number } {

--- a/src/runtime/node/community/db-row-parser.ts
+++ b/src/runtime/node/community/db-row-parser.ts
@@ -7,9 +7,11 @@ import {
 } from "../../../publications/comment/schema.js";
 import { CommentEditsTableRowSchema } from "../../../publications/comment-edit/schema.js";
 import { VoteTablesRowSchema } from "../../../publications/vote/schema.js";
+import { CommentModerationsTableRowSchema } from "../../../publications/comment-moderation/schema.js";
 import type { CommentUpdateType, CommentsTableRow, CommentUpdatesRow, CommentIpfsType } from "../../../publications/comment/types.js";
 import type { CommentEditsTableRow } from "../../../publications/comment-edit/types.js";
 import type { VotesTableRow } from "../../../publications/vote/types.js";
+import type { CommentModerationTableRow } from "../../../publications/comment-moderation/types.js";
 
 // Types for query results with prefixed columns
 export type CommentIpfsPrefixedColumns = {
@@ -33,6 +35,7 @@ const parseCommentsTableRowSchema = createSchemaRowParser(CommentsTableRowSchema
 const parseCommentUpdatesTableRowSchema = createSchemaRowParser(CommentUpdateTableRowSchema, { validate: false });
 const parseCommentEditsTableRowSchema = createSchemaRowParser(CommentEditsTableRowSchema, { validate: false });
 const parseVotesTableRowSchema = createSchemaRowParser(VoteTablesRowSchema, { validate: false });
+const parseCommentModerationRowSchema = createSchemaRowParser(CommentModerationsTableRowSchema, { validate: false });
 
 export function parsePrefixedComment(row: PrefixedCommentRow): {
     comment: CommentIpfsType;
@@ -69,4 +72,9 @@ export function parseCommentEditsRow(row: unknown): CommentEditsTableRow {
 export function parseVoteRow(row: unknown): VotesTableRow {
     const { data } = parseVotesTableRowSchema(row as Record<string, unknown>);
     return data as VotesTableRow;
+}
+
+export function parseCommentModerationRow(row: unknown): CommentModerationTableRow {
+    const { data } = parseCommentModerationRowSchema(row as Record<string, unknown>);
+    return data as CommentModerationTableRow;
 }

--- a/src/runtime/node/community/local-community.ts
+++ b/src/runtime/node/community/local-community.ts
@@ -80,7 +80,8 @@ import {
     loadAndPruneExportsFromKeyv
 } from "./local-community/export.js";
 import type { InternalExportHandle } from "./local-community/export.js";
-import type { CommunityExportRecord, ExportCommunityUserOptions } from "../../../community/types.js";
+import type { CommunityExportRecord, ExportCommunityUserOptions, ExportCommunityModLogsOptions } from "../../../community/types.js";
+import type { CommentModerationTableRow } from "../../../publications/comment-moderation/types.js";
 
 // This is a sub we have locally in our pkc datapath, in a NodeJS environment
 export class LocalCommunity extends RpcLocalCommunity implements CreateNewLocalCommunityParsedOptions {
@@ -393,6 +394,17 @@ export class LocalCommunity extends RpcLocalCommunity implements CreateNewLocalC
 
     override async export(options?: ExportCommunityUserOptions): Promise<{ exportId: string }> {
         return exportCommunityEmbedded(this, options);
+    }
+
+    override async exportCommunityModLogs(opts?: ExportCommunityModLogsOptions): Promise<{ moderations: CommentModerationTableRow[] }> {
+        await this.initDbHandlerIfNeeded(); // create the handler if missing (never-started community)
+        await this._dbHandler.initDbIfNeeded(); // re-open the connection if a prior stop() closed it
+        try {
+            return { moderations: this._dbHandler.queryAllCommentModerations(opts) };
+        } finally {
+            // Don't leave a DB connection open on a community that isn't running.
+            if (this.state === "stopped") this._dbHandler.destoryConnection();
+        }
     }
 
     async _cancelExport(exportId: string): Promise<void> {

--- a/test/node/community/export-modlogs.community.test.ts
+++ b/test/node/community/export-modlogs.community.test.ts
@@ -9,13 +9,16 @@ import {
     publishWithExpectedResult,
     resolveWhenConditionIsTrue,
     mockPKC,
+    mockPKCNoDataPathWithOnlyKuboClient,
+    mockRpcRemotePKC,
     getAvailablePKCConfigsToTestAgainst
 } from "../../../dist/node/test/test-util.js";
-import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { describeSkipIfRpc, itSkipIfRpc, itIfRpc } from "../../helpers/conditional-tests.js";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import type { PKC } from "../../../dist/node/pkc/pkc.js";
 import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
-import type { RpcLocalCommunity } from "../../../dist/node/community/rpc-local-community.js";
+import { RpcLocalCommunity } from "../../../dist/node/community/rpc-local-community.js";
+import { RpcExportCommunityModLogsParamSchema } from "../../../dist/node/clients/rpc-client/schema.js";
 import type { SignerWithPublicKeyAddress } from "../../../dist/node/signer/index.js";
 
 type AnyLocalCommunity = LocalCommunity | RpcLocalCommunity;
@@ -149,5 +152,87 @@ describeSkipIfRpc("community.exportCommunityModLogs() DB connection lifecycle (e
         expect(mod!.commentModeration.removed).to.equal(true);
         // No DB handle should be left open on a stopped community.
         expect(isDbOpen(community)).to.equal(false);
+    });
+
+    it.sequential("exports mod logs on a never-started community, opening then closing the DB it created", async () => {
+        // Fresh community instance for the same owned address, created but never start()ed: this is the
+        // initDbHandlerIfNeeded "create the handler if missing" branch the started/stopped tests don't hit.
+        const neverStarted = (await pkc.createCommunity({ address: community.address })) as LocalCommunity;
+        expect(neverStarted).to.be.instanceOf((community as LocalCommunity).constructor);
+        expect(neverStarted.state).to.equal("stopped");
+        const { moderations } = await neverStarted.exportCommunityModLogs({ commentCid: postCid });
+        const mod = moderations.find((m) => m.commentCid === postCid);
+        expect(mod, "moderation should be readable from a never-started community").to.exist;
+        expect(mod!.commentModeration.removed).to.equal(true);
+        // The handler was created on demand purely for this read; it must not be left open.
+        expect(isDbOpen(neverStarted)).to.equal(false);
+    });
+});
+
+// Error paths for the base RemoteCommunity.exportCommunityModLogs() stub. Mirrors export.test.ts:
+// the embedded variant builds a read-only RemoteCommunity from a second dataPath-less PKC; the RPC
+// variant asks the daemon for an address it doesn't host so the client returns an RpcRemoteCommunity.
+// Both inherit the base stub that rejects with ERR_COMMUNITY_NOT_LOCAL.
+describe("community.exportCommunityModLogs() — error paths", () => {
+    itSkipIfRpc("a read-only RemoteCommunity rejects with ERR_COMMUNITY_NOT_LOCAL", async () => {
+        const pkc1 = await mockPKC({});
+        const localComm = (await createSubWithNoChallenge({}, pkc1)) as LocalCommunity;
+        await localComm.start();
+        await resolveWhenConditionIsTrue({ toUpdate: localComm, predicate: async () => typeof localComm.updatedAt === "number" });
+
+        const pkc2 = await mockPKCNoDataPathWithOnlyKuboClient();
+        const remoteComm = await pkc2.createCommunity({ address: localComm.address });
+        try {
+            await expect(remoteComm.exportCommunityModLogs()).rejects.toMatchObject({ code: "ERR_COMMUNITY_NOT_LOCAL" });
+        } finally {
+            await localComm.stop();
+            await pkc1.destroy();
+            await pkc2.destroy();
+        }
+    });
+
+    itIfRpc("an RpcRemoteCommunity rejects with ERR_COMMUNITY_NOT_LOCAL", async () => {
+        const pkc = await mockRpcRemotePKC();
+        try {
+            // Fresh signer → address the RPC server has never hosted, so pkc-with-rpc-client.ts returns an
+            // RpcRemoteCommunity (no exportCommunityModLogs override) and the call hits the base stub client-side.
+            const freshSigner = await pkc.createSigner();
+            const remoteComm = await pkc.createCommunity({ address: freshSigner.address });
+            expect(remoteComm).not.toBeInstanceOf(RpcLocalCommunity);
+            await expect(remoteComm.exportCommunityModLogs()).rejects.toMatchObject({ code: "ERR_COMMUNITY_NOT_LOCAL" });
+        } finally {
+            await pkc.destroy();
+        }
+    });
+});
+
+// RPC wire-param contract for exportCommunityModLogs. The param schema is pure validation (no server),
+// so it runs in any config; the ERR_COMMUNITY_NOT_FOUND path needs a live daemon and is RPC-only.
+describe("community.exportCommunityModLogs() — RPC param contract", () => {
+    it("param schema requires at least one of name / publicKey", () => {
+        // No identity → refinement fails.
+        expect(RpcExportCommunityModLogsParamSchema.safeParse({}).success).to.equal(false);
+        expect(RpcExportCommunityModLogsParamSchema.safeParse({ limit: 1 }).success).to.equal(false);
+        // Either identifier alone is enough.
+        expect(RpcExportCommunityModLogsParamSchema.safeParse({ name: "some-community.eth" }).success).to.equal(true);
+        expect(RpcExportCommunityModLogsParamSchema.safeParse({ publicKey: "12D3KooWSomePublicKey" }).success).to.equal(true);
+        // Filter options still flow through alongside identity.
+        expect(
+            RpcExportCommunityModLogsParamSchema.safeParse({ name: "some-community.eth", commentCid: "Qm...", order: "ASC" }).success
+        ).to.equal(true);
+    });
+
+    itIfRpc("the RPC server rejects with ERR_COMMUNITY_NOT_FOUND for an address it does not host", async () => {
+        const pkc = await mockRpcRemotePKC();
+        try {
+            const freshSigner = await pkc.createSigner();
+            // Call the raw client so we bypass RpcLocalCommunity (which only exists for owned communities)
+            // and exercise the server's _findCommunityAddress → not-found branch directly.
+            await expect(pkc._pkcRpcClient!.exportCommunityModLogs({ name: freshSigner.address })).rejects.toMatchObject({
+                code: "ERR_COMMUNITY_NOT_FOUND"
+            });
+        } finally {
+            await pkc.destroy();
+        }
     });
 });

--- a/test/node/community/export-modlogs.community.test.ts
+++ b/test/node/community/export-modlogs.community.test.ts
@@ -1,0 +1,153 @@
+// Tests for community.exportCommunityModLogs() — issue #89.
+// The matrix block runs under whichever pkc-config the runner selected: local-kubo-rpc (embedded
+// LocalCommunity) and, under USE_RPC=1, remote-pkc-rpc (RpcLocalCommunity -> server -> LocalCommunity).
+// The DB-connection lifecycle block is embedded-only because it inspects the LocalCommunity's
+// internal better-sqlite3 handle, which the RPC client does not expose.
+import {
+    createSubWithNoChallenge,
+    publishRandomPost,
+    publishWithExpectedResult,
+    resolveWhenConditionIsTrue,
+    mockPKC,
+    getAvailablePKCConfigsToTestAgainst
+} from "../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import type { PKC } from "../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
+import type { RpcLocalCommunity } from "../../../dist/node/community/rpc-local-community.js";
+import type { SignerWithPublicKeyAddress } from "../../../dist/node/signer/index.js";
+
+type AnyLocalCommunity = LocalCommunity | RpcLocalCommunity;
+
+// Reaches into the LocalCommunity's better-sqlite3 handle. destoryConnection() sets _db to undefined,
+// so an absent handle (or a closed one) reads as "not open".
+function isDbOpen(community: LocalCommunity): boolean {
+    const dbHandler = (community as unknown as { _dbHandler?: { _db?: { open?: boolean } } })._dbHandler;
+    return dbHandler?._db?.open === true;
+}
+
+getAvailablePKCConfigsToTestAgainst().map((config) => {
+    describe(`community.exportCommunityModLogs() — ${config.name}`, () => {
+        let pkc: PKC;
+        let community: AnyLocalCommunity;
+        let moderatorSigner: SignerWithPublicKeyAddress;
+        let postCid: string;
+
+        beforeAll(async () => {
+            pkc = await config.pkcInstancePromise();
+            community = (await createSubWithNoChallenge({}, pkc)) as AnyLocalCommunity;
+            await community.start();
+            await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+
+            moderatorSigner = await pkc.createSigner();
+            await community.edit({ roles: { [moderatorSigner.address]: { role: "moderator" } } });
+            await resolveWhenConditionIsTrue({
+                toUpdate: community,
+                predicate: async () => community.roles?.[moderatorSigner.address]?.role === "moderator"
+            });
+
+            const post = await publishRandomPost({ communityAddress: community.address, pkc });
+            postCid = post.cid!;
+
+            const modPublication = await pkc.createCommentModeration({
+                communityAddress: community.address,
+                commentCid: postCid,
+                commentModeration: { removed: true, reason: "test mod log" },
+                signer: moderatorSigner
+            });
+            await publishWithExpectedResult({ publication: modPublication, expectedChallengeSuccess: true });
+        });
+
+        afterAll(async () => {
+            await community.stop();
+            await pkc.destroy();
+        });
+
+        it("returns the published moderation with JSON columns parsed", async () => {
+            const { moderations } = await community.exportCommunityModLogs({ commentCid: postCid });
+            expect(moderations.length).to.be.greaterThan(0);
+            const mod = moderations.find((m) => m.commentCid === postCid);
+            expect(mod, "moderation targeting the post should be returned").to.exist;
+            expect(mod!.commentModeration.removed).to.equal(true);
+            expect(mod!.commentModeration.reason).to.equal("test mod log");
+            // commentModeration and signature must come back as objects, not JSON strings.
+            expect(mod!.commentModeration).to.be.an("object");
+            expect(mod!.signature).to.be.an("object");
+            expect(mod!.signature).to.not.be.a("string");
+            expect(mod!.modSignerAddress).to.equal(moderatorSigner.address);
+        });
+
+        it("honors the commentCid, timestamp window and limit filters", async () => {
+            const filtered = await community.exportCommunityModLogs({ commentCid: postCid });
+            expect(filtered.moderations.length).to.be.greaterThan(0);
+            filtered.moderations.forEach((m) => expect(m.commentCid).to.equal(postCid));
+
+            // A window ending before any moderation existed returns nothing.
+            const none = await community.exportCommunityModLogs({ endTimestamp: 1 });
+            expect(none.moderations).to.deep.equal([]);
+
+            const limited = await community.exportCommunityModLogs({ limit: 1 });
+            expect(limited.moderations.length).to.equal(1);
+        });
+    });
+});
+
+// Embedded-only: inspects the LocalCommunity's internal better-sqlite3 handle, which the RPC
+// client does not expose. Verifies exportCommunityModLogs works on a stopped community and does
+// not leak a DB connection on a non-running community.
+describeSkipIfRpc("community.exportCommunityModLogs() DB connection lifecycle (embedded)", () => {
+    let pkc: PKC;
+    let community: LocalCommunity;
+    let moderatorSigner: SignerWithPublicKeyAddress;
+    let postCid: string;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = (await createSubWithNoChallenge({}, pkc)) as LocalCommunity;
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+
+        moderatorSigner = await pkc.createSigner();
+        await community.edit({ roles: { [moderatorSigner.address]: { role: "moderator" } } });
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => community.roles?.[moderatorSigner.address]?.role === "moderator"
+        });
+
+        const post = await publishRandomPost({ communityAddress: community.address, pkc });
+        postCid = post.cid!;
+
+        const modPublication = await pkc.createCommentModeration({
+            communityAddress: community.address,
+            commentCid: postCid,
+            commentModeration: { removed: true, reason: "lifecycle mod log" },
+            signer: moderatorSigner
+        });
+        await publishWithExpectedResult({ publication: modPublication, expectedChallengeSuccess: true });
+    });
+
+    afterAll(async () => {
+        await pkc.destroy();
+    });
+
+    it.sequential("keeps the DB connection open when exporting on a started community", async () => {
+        expect(community.state).to.equal("started");
+        const { moderations } = await community.exportCommunityModLogs({ commentCid: postCid });
+        expect(moderations.length).to.be.greaterThan(0);
+        // The running community's update/publish loop relies on this connection; it must stay open.
+        expect(isDbOpen(community)).to.equal(true);
+    });
+
+    it.sequential("exports mod logs after stop(), then closes the connection it opened", async () => {
+        await community.stop();
+        expect(community.state).to.equal("stopped");
+        // stop() closed the DB connection; exportCommunityModLogs must transparently re-open it to read.
+        const { moderations } = await community.exportCommunityModLogs({ commentCid: postCid });
+        const mod = moderations.find((m) => m.commentCid === postCid);
+        expect(mod, "moderation should still be readable after stop()").to.exist;
+        expect(mod!.commentModeration.removed).to.equal(true);
+        // No DB handle should be left open on a stopped community.
+        expect(isDbOpen(community)).to.equal(false);
+    });
+});

--- a/test/node/community/modlogs.db.community.test.ts
+++ b/test/node/community/modlogs.db.community.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, afterEach, describe, it } from "vitest";
+import assert from "assert";
+import { DbHandler } from "../../../dist/node/runtime/node/community/db-handler.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { CommentModerationPubsubMessagePublicationSchema } from "../../../dist/node/publications/comment-moderation/schema.js";
+import { cleanWireAuthor } from "../../../dist/node/publications/publication-author.js";
+import type { CommentModerationsTableRowInsert } from "../../../dist/node/publications/comment-moderation/types.js";
+import { JsonSignatureSchema } from "../../../dist/node/schema/schema.js";
+import type { z } from "zod";
+
+type JsonSignature = z.infer<typeof JsonSignatureSchema>;
+
+const PROTOCOL_VERSION = "1.0.0";
+// Two valid CIDv0s so we can test the commentCid filter (CID_A is referenced by two rows).
+const CID_A = "QmYHzA8euDgUpNy3fh7JRwpPwt6jCgF35YTutYkyGGyr8f";
+const CID_B = "QmX7yV8dWgyMUiw5DSBt5ABToBWqi55GVEtnidAbNGGFoG";
+
+function buildSignature(): JsonSignature {
+    return {
+        type: "ed25519",
+        signature: "test-signature",
+        publicKey: "test-public-key",
+        signedPropertyNames: ["author", "commentModeration", "commentCid", "timestamp", "protocolVersion"]
+    };
+}
+
+// DbHandler is a Node-only internal that is never reachable over RPC, so this DB-level suite that
+// directly exercises queryAllCommentModerations (the query backing community.exportCommunityModLogs)
+// is embedded-only.
+describeSkipIfRpc("dbHandler.queryAllCommentModerations (exportCommunityModLogs backing query)", () => {
+    let _dbHandler: DbHandler | undefined;
+    let communityAddress: string;
+
+    async function createTestDbHandler(): Promise<DbHandler> {
+        communityAddress = `test-sub-${Date.now()}-${Math.random()}`;
+        const fakePKC = { noData: true };
+        const fakeCommunity = { address: communityAddress, _pkc: fakePKC };
+        const handler = new DbHandler(fakeCommunity as never);
+        await handler.initDbIfNeeded({ filename: ":memory:", fileMustExist: false });
+        await handler.createOrMigrateTablesIfNeeded();
+        return handler;
+    }
+
+    function buildModRow(opts: {
+        commentCid: string;
+        timestamp: number;
+        removed?: boolean;
+        reason?: string;
+    }): CommentModerationsTableRowInsert {
+        const raw = {
+            author: { name: "mod-author.eth" },
+            commentCid: opts.commentCid,
+            commentModeration: { removed: opts.removed ?? true, reason: opts.reason ?? "spam" },
+            communityAddress,
+            timestamp: opts.timestamp,
+            signature: buildSignature(),
+            protocolVersion: PROTOCOL_VERSION
+        };
+        // Mirror the strip + cleanWireAuthor pipeline local-community.ts storeCommentModeration applies before insert.
+        const stripped = CommentModerationPubsubMessagePublicationSchema.strip().parse(raw);
+        stripped.author = cleanWireAuthor(stripped.author);
+        return {
+            ...stripped,
+            modSignerAddress: "12D3KooWModSigner",
+            insertedAt: opts.timestamp
+        } as CommentModerationsTableRowInsert;
+    }
+
+    function seedRows() {
+        assert(_dbHandler, "DbHandler not initialised");
+        _dbHandler.insertCommentModerations([
+            buildModRow({ commentCid: CID_A, timestamp: 100, removed: true, reason: "first" }),
+            buildModRow({ commentCid: CID_B, timestamp: 200, removed: false, reason: "second" }),
+            buildModRow({ commentCid: CID_A, timestamp: 300, removed: true, reason: "third" })
+        ]);
+    }
+
+    beforeEach(async () => {
+        _dbHandler = await createTestDbHandler();
+        assert(_dbHandler, "Failed to initialise DbHandler");
+    });
+
+    afterEach(async () => {
+        if (_dbHandler) {
+            await _dbHandler.destoryConnection();
+            _dbHandler = undefined;
+        }
+    });
+
+    it("returns JSON columns parsed into objects (not strings)", () => {
+        assert(_dbHandler);
+        seedRows();
+        const rows = _dbHandler.queryAllCommentModerations();
+        expect(rows.length).to.equal(3);
+        const row = rows[0]; // newest (timestamp 300, reason "third", removed true)
+        expect(row.commentModeration).to.be.an("object");
+        expect(row.commentModeration).to.not.be.a("string");
+        expect(row.commentModeration.removed).to.equal(true);
+        expect(row.commentModeration.reason).to.equal("third");
+        expect(row.signature).to.be.an("object");
+        expect(row.signature).to.not.be.a("string");
+        expect(row.author).to.be.an("object");
+        expect(row.author).to.have.property("name", "mod-author.eth");
+    });
+
+    it("orders newest-first by default (timestamp DESC) and ASC when requested", () => {
+        assert(_dbHandler);
+        seedRows();
+        const desc = _dbHandler.queryAllCommentModerations();
+        expect(desc.map((r) => r.timestamp)).to.deep.equal([300, 200, 100]);
+        const asc = _dbHandler.queryAllCommentModerations({ order: "ASC" });
+        expect(asc.map((r) => r.timestamp)).to.deep.equal([100, 200, 300]);
+    });
+
+    it("filters by startTimestamp / endTimestamp window", () => {
+        assert(_dbHandler);
+        seedRows();
+        const fromMid = _dbHandler.queryAllCommentModerations({ startTimestamp: 200 });
+        expect(fromMid.map((r) => r.timestamp)).to.deep.equal([300, 200]);
+        const untilMid = _dbHandler.queryAllCommentModerations({ endTimestamp: 200 });
+        expect(untilMid.map((r) => r.timestamp)).to.deep.equal([200, 100]);
+        const exact = _dbHandler.queryAllCommentModerations({ startTimestamp: 200, endTimestamp: 200 });
+        expect(exact.map((r) => r.timestamp)).to.deep.equal([200]);
+    });
+
+    it("filters by commentCid", () => {
+        assert(_dbHandler);
+        seedRows();
+        const cidA = _dbHandler.queryAllCommentModerations({ commentCid: CID_A });
+        expect(cidA.map((r) => r.timestamp)).to.deep.equal([300, 100]);
+        cidA.forEach((r) => expect(r.commentCid).to.equal(CID_A));
+    });
+
+    it("caps results with limit, applied after ordering", () => {
+        assert(_dbHandler);
+        seedRows();
+        const newest = _dbHandler.queryAllCommentModerations({ limit: 1 });
+        expect(newest.map((r) => r.timestamp)).to.deep.equal([300]);
+        const oldest = _dbHandler.queryAllCommentModerations({ limit: 1, order: "ASC" });
+        expect(oldest.map((r) => r.timestamp)).to.deep.equal([100]);
+    });
+
+    it("returns an empty array when there are no moderations", () => {
+        assert(_dbHandler);
+        expect(_dbHandler.queryAllCommentModerations()).to.deep.equal([]);
+    });
+});

--- a/test/node/community/modlogs.db.community.test.ts
+++ b/test/node/community/modlogs.db.community.test.ts
@@ -6,6 +6,7 @@ import { CommentModerationPubsubMessagePublicationSchema } from "../../../dist/n
 import { cleanWireAuthor } from "../../../dist/node/publications/publication-author.js";
 import type { CommentModerationsTableRowInsert } from "../../../dist/node/publications/comment-moderation/types.js";
 import { JsonSignatureSchema } from "../../../dist/node/schema/schema.js";
+import { ExportCommunityModLogsOptionsSchema } from "../../../dist/node/community/schema.js";
 import type { z } from "zod";
 
 type JsonSignature = z.infer<typeof JsonSignatureSchema>;
@@ -46,6 +47,7 @@ describeSkipIfRpc("dbHandler.queryAllCommentModerations (exportCommunityModLogs 
         timestamp: number;
         removed?: boolean;
         reason?: string;
+        extraProps?: Record<string, unknown>;
     }): CommentModerationsTableRowInsert {
         const raw = {
             author: { name: "mod-author.eth" },
@@ -62,7 +64,8 @@ describeSkipIfRpc("dbHandler.queryAllCommentModerations (exportCommunityModLogs 
         return {
             ...stripped,
             modSignerAddress: "12D3KooWModSigner",
-            insertedAt: opts.timestamp
+            insertedAt: opts.timestamp,
+            ...(opts.extraProps ? { extraProps: opts.extraProps } : {})
         } as CommentModerationsTableRowInsert;
     }
 
@@ -143,5 +146,58 @@ describeSkipIfRpc("dbHandler.queryAllCommentModerations (exportCommunityModLogs 
     it("returns an empty array when there are no moderations", () => {
         assert(_dbHandler);
         expect(_dbHandler.queryAllCommentModerations()).to.deep.equal([]);
+    });
+
+    it("composes commentCid + timestamp window + order + limit filters in a single query (AND semantics)", () => {
+        assert(_dbHandler);
+        // Extra CID_A rows at timestamps 150 and 250 so the window can slice within one CID.
+        _dbHandler.insertCommentModerations([
+            buildModRow({ commentCid: CID_A, timestamp: 100, reason: "a-100" }),
+            buildModRow({ commentCid: CID_B, timestamp: 150, reason: "b-150" }), // excluded by commentCid
+            buildModRow({ commentCid: CID_A, timestamp: 200, reason: "a-200" }),
+            buildModRow({ commentCid: CID_A, timestamp: 300, reason: "a-300" }), // excluded by endTimestamp
+            buildModRow({ commentCid: CID_A, timestamp: 250, reason: "a-250" })
+        ]);
+        // CID_A AND 150 <= timestamp <= 250, ASC → [200, 250]; CID_B@150 and CID_A@{100,300} all excluded.
+        const rows = _dbHandler.queryAllCommentModerations({
+            commentCid: CID_A,
+            startTimestamp: 150,
+            endTimestamp: 250,
+            order: "ASC"
+        });
+        expect(rows.map((r) => r.timestamp)).to.deep.equal([200, 250]);
+        rows.forEach((r) => expect(r.commentCid).to.equal(CID_A));
+        // limit applies after the combined WHERE + ORDER BY.
+        const limited = _dbHandler.queryAllCommentModerations({
+            commentCid: CID_A,
+            startTimestamp: 150,
+            endTimestamp: 250,
+            order: "ASC",
+            limit: 1
+        });
+        expect(limited.map((r) => r.timestamp)).to.deep.equal([200]);
+    });
+
+    it("round-trips extraProps as a parsed object (not a string)", () => {
+        assert(_dbHandler);
+        _dbHandler.insertCommentModerations([
+            buildModRow({ commentCid: CID_A, timestamp: 100, extraProps: { customField: "hello", nested: { n: 1 } } })
+        ]);
+        const rows = _dbHandler.queryAllCommentModerations();
+        expect(rows.length).to.equal(1);
+        expect(rows[0].extraProps).to.be.an("object");
+        expect(rows[0].extraProps).to.not.be.a("string");
+        expect(rows[0].extraProps).to.deep.equal({ customField: "hello", nested: { n: 1 } });
+    });
+
+    // limit is a runtime option, so the public ExportCommunityModLogsOptionsSchema is what guards it.
+    it("schema rejects non-positive limit and accepts a positive integer or omission", () => {
+        // omit → unlimited (valid)
+        expect(ExportCommunityModLogsOptionsSchema.safeParse({}).success).to.equal(true);
+        expect(ExportCommunityModLogsOptionsSchema.safeParse({ limit: 1 }).success).to.equal(true);
+        // 0 used to be accepted (nonnegative) and silently returned zero rows via SQL LIMIT 0 — now rejected.
+        expect(ExportCommunityModLogsOptionsSchema.safeParse({ limit: 0 }).success).to.equal(false);
+        expect(ExportCommunityModLogsOptionsSchema.safeParse({ limit: -5 }).success).to.equal(false);
+        expect(ExportCommunityModLogsOptionsSchema.safeParse({ limit: 1.5 }).success).to.equal(false);
     });
 });


### PR DESCRIPTION
Closes #89.

## What

Adds a read-only `community.exportCommunityModLogs(opts?)` that surfaces the `commentModerations` rows already stored in a community's SQLite DB, so mod-log UIs (and community owners) can render a feed of moderation actions.

```ts
exportCommunityModLogs(opts?: {
  startTimestamp?: number;   // timestamp >= (unix seconds)
  endTimestamp?: number;     // timestamp <= (unix seconds)
  commentCid?: string;       // filter to mod actions targeting one comment
  limit?: number;            // omit to return all matches
  order?: "ASC" | "DESC";    // sort by timestamp; default "DESC" (newest first)
}): Promise<{ moderations: CommentModerationTableRow[] }>
```

JSON columns (`signature`, `author`, `commentModeration`, `extraProps`) come back parsed into objects, not strings. The `{ moderations }` wrapper leaves room to add totals/pagination later without breaking callers.

## Design

- **Inheritance:** declared on the `RemoteCommunity` base where it throws `ERR_COMMUNITY_NOT_LOCAL`, and overridden only by the two owner classes — `LocalCommunity` (direct DB read) and `RpcLocalCommunity` (RPC round-trip). This mirrors `community.export()` exactly, so the method exists on every community instance but only works for owners.
- **Ordering:** configurable via SQLite-native `ASC`/`DESC` (sort by `timestamp`, `rowid` tiebreaker), default `DESC`.
- **Connection lifecycle (embedded):** reads work whether the community is running, stopped, or never-started. The override opens the DB on demand (`initDbHandlerIfNeeded` + `initDbIfNeeded`, since `stop()` closes `_db` but keeps `_dbHandler`) and, if the community is stopped, closes the connection again afterward so no DB handle leaks on a non-running community. A running community keeps its connection. Mirrors the read-then-close in `delete()`.
- **No auth gate** on the RPC handler: comment moderations are public, signed, pubsub-published data, unlike the private-key export that `export()` gates.
- **No `DB_VERSION` bump** — pure read-side addition.

## Wiring

- `db-handler.ts`: `queryAllCommentModerations(opts)` (dynamic WHERE like `queryAuthorModEdits`) + `_parseCommentModerationRow`
- `db-row-parser.ts`: `parseCommentModerationRow` via `createSchemaRowParser`
- shared `ExportCommunityModLogsOptionsSchema`/type in `src/community/`
- RPC param/result schemas + parsers, client method, and server handler (resolves the owned community like `editCommunity`)
- README: documents `community.exportCommunityModLogs(opts?)`

## Tests

- **Unit** (`modlogs.db.community.test.ts`, in-memory DbHandler): JSON parsing, all filters, ordering (`DESC` default + `ASC`), `limit`, empty case — 6/6.
- **Integration + lifecycle** (`export-modlogs.community.test.ts`): publishes a real `CommentModeration` and reads it back over **both** embedded (`local-kubo-rpc`) and RPC (`remote-pkc-rpc`) transports; embedded-only lifecycle tests assert export works after `stop()`, the connection is closed afterward, and a started community keeps its connection open.

Run:
```
node test/run-test-config.js --pkc-config "local-kubo-rpc" test/node/community/modlogs.db.community.test.ts test/node/community/export-modlogs.community.test.ts
USE_RPC=1 node test/run-test-config.js --pkc-config "local-kubo-rpc,remote-pkc-rpc" test/node/community/export-modlogs.community.test.ts
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added community.exportCommunityModLogs() to export moderation logs with filters (time range, comment ID), limit and sort order; returns parsed JSON fields.
  * Exposed via both local API and JSON-RPC; remote communities reject with ERR_COMMUNITY_NOT_LOCAL.

* **Documentation**
  * README updated with usage, options, return shape and example.

* **Tests**
  * Added unit and integration tests covering filtering, ordering, limits, DB lifecycle, parsing, and RPC contract validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->