### PR TITLE
perf: enable V8 compile cache by default on the Node ESM entry (#120)

### DIFF
--- a/docs/protocol/import-performance.md
+++ b/docs/protocol/import-performance.md
@@ -45,13 +45,16 @@ Tune iterations with `BENCH_IMPORT_ITERATIONS` (default 5). Each measurement run
 process** (ESM caches a graph after the first import), and the median is reported. Scratch files go
 to `.tmp/` (never `/tmp`, which is RAM-backed tmpfs on Linux).
 
-The benchmark prints three sections:
+The benchmark prints four sections:
 
 -   **Per-layer cold import** — imports each layer in isolation; the marginal jump between rows
     attributes cost. The leanest layer (`rpc-client`) vs the full `index.js` shows what the RPC-only
     path is forced to over-pay.
 -   **Cold vs warm V8 compile cache** — sizes the parse/compile portion (recoverable via
     `NODE_COMPILE_CACHE` / `module.enableCompileCache()`) separately from linking + execution.
+-   **npm import entry, self-enabled compile cache** — measures `index-with-compile-cache.js`
+    (the `"."` → `import` export condition), which enables the compile cache itself: first run
+    (populates the cache) vs warm runs. This is the default experience for Node ESM consumers.
 -   **Per-file self-time attribution** — runs the import under V8's native sampling profiler
     (`--cpu-prof`) and aggregates the resulting `.cpuprofile` into self-time per source file, plus a
     coarse bucket breakdown (our code / deps / node internals / runtime). This is the
@@ -128,9 +131,25 @@ when it lands.
         saves only ~10ms for real churn/risk. The residual ~88ms is the many-small-modules tail,
         which only bundling addresses.
 
--   [ ] **V8 compile cache** — `module.enableCompileCache()` on the Node entry (Node ≥ 22.8), or
-        document `NODE_COMPILE_CACHE`. Recovers the ~29% parse/compile portion (~83ms after the
-        lazy-load above). Cheap, low-risk, orthogonal to lazy-loading.
+-   [x] **V8 compile cache** (done in #125) — the `"."` → `import` export condition now points at a
+        thin bootstrap, [`src/index-with-compile-cache.ts`](../../src/index-with-compile-cache.ts),
+        that calls `module.enableCompileCache()` (via
+        [`src/runtime/node/compile-cache.ts`](../../src/runtime/node/compile-cache.ts), no-op on
+        Node < 22.8 and in browsers) and only then dynamic-imports the real `index.js`.
+
+    The bootstrap exists because the cache only covers modules compiled _after_ the call, and
+    Node's ESM loader compiles the whole static graph before any module body runs — so calling
+    it from inside `index.ts` would always be too late; the dynamic `import()` is what delays
+    the graph's compilation until the cache is on. The `require` condition keeps pointing at
+    plain `index.js` since `require(esm)` rejects graphs with top-level await; CJS consumers
+    keep the previous (uncached) behavior.
+
+    Result: Node ESM consumers get the warm-cache import by default — ~272ms cold → ~208ms on
+    every run after the first (~24% faster) on the reference host, no consumer config needed.
+    The wrapper itself adds ~0ms (272ms vs 272ms with the cache disabled), and the first run
+    pays a one-time ~30ms cache-population cost. Cache dir is Node's default
+    (`os.tmpdir()/node-compile-cache`), overridable with `NODE_COMPILE_CACHE`; opt out with
+    `NODE_DISABLE_COMPILE_CACHE=1`.
 -   [ ] **Thin client entry point** — e.g. a `./client` export that pulls a minimal graph so RPC-only
         consumers never resolve/link the local-node modules at all. Likely unnecessary now that the
         heavy leaves are lazy; revisit only if the residual is still too high on slow hardware.
@@ -147,3 +166,4 @@ row here so each change shows its delta against the prior one. (Fast 8-core host
 | -------------------------------- | ---------- | ---------------- | --------------- | ------------ | -------------------------- | --------------------------- |
 | baseline                         | ~535ms     | ~395ms           | ~173ms          | ~475ms       | ~65% node ESM resolve/link | #120 (measurement only)     |
 | lazy-load helia + LocalCommunity | ~290ms     | ~206ms           | ~164ms          | ~249ms       | ~64% node ESM resolve/link | #124 (~46% faster index.js) |
+| self-enabled compile cache       | ~272ms     | ~208ms (now the default) | ~185ms  | ~257ms       | ~66% node ESM resolve/link | #125 (warm-by-default ESM entry) |

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         ".": {
             "types": "./dist/node/index.d.ts",
             "browser": "./dist/browser/index.js",
-            "import": "./dist/node/index.js",
+            "import": "./dist/node/index-with-compile-cache.js",
             "require": "./dist/node/index.js"
         },
         "./challenges": {

--- a/scripts/bench-import-time.js
+++ b/scripts/bench-import-time.js
@@ -45,7 +45,10 @@ const targets = [
     { label: "challenges subsystem", file: "runtime/node/community/challenges/index.js" },
     { label: "pkc core class", file: "pkc/pkc.js" },
     { label: "pkc-with-rpc-client (extends PKC)", file: "pkc/pkc-with-rpc-client.js" },
-    { label: "index.js (public entry)", file: "index.js" }
+    { label: "index.js (public entry)", file: "index.js" },
+    // cache disabled in cold runs (NODE_DISABLE_COMPILE_CACHE=1), so this row isolates the
+    // bootstrap wrapper's own overhead vs index.js — it should be ~0
+    { label: "index-with-compile-cache.js (npm import entry, cache disabled)", file: "index-with-compile-cache.js" }
 ];
 
 const median = (xs) => {
@@ -60,8 +63,15 @@ const median = (xs) => {
 function measureOnce(absFile, compileCacheDir) {
     const code = `const t=performance.now();await import(${JSON.stringify(absFile)});process.stderr.write(String(performance.now()-t));process.exit(0);`;
     const env = { ...process.env, TMPDIR: benchTmpBase };
-    if (compileCacheDir) env.NODE_COMPILE_CACHE = compileCacheDir;
-    else delete env.NODE_COMPILE_CACHE;
+    if (compileCacheDir) {
+        env.NODE_COMPILE_CACHE = compileCacheDir;
+        delete env.NODE_DISABLE_COMPILE_CACHE;
+    } else {
+        // Genuinely cold: index-with-compile-cache.js self-enables the cache (defaulting to
+        // os.tmpdir()), so without this a "cold" run would silently warm up across iterations.
+        delete env.NODE_COMPILE_CACHE;
+        env.NODE_DISABLE_COMPILE_CACHE = "1";
+    }
     const res = spawnSync(process.execPath, ["--input-type=module", "-e", code], { env, encoding: "utf8" });
     if (res.status !== 0) {
         throw new Error(`import of ${absFile} failed:\n${res.stderr}`);
@@ -109,7 +119,28 @@ try {
     rmSync(cacheDir, { recursive: true, force: true });
 }
 
-// 3) Per-file self-time attribution — the "where in our code is it slow" answer. We run the import
+// 3) The npm "import"-condition entry (index-with-compile-cache.js): it enables Node's compile
+// cache itself before dynamic-importing index.js, so consumers get the warm-cache speedup by
+// default — no NODE_COMPILE_CACHE env needed. First run with an empty cache dir populates it
+// (and pays a small write cost); subsequent runs reuse the bytecode. We point NODE_COMPILE_CACHE
+// at a scratch dir under .tmp/ so the benchmark controls (and cleans up) where the entry's
+// self-enabled cache lands, instead of polluting the real os.tmpdir().
+console.log(`\n## index-with-compile-cache.js (npm import entry) — self-enabled compile cache\n`);
+const bootstrapAbs = path.join(distNode, "index-with-compile-cache.js");
+const bootstrapCacheDir = mkdtempSync(path.join(benchTmpBase, "pkc-bench-bootstrap-cc-"));
+try {
+    const first = measureOnce(bootstrapAbs, bootstrapCacheDir);
+    const warm = measureMedian(bootstrapAbs, bootstrapCacheDir);
+    console.log(`| Run | Time |`);
+    console.log(`| --- | --- |`);
+    console.log(`| first (self-populates bytecode cache) | ${first.toFixed(0)}ms |`);
+    console.log(`| warm (bytecode reused) | ${warm.toFixed(0)}ms |`);
+    console.log(`\nThis is the default experience for Node ESM consumers importing the package.`);
+} finally {
+    rmSync(bootstrapCacheDir, { recursive: true, force: true });
+}
+
+// 4) Per-file self-time attribution — the "where in our code is it slow" answer. We run the import
 // once under V8's CPU sampling profiler (--cpu-prof), then aggregate self-time per source file from
 // the .cpuprofile. Self-time per profiler node = sum of the sample timeDeltas attributed to that
 // node id; we map each node to its callFrame.url (the source file) and sum across all nodes sharing

--- a/src/index-with-compile-cache.ts
+++ b/src/index-with-compile-cache.ts
@@ -1,0 +1,31 @@
+// Thin bootstrap entry for Node ESM consumers (the `"."` -> `import` condition in
+// package.json). Part of issue #120: it enables Node's on-disk V8 compile cache and ONLY
+// THEN dynamic-imports the real entry, so the whole module graph compiles with the cache
+// active and runs after the first import reuse the cached bytecode (recovering the
+// parse/compile ~29% of import time).
+//
+// Why a separate file instead of calling enableCompileCache() in index.ts: Node's ESM
+// loader compiles the ENTIRE static import graph before any module body executes, and the
+// compile cache only covers modules compiled after the call — so from inside index.ts it
+// would always be too late. The dynamic import() below is what delays the graph's
+// compilation until the cache is on.
+//
+// Why the `require` condition keeps pointing at plain index.js: this file uses top-level
+// await, and require(esm) throws ERR_REQUIRE_ASYNC_MODULE on graphs containing TLA. CJS
+// consumers simply keep the previous (uncached) behavior.
+import { enableNodeCompileCache } from "./runtime/node/compile-cache.js";
+
+enableNodeCompileCache();
+
+const index = await import("./index.js");
+
+export default index.default;
+export const setNativeFunctions = index.setNativeFunctions;
+export const nativeFunctions = index.nativeFunctions;
+export const getShortCid = index.getShortCid;
+export const getShortAddress = index.getShortAddress;
+export const challenges = index.challenges;
+
+// Keep the type-only surface identical to index.ts.
+export type { NameResolverInterface } from "./schema.js";
+export type { NameResolver } from "./types.js";

--- a/src/runtime/browser/compile-cache.ts
+++ b/src/runtime/browser/compile-cache.ts
@@ -1,0 +1,7 @@
+// Browser counterpart of runtime/node/compile-cache.ts — V8's on-disk compile cache is a
+// Node-only feature, so this is a no-op. It exists so the browser build's
+// `/runtime/node/` -> `/runtime/browser/` import rewrite doesn't dangle.
+
+export function enableNodeCompileCache(): void {
+    // no-op in browsers
+}

--- a/src/runtime/node/compile-cache.ts
+++ b/src/runtime/node/compile-cache.ts
@@ -1,0 +1,28 @@
+// Enables Node's on-disk V8 compile cache (issue #120). Caching the compiled bytecode
+// recovers the parse/compile portion of import time (~29% of the post-lazy-load cost) on
+// every run after the first.
+//
+// V8 only caches modules compiled AFTER the cache is enabled — and Node's ESM loader
+// compiles the entire static import graph before any module body runs. So calling this
+// from inside index.ts would never cover the package's own graph; it must be called from
+// a thin bootstrap entry (index-with-compile-cache.ts) BEFORE the real entry is
+// dynamic-imported.
+//
+// Designed to be a quiet optimization, never fatal:
+// - no-op on Node < 22.8 (enableCompileCache doesn't exist there; engines allows >= 22)
+// - cache dir is Node's default (os.tmpdir()/node-compile-cache), overridable with the
+//   NODE_COMPILE_CACHE env var; consumers can opt out with NODE_DISABLE_COMPILE_CACHE=1
+// - enableCompileCache itself reports failures via its return value instead of throwing,
+//   but we still guard with try/catch in case of exotic runtimes
+
+// Default import, not a named import: named imports of builtins are validated at link
+// time, so `import { enableCompileCache }` would throw on Node 22.0-22.7.
+import nodeModule from "node:module";
+
+export function enableNodeCompileCache(): void {
+    try {
+        if (typeof nodeModule.enableCompileCache === "function") nodeModule.enableCompileCache();
+    } catch {
+        // compile cache is an optimization only — never let it break startup
+    }
+}


### PR DESCRIPTION
Part of #120. Stacked on #124 (lazy-load helia + LocalCommunity) — only the last commit is new; review that one.

## What

- New thin bootstrap entry `src/index-with-compile-cache.ts`: enables Node's on-disk V8 compile cache (`module.enableCompileCache()`), then dynamic-imports the real `index.js` and re-exports its surface. The `"."` → `import` export condition in `package.json` now points at it.
- `src/runtime/node/compile-cache.ts` holds the guarded call (no-op on Node 22.0–22.7 via a default import + runtime check, never throws, env-overridable); `src/runtime/browser/compile-cache.ts` is the no-op counterpart for the browser string-replace build.
- `scripts/bench-import-time.js`: new section measuring the bootstrap entry (first run vs warm, cache redirected into `.tmp/`), a bootstrap row in the per-layer cold table, and cold runs now set `NODE_DISABLE_COMPILE_CACHE=1` so the self-enabling entry can't silently warm them.
- Tracking doc updated (checklist tick + benchmark history row).

## Why a bootstrap instead of calling it in index.ts

The compile cache only covers modules compiled **after** the call, and Node's ESM loader compiles the entire static graph before any module body runs — from inside `index.ts` it would always be too late. The dynamic `import()` delays the graph's compilation until the cache is on.

The `require` condition keeps pointing at plain `index.js`: `require(esm)` throws `ERR_REQUIRE_ASYNC_MODULE` on graphs containing top-level await, so CJS consumers keep the previous (uncached) behavior — no regression.

## Numbers (reference host, Node v22.22.0, median of 5 fresh processes)

| Measurement | Before | After |
| --- | --- | --- |
| index.js cold | ~268ms | ~272ms (unchanged) |
| bootstrap entry, cache disabled | n/a | ~272ms (+0ms wrapper overhead) |
| bootstrap entry, first run (populates cache) | n/a | ~304ms (one-time) |
| **bootstrap entry, warm (default ESM experience)** | n/a | **~208ms (~24% faster, zero config)** |

Cache dir is Node's default (`os.tmpdir()/node-compile-cache`), overridable with `NODE_COMPILE_CACHE`; opt out entirely with `NODE_DISABLE_COMPILE_CACHE=1`.

## Verification

- `npm run build` passes (incl. `verify-browser-imports`).
- Smoke-tested both entries: ESM self-reference import of `@pkcprotocol/pkc-js` (default export callable + all named exports present) and CJS `require("@pkcprotocol/pkc-js")`.
- Blast radius: only `src/rpc/start.js` imports the package by name (ESM, already uses TLA itself); all test files import `dist/node/index.js` by relative path and bypass the exports map.