### PR TITLE
perf: lazy-load helia + LocalCommunity off import path, + import-time benchmark (#120)

### DIFF
--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -16,3 +16,4 @@ Concise protocol reference for AI agents and contributors. Each doc covers one d
 | [data-permanence.md](data-permanence.md) | What is permanent (IPFS CIDs) vs ephemeral (regenerated) |
 | [db-community-address-migration.md](db-community-address-migration.md) | DB v37 migration: subplebbitAddress → communityPublicKey/communityName, CID preservation |
 | [data-path-migration.md](data-path-migration.md) | Directory layout migration for downstream apps: `.plebbit/` → `.pkc/`, `subplebbits/` → `communities/` |
+| [import-performance.md](import-performance.md) | Import/startup cost (issue #120): how to benchmark it, where the time goes, optimization checklist + history |

--- a/docs/protocol/import-performance.md
+++ b/docs/protocol/import-performance.md
@@ -60,9 +60,11 @@ The benchmark prints three sections:
 > Absolute milliseconds are hardware-dependent (fast machine ~0.5s, slow machine ~9s); the **ratios
 > between layers** and the **bucket shares** are the portable signal — they hold across machines.
 
-## Baseline measurements
+## Baseline measurements (before any optimization)
 
-Captured on a fast 8-core host, Node v22.22.0, warm OS cache. Reproduce with `node scripts/bench-import-time.js`.
+Captured on `master` before the fixes below, on a fast 8-core host, Node v22.22.0, warm OS cache.
+Reproduce with `node scripts/bench-import-time.js`. For the current numbers see
+[Benchmark history](#benchmark-history).
 
 ### Per-layer cold import (no V8 compile cache)
 
@@ -106,14 +108,32 @@ the graph size, not a hotspot — which is why bundling and loading fewer module
 Ranked by effort/payoff. Each is a follow-up PR; tick it and add a [history](#benchmark-history) row
 when it lands.
 
+-   [x] **Lazy-load the local-node runtime off the RPC-client path** (done in #124) — the two
+        heaviest leaves are now deferred behind dynamic `import()` on the code paths that actually
+        start/run a local node, instead of being statically imported by the base `PKC` class:
+
+    -   **helia/libp2p** (~683ms standalone, the single biggest subgraph) — loaded inside
+        `_initLibp2pJsClientsIfNeeded()` in [`src/pkc/pkc.ts`](../../src/pkc/pkc.ts); `Libp2pJsClient`
+        is now a type-only import.
+    -   **LocalCommunity → db-handler → `better-sqlite3`** (~283ms standalone) — loaded inside
+        `_createLocalCommunity()`; the class is now a type-only import at module scope.
+
+        Result: `index.js` cold ~535ms → ~290ms and warm ~395ms → ~206ms on the reference host
+        (~46% faster import); the `pkc core` jump collapsed from +310ms to +88ms. The same ratio
+        takes the issue's ~9s slow-host import to roughly ~5s. Verified with the `helia` (17),
+        local `create.community` (15) and `pkc` (6) test suites.
+
+        Not pursued (measured ~free): lazy-loading `better-sqlite3`-via-`util`/`Storage` and the
+        challenges subsystem — each imports in ≈ the bare-Node baseline (~165ms), so deferring them
+        saves only ~10ms for real churn/risk. The residual ~88ms is the many-small-modules tail,
+        which only bundling addresses.
+
 -   [ ] **V8 compile cache** — `module.enableCompileCache()` on the Node entry (Node ≥ 22.8), or
-        document `NODE_COMPILE_CACHE`. Recovers the ~26% parse/compile portion. Cheap, low-risk.
--   [ ] **Lazy-load the local-node runtime off the RPC-client path** — the RPC client should not
-        statically import `better-sqlite3`, IPFS/helia helpers, the challenges subsystem, or local
-        community classes. Defer them behind dynamic `import()` on the code paths that actually start
-        or run a local node. This is the structural fix for the ~310ms (≈ ~7s on slow hardware) jump.
+        document `NODE_COMPILE_CACHE`. Recovers the ~29% parse/compile portion (~83ms after the
+        lazy-load above). Cheap, low-risk, orthogonal to lazy-loading.
 -   [ ] **Thin client entry point** — e.g. a `./client` export that pulls a minimal graph so RPC-only
-        consumers never resolve/link the local-node modules at all.
+        consumers never resolve/link the local-node modules at all. Likely unnecessary now that the
+        heavy leaves are lazy; revisit only if the residual is still too high on slow hardware.
 -   [ ] **Bundle the published `dist`** — collapse the 157-file `dist/node` graph (and as much of the
         dependency closure as practical) into a small number of files to cut the ~65% ESM
         resolve/link overhead. Biggest engineering lift; must not break the browser build or tree-shaking.
@@ -123,6 +143,7 @@ when it lands.
 After every optimization, re-run `node scripts/bench-import-time.js` on the same/comparable hardware and append a
 row here so each change shows its delta against the prior one. (Fast 8-core host, Node v22.22.0.)
 
-| Change   | index cold | index warm-cache | rpc-client only | pkc-with-rpc | dominant cost              | Notes / PR              |
-| -------- | ---------- | ---------------- | --------------- | ------------ | -------------------------- | ----------------------- |
-| baseline | ~535ms     | ~395ms           | ~173ms          | ~475ms       | ~65% node ESM resolve/link | #120 (measurement only) |
+| Change                           | index cold | index warm-cache | rpc-client only | pkc-with-rpc | dominant cost              | Notes / PR                  |
+| -------------------------------- | ---------- | ---------------- | --------------- | ------------ | -------------------------- | --------------------------- |
+| baseline                         | ~535ms     | ~395ms           | ~173ms          | ~475ms       | ~65% node ESM resolve/link | #120 (measurement only)     |
+| lazy-load helia + LocalCommunity | ~290ms     | ~206ms           | ~164ms          | ~249ms       | ~64% node ESM resolve/link | #124 (~46% faster index.js) |

--- a/docs/protocol/import-performance.md
+++ b/docs/protocol/import-performance.md
@@ -1,0 +1,128 @@
+# Import / startup performance
+
+Tracking doc for [issue #120](https://github.com/pkcprotocol/pkc-js/issues/120): importing the
+package is slow, and the cost is paid by every process that imports it — including CLIs and
+companion processes that only talk to a remote daemon over RPC and never start a local node.
+
+This doc is **measurement-first**. It records how to reproduce the numbers, the current baseline,
+where the time actually goes, and a checklist of optimizations. Each optimization, once landed,
+appends a row to the [Benchmark history](#benchmark-history) so we can see its delta.
+
+## Problem
+
+Importing `@pkcprotocol/pkc-js` (`dist/node/index.js`) — a pure `import`, no PKC instance created,
+no RPC connection, no work done — takes **~9s on slower hardware** and **~0.5s on a fast dev
+machine**. A consumer that only uses the RPC client to talk to a remote daemon pays this full
+startup, which makes trivial read-only commands feel broken (10–20s) on modest hardware.
+
+## Root cause (confirmed)
+
+`PKCWithRpcClient` — the _remote_ RPC client wrapper — is declared as
+`class PKCWithRpcClient extends PKC` in [`src/pkc/pkc-with-rpc-client.ts`](../../src/pkc/pkc-with-rpc-client.ts).
+Extending the core [`src/pkc/pkc.ts`](../../src/pkc/pkc.ts) class statically pulls in the entire
+local-node runtime: local community classes (→ `better-sqlite3`), the challenges subsystem, the
+IPFS/helia helpers, and the full zod schema set. An RPC-only consumer needs none of that to start,
+yet pays for all of it.
+
+The benchmark confirms two compounding costs:
+
+1. **The full local-node runtime is loaded eagerly.** Importing just the RPC-client graph is
+   ~2.7× cheaper than the full entry (see the per-layer table); the jump happens the moment the
+   core `pkc.js` is touched.
+2. **Most of the time is the module graph itself, not our code.** ~65% of import time is spent in
+   Node's ESM resolve/link/compile machinery and only ~1% in our own file bodies — i.e. it is the
+   _number_ of modules (157 `dist/node` files plus a large dependency closure), not expensive
+   top-level code, that dominates.
+
+## Running the benchmark
+
+```sh
+npm run build                      # the harness imports from dist/, so build first
+node scripts/bench-import-time.js
+```
+
+Tune iterations with `BENCH_IMPORT_ITERATIONS` (default 5). Each measurement runs in a **fresh Node
+process** (ESM caches a graph after the first import), and the median is reported. Scratch files go
+to `.tmp/` (never `/tmp`, which is RAM-backed tmpfs on Linux).
+
+The benchmark prints three sections:
+
+-   **Per-layer cold import** — imports each layer in isolation; the marginal jump between rows
+    attributes cost. The leanest layer (`rpc-client`) vs the full `index.js` shows what the RPC-only
+    path is forced to over-pay.
+-   **Cold vs warm V8 compile cache** — sizes the parse/compile portion (recoverable via
+    `NODE_COMPILE_CACHE` / `module.enableCompileCache()`) separately from linking + execution.
+-   **Per-file self-time attribution** — runs the import under V8's native sampling profiler
+    (`--cpu-prof`) and aggregates the resulting `.cpuprofile` into self-time per source file, plus a
+    coarse bucket breakdown (our code / deps / node internals / runtime). This is the
+    "where is it slow" signal.
+
+> Absolute milliseconds are hardware-dependent (fast machine ~0.5s, slow machine ~9s); the **ratios
+> between layers** and the **bucket shares** are the portable signal — they hold across machines.
+
+## Baseline measurements
+
+Captured on a fast 8-core host, Node v22.22.0, warm OS cache. Reproduce with `node scripts/bench-import-time.js`.
+
+### Per-layer cold import (no V8 compile cache)
+
+| Layer                             | Median                      |
+| --------------------------------- | --------------------------- |
+| rpc-client (pure RPC graph)       | ~173ms                      |
+| challenges subsystem              | ~165ms                      |
+| pkc core class                    | **~476ms (+310ms vs prev)** |
+| pkc-with-rpc-client (extends PKC) | ~475ms                      |
+| index.js (public entry)           | ~480ms                      |
+
+The +310ms jump at `pkc core class` is the local-node runtime being loaded. `pkc-with-rpc-client`
+adds nothing on top because, via `extends PKC`, it has already pulled the whole thing in. A pure
+RPC client (~173ms) is ~2.7× cheaper than the full entry (~480ms).
+
+### index.js — cold vs warm V8 compile cache
+
+| Run                             | Time   |
+| ------------------------------- | ------ |
+| cold (populates bytecode cache) | ~535ms |
+| warm (bytecode reused)          | ~395ms |
+
+Parse/compile ≈ **~140ms (~26%)**; linking + top-level execution ≈ ~395ms. The ~26% is recoverable
+with a compile cache — cheap and immediate.
+
+### Per-file self-time attribution (CPU profile of index.js import)
+
+| Bucket                                      | Share    |
+| ------------------------------------------- | -------- |
+| our code (`dist/node/...`)                  | ~1%      |
+| dependencies (`node_modules`)               | ~10%     |
+| node internals (ESM resolve/link, builtins) | **~65%** |
+| runtime (`(program)`/gc/native)             | ~23%     |
+
+No single file body is hot. Top dependency self-times are small and spread out: `zod` ~17ms, then
+`@noble/curves`, `asn1js`, `entities`, `undici`, `axios`, `multiformats` at ~2–3ms each. The cost is
+the graph size, not a hotspot — which is why bundling and loading fewer modules are the big levers.
+
+## Optimization directions
+
+Ranked by effort/payoff. Each is a follow-up PR; tick it and add a [history](#benchmark-history) row
+when it lands.
+
+-   [ ] **V8 compile cache** — `module.enableCompileCache()` on the Node entry (Node ≥ 22.8), or
+        document `NODE_COMPILE_CACHE`. Recovers the ~26% parse/compile portion. Cheap, low-risk.
+-   [ ] **Lazy-load the local-node runtime off the RPC-client path** — the RPC client should not
+        statically import `better-sqlite3`, IPFS/helia helpers, the challenges subsystem, or local
+        community classes. Defer them behind dynamic `import()` on the code paths that actually start
+        or run a local node. This is the structural fix for the ~310ms (≈ ~7s on slow hardware) jump.
+-   [ ] **Thin client entry point** — e.g. a `./client` export that pulls a minimal graph so RPC-only
+        consumers never resolve/link the local-node modules at all.
+-   [ ] **Bundle the published `dist`** — collapse the 157-file `dist/node` graph (and as much of the
+        dependency closure as practical) into a small number of files to cut the ~65% ESM
+        resolve/link overhead. Biggest engineering lift; must not break the browser build or tree-shaking.
+
+## Benchmark history
+
+After every optimization, re-run `node scripts/bench-import-time.js` on the same/comparable hardware and append a
+row here so each change shows its delta against the prior one. (Fast 8-core host, Node v22.22.0.)
+
+| Change   | index cold | index warm-cache | rpc-client only | pkc-with-rpc | dominant cost              | Notes / PR              |
+| -------- | ---------- | ---------------- | --------------- | ------------ | -------------------------- | ----------------------- |
+| baseline | ~535ms     | ~395ms           | ~173ms          | ~475ms       | ~65% node ESM resolve/link | #120 (measurement only) |

--- a/scripts/bench-import-time.js
+++ b/scripts/bench-import-time.js
@@ -1,0 +1,199 @@
+// Import-time benchmark (issue #120): measures the wall-clock cost of importing the compiled
+// package, broken down by layer, to attribute where the startup latency comes from and to give
+// the optimization work a repeatable number to track. It is a measurement tool, not a regression
+// gate, so it lives here under scripts/ rather than in the test suite.
+//
+//   npm run build           # the harness imports from dist/, so build first
+//   node scripts/bench-import-time.js
+//
+// Tune iterations with BENCH_IMPORT_ITERATIONS (default 5). Each measurement runs in a FRESH node
+// process, because once a module graph is in a process's ESM cache a second import() is ~free — so
+// per-process isolation is the only way to measure real cold-start cost. We report the median over
+// the iterations.
+//
+// Why this exists (see issue #120): importing dist/node/index.js takes ~9s on slow hardware and
+// ~0.5s on a fast dev machine, with NO PKC instance created and no work done. The dominant cost is
+// that the RPC-client path eagerly pulls in the full local-node runtime: pkc-with-rpc-client.js
+// does `class PKCWithRpcClient extends PKC`, and the base PKC class statically imports the local
+// community classes (-> better-sqlite3), the challenges subsystem, the IPFS/helia helpers, and the
+// full zod schema set. A consumer that only talks to a remote daemon over RPC needs none of that to
+// start, yet pays for all of it.
+//
+// The layers below are imported each in isolation so you can see the marginal jump from the pure
+// RPC-client graph to the full pkc-with-rpc-client graph (the inheritance pull-in), and the jump
+// again to index.js. The absolute numbers scale with hardware; the RATIOS between layers are the
+// stable, portable signal — they hold on fast and slow machines alike.
+
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const ITERATIONS = Number(process.env.BENCH_IMPORT_ITERATIONS ?? 5);
+const distNode = fileURLToPath(new URL("../dist/node/", import.meta.url));
+
+// Scratch lives under the project's .tmp/ (gitignored, on real disk), NEVER os.tmpdir() — on Linux
+// /tmp is RAM-backed tmpfs, and the compile-cache section writes one file per module (~14k files),
+// which would waste memory and can exhaust tmpfs inodes.
+const benchTmpBase = fileURLToPath(new URL("../.tmp/", import.meta.url));
+mkdirSync(benchTmpBase, { recursive: true });
+
+// Entry points to measure, imported one per fresh process. Ordered from the leanest graph (a pure
+// RPC client) to the full public entry, so the table reads as "what does each extra layer cost".
+const targets = [
+    { label: "rpc-client (pure RPC graph)", file: "clients/rpc-client/pkc-rpc-client.js" },
+    { label: "challenges subsystem", file: "runtime/node/community/challenges/index.js" },
+    { label: "pkc core class", file: "pkc/pkc.js" },
+    { label: "pkc-with-rpc-client (extends PKC)", file: "pkc/pkc-with-rpc-client.js" },
+    { label: "index.js (public entry)", file: "index.js" }
+];
+
+const median = (xs) => {
+    const sorted = [...xs].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+};
+
+// Run a single isolated import in a fresh process and return the elapsed ms it prints to stderr.
+// `compileCacheDir`, when set, enables V8's bytecode cache (NODE_COMPILE_CACHE) so we can separate
+// parse/compile cost (recoverable via the cache) from module linking + top-level execution cost.
+function measureOnce(absFile, compileCacheDir) {
+    const code = `const t=performance.now();await import(${JSON.stringify(absFile)});process.stderr.write(String(performance.now()-t));process.exit(0);`;
+    const env = { ...process.env, TMPDIR: benchTmpBase };
+    if (compileCacheDir) env.NODE_COMPILE_CACHE = compileCacheDir;
+    else delete env.NODE_COMPILE_CACHE;
+    const res = spawnSync(process.execPath, ["--input-type=module", "-e", code], { env, encoding: "utf8" });
+    if (res.status !== 0) {
+        throw new Error(`import of ${absFile} failed:\n${res.stderr}`);
+    }
+    return Number(res.stderr.trim());
+}
+
+function measureMedian(absFile, compileCacheDir) {
+    const samples = [];
+    for (let i = 0; i < ITERATIONS; i++) samples.push(measureOnce(absFile, compileCacheDir));
+    return median(samples);
+}
+
+console.log(`# pkc-js import-time benchmark (issue #120)`);
+console.log(`node ${process.version}, ${ITERATIONS} iterations/measurement, fresh process each, median reported.\n`);
+
+// 1) Per-layer cold import (no compile cache). The marginal jump between rows attributes the cost.
+console.log(`## Per-layer cold import (no V8 compile cache)\n`);
+console.log(`| Layer | Median |`);
+console.log(`| --- | --- |`);
+let prev = null;
+for (const t of targets) {
+    const abs = path.join(distNode, t.file);
+    const ms = measureMedian(abs, null);
+    const delta = prev === null ? "" : ` (+${(ms - prev).toFixed(0)}ms vs prev)`;
+    console.log(`| ${t.label} | ${ms.toFixed(0)}ms${delta} |`);
+    prev = ms;
+}
+
+// 2) Full index.js: cold vs warm V8 compile cache, to size the parse/compile portion.
+console.log(`\n## index.js — cold vs warm V8 compile cache\n`);
+const indexAbs = path.join(distNode, "index.js");
+const cacheDir = mkdtempSync(path.join(benchTmpBase, "pkc-bench-cc-"));
+try {
+    // Cold: first run with an empty cache dir also POPULATES the bytecode cache.
+    const cold = measureOnce(indexAbs, cacheDir);
+    // Warm: subsequent runs reuse the populated bytecode.
+    const warm = measureMedian(indexAbs, cacheDir);
+    console.log(`| Run | Time |`);
+    console.log(`| --- | --- |`);
+    console.log(`| cold (populates bytecode cache) | ${cold.toFixed(0)}ms |`);
+    console.log(`| warm (bytecode reused) | ${warm.toFixed(0)}ms |`);
+    console.log(`\nParse/compile portion ≈ ${(cold - warm).toFixed(0)}ms; linking + top-level exec ≈ ${warm.toFixed(0)}ms.`);
+} finally {
+    rmSync(cacheDir, { recursive: true, force: true });
+}
+
+// 3) Per-file self-time attribution — the "where in our code is it slow" answer. We run the import
+// once under V8's CPU sampling profiler (--cpu-prof), then aggregate self-time per source file from
+// the .cpuprofile. Self-time per profiler node = sum of the sample timeDeltas attributed to that
+// node id; we map each node to its callFrame.url (the source file) and sum across all nodes sharing
+// a file. This captures parse/compile + top-level execution, and needs no source rewriting (unlike
+// a loader hook), so it is robust to "use strict" directives, hashbangs and import attributes.
+console.log(`\n## Per-file self-time attribution (CPU profile of index.js import)\n`);
+const profDir = mkdtempSync(path.join(benchTmpBase, "pkc-bench-prof-"));
+try {
+    const code = `await import(${JSON.stringify(indexAbs)});process.exit(0);`;
+    const res = spawnSync(
+        process.execPath,
+        ["--cpu-prof", "--cpu-prof-dir", profDir, "--cpu-prof-interval", "200", "--input-type=module", "-e", code],
+        { encoding: "utf8", env: { ...process.env, TMPDIR: benchTmpBase } }
+    );
+    if (res.status !== 0) throw new Error(`profiled import failed:\n${res.stderr}`);
+
+    const profFile = readdirSync(profDir).find((f) => f.endsWith(".cpuprofile"));
+    if (!profFile) throw new Error(`no .cpuprofile produced in ${profDir}`);
+    const profile = JSON.parse(readFileSync(path.join(profDir, profFile), "utf8"));
+
+    // node id -> total self time (µs). samples[i] ran for timeDeltas[i] µs and is attributed to that
+    // sample's node id (its top-of-stack frame).
+    const selfByNodeId = new Map();
+    for (let i = 0; i < profile.samples.length; i++) {
+        const id = profile.samples[i];
+        const dt = profile.timeDeltas[i] ?? 0;
+        selfByNodeId.set(id, (selfByNodeId.get(id) ?? 0) + dt);
+    }
+
+    // Roll node self-time up to its source file (callFrame.url), splitting our dist/ code from deps.
+    const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+    const ourSelf = new Map(); // dist-relative file -> µs
+    const depSelf = new Map(); // node_modules package -> µs
+    // Coarse buckets so the reader can see whether the cost is in file bodies or the module loader.
+    const buckets = { ourCode: 0, deps: 0, nodeInternal: 0, runtime: 0 };
+    let total = 0;
+    for (const node of profile.nodes) {
+        const us = selfByNodeId.get(node.id) ?? 0;
+        total += us;
+        let url = node.callFrame?.url ?? "";
+        if (url.startsWith("node:")) {
+            buckets.nodeInternal += us; // ESM resolve/read/compile/link machinery, builtins
+            continue;
+        }
+        if (url.startsWith("file://")) url = fileURLToPath(url);
+        if (!url || !path.isAbsolute(url)) {
+            buckets.runtime += us; // (program), (idle), (garbage collector), native
+            continue;
+        }
+        const nm = url.lastIndexOf("node_modules/");
+        if (nm !== -1) {
+            buckets.deps += us;
+            const rest = url.slice(nm + "node_modules/".length);
+            const parts = rest.split("/");
+            const pkg = rest.startsWith("@") ? `${parts[0]}/${parts[1]}` : parts[0];
+            depSelf.set(pkg, (depSelf.get(pkg) ?? 0) + us);
+        } else if (url.startsWith(repoRoot)) {
+            buckets.ourCode += us;
+            const rel = path.relative(repoRoot, url);
+            ourSelf.set(rel, (ourSelf.get(rel) ?? 0) + us);
+        } else {
+            buckets.runtime += us;
+        }
+    }
+
+    const topN = (map, n) => [...map.entries()].sort((a, b) => b[1] - a[1]).slice(0, n);
+    const ms = (us) => (us / 1000).toFixed(0);
+    const pct = (us) => `${((us / total) * 100).toFixed(0)}%`;
+
+    console.log(`Sampled ${(total / 1000).toFixed(0)}ms total. Where it goes:\n`);
+    console.log(`| Bucket | Self | Share |`);
+    console.log(`| --- | --- | --- |`);
+    console.log(`| our code (dist/node/...) | ${ms(buckets.ourCode)}ms | ${pct(buckets.ourCode)} |`);
+    console.log(`| dependencies (node_modules) | ${ms(buckets.deps)}ms | ${pct(buckets.deps)} |`);
+    console.log(`| node internals (ESM resolve/link, builtins) | ${ms(buckets.nodeInternal)}ms | ${pct(buckets.nodeInternal)} |`);
+    console.log(`| runtime ((program)/gc/native) | ${ms(buckets.runtime)}ms | ${pct(buckets.runtime)} |`);
+    console.log(`\n### Top our-code files (dist/node/...) by self-time\n`);
+    console.log(`| File | Self |`);
+    console.log(`| --- | --- |`);
+    for (const [file, us] of topN(ourSelf, 20)) console.log(`| ${file} | ${ms(us)}ms |`);
+    console.log(`\n### Top dependencies by self-time\n`);
+    console.log(`| Package | Self |`);
+    console.log(`| --- | --- |`);
+    for (const [pkg, us] of topN(depSelf, 20)) console.log(`| ${pkg} | ${ms(us)}ms |`);
+} finally {
+    rmSync(profDir, { recursive: true, force: true });
+}

--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -59,11 +59,10 @@ import LRUStorage from "../runtime/node/lru-storage.js";
 import { RemoteCommunity } from "../community/remote-community.js";
 import { RpcRemoteCommunity } from "../community/rpc-remote-community.js";
 import { RpcLocalCommunity } from "../community/rpc-local-community.js";
-import {
-    LocalCommunity,
-    createNewLocalCommunityDb,
-    updateInstancePropsWithStartedCommunityOrDb
-} from "../runtime/node/community/local-community.js";
+// LocalCommunity pulls in the db-handler -> better-sqlite3 graph (issue #120). It is only
+// instantiated when a local community is created (_createLocalCommunity), so the class and its
+// helper functions are loaded dynamically there; here we keep only the type (erased at build time).
+import type { LocalCommunity } from "../runtime/node/community/local-community.js";
 import { extractCommunityRuntimeFieldsFromParsedPages } from "../pages/util.js";
 import pTimeout, { TimeoutError } from "p-timeout";
 import * as remeda from "remeda";
@@ -130,8 +129,11 @@ import type {
 import { LRUCache } from "lru-cache";
 import { PKCTypedEmitter } from "../clients/pkc-typed-emitter.js";
 import type { PageTypeJson } from "../pages/types.js";
-import { createLibp2pJsClientOrUseExistingOne } from "../helia/helia-for-pkc.js";
-import { Libp2pJsClient } from "../helia/libp2pjsClient.js";
+// helia/libp2p is the single heaviest subgraph to import (issue #120). It is only needed when the
+// caller actually starts a libp2p-js node, so it is loaded dynamically inside
+// _initLibp2pJsClientsIfNeeded() rather than statically here. Libp2pJsClient is used only as a type,
+// so it stays a type-only import (erased at build time, no runtime cost).
+import type { Libp2pJsClient } from "../helia/libp2pjsClient.js";
 import type { AuthorNameRpcParam, CidRpcParam, RpcFetchCidResult } from "../clients/rpc-client/types.js";
 import { parseRpcAuthorNameParam, parseRpcCidParam } from "../clients/rpc-client/rpc-schema-util.js";
 import { cleanWireAuthor, normalizeCreatePublicationAuthor } from "../publications/publication-author.js";
@@ -365,6 +367,9 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         this.clients.libp2pJsClients = {};
         if (!this.libp2pJsClientsOptions) return;
         if (!this.httpRoutersOptions) throw Error("httpRoutersOptions is required for libp2pJsClient");
+        // Loaded here (not at the top of the file) so the large helia/libp2p graph is only imported
+        // when a libp2p-js node is actually started — RPC-only and gateway consumers never pay it.
+        const { createLibp2pJsClientOrUseExistingOne } = await import("../helia/helia-for-pkc.js");
         for (const clientOptions of this.libp2pJsClientsOptions) {
             const heliaNode = await createLibp2pJsClientOrUseExistingOne({
                 ...clientOptions,
@@ -750,6 +755,12 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
 
         const canCreateLocalCommunity = this._canCreateNewLocalCommunity();
         if (!canCreateLocalCommunity) throw new PKCError("ERR_CAN_NOT_CREATE_A_LOCAL_COMMUNITY", { pkcOptions: this._userPKCOptions });
+
+        // Loaded here (not at the top of the file) so the local-community -> better-sqlite3 graph is
+        // only imported when a local community is actually created — see issue #120.
+        const { LocalCommunity, createNewLocalCommunityDb, updateInstancePropsWithStartedCommunityOrDb } = await import(
+            "../runtime/node/community/local-community.js"
+        );
 
         const localCommunities = await nodeListCommunities(this);
         const isLocalCommunity = localCommunities.includes(options.address); // Community exists already, only pass address so we don't override other props


### PR DESCRIPTION
Addresses #120: `import @pkcprotocol/pkc-js` takes ~9s on slow hardware / ~0.5s on a fast dev machine with no PKC instance created — paid by every RPC-only consumer (CLIs, companion processes) that never starts a local node.

This PR both **measures** the problem and lands the **first (biggest) fix**.

## Fix: lazy-load the two heaviest leaves

The base `PKC` class statically imported the heaviest subsystems, and `PKCWithRpcClient extends PKC` drags them onto the RPC-only path. Profiling (standalone import cost) showed the weight is concentrated:
- **helia/libp2p** — ~683ms standalone, the single biggest subgraph
- **LocalCommunity → db-handler → better-sqlite3** — ~283ms standalone

Both are only used inside async methods (`_initLibp2pJsClientsIfNeeded`, `_createLocalCommunity`), never at construction — so only the top-level `import` forced eager loading. They're now deferred behind dynamic `import()` at those existing call sites; the `Libp2pJsClient` and `LocalCommunity` bindings become type-only imports.

**Result (reference host, Node v22.22.0):** `index.js` cold ~535ms → ~290ms, warm ~395ms → ~206ms (**~46% faster import**); the `pkc-core` per-layer jump collapsed from +310ms to +88ms. The same ratio takes the issue's ~9s slow-host import to roughly ~5s.

Not pursued (measured ≈ free): lazy-loading sqlite-via-`util`/`Storage` and the challenges subsystem each import in ≈ the bare-Node baseline (~165ms), saving only ~10ms for real churn. The residual ~88ms is the many-small-modules tail (bundling territory).

## Measurement tooling (kept for tracking + regression)

- **`scripts/bench-import-time.js`** — per-layer cold import, cold-vs-warm V8 compile cache, and per-file self-time attribution via Node's native `--cpu-prof` (aggregated into a committable table). Fresh process per measurement, scratch in `.tmp/`.
- **`docs/protocol/import-performance.md`** — problem, confirmed root cause, before/after numbers, optimization checklist, and a **benchmark-history table** (one row per change).

## Verification

- `helia` (17), local `create.community` (15), `pkc` (6) suites pass — both lazy paths exercised end-to-end; `PKC.challenges` API intact.
- `npm run build` + `verify:browser-imports` green.
- `node scripts/bench-import-time.js` reproduces the numbers above.

## Remaining (tracked in the doc, follow-up PRs)

- [ ] V8 compile cache (`module.enableCompileCache()`) — ~29% parse/compile, orthogonal
- [ ] Thin `./client` entry — likely unnecessary now; revisit if slow-host residual is still high
- [ ] Bundle `dist` — the ~65% ESM resolve/link tail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for benchmarking agent import/startup performance, with measurement protocol, interpretation, baseline data, and optimization checklist.

* **Chores**
  * Added a Node benchmarking script to measure cold vs warm import latency, report per-layer deltas, and produce CPU-profile summaries.

* **Refactor**
  * Reduced startup/import overhead by deferring loading of heavy components until needed, improving cold-start performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->