### PR TITLE
test: fix flaky Pkc() construction-timing test on Firefox

### DIFF
--- a/test/node-and-browser/pkc/pkc-construction-timing.pkc.test.ts
+++ b/test/node-and-browser/pkc/pkc-construction-timing.pkc.test.ts
@@ -3,13 +3,19 @@ import { getAvailablePKCConfigsToTestAgainst } from "../../../dist/node/test/tes
 
 const configs = getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true });
 
-const MAX_MS = 100;
-const TIMED_RUNS = 3;
+const DEFAULT_MAX_MS = 100;
+// remote-libp2pjs constructs a Helia/libp2p node (keypair generation, transports), measured at 40-110ms
+// on Firefox CI runners, so it gets a higher budget than the thin kubo-rpc/gateway clients
+const MAX_MS_PER_CONFIG: Partial<Record<string, number>> = { "remote-libp2pjs": 200 };
+const TIMED_RUNS = 5;
 
-describe.concurrent("Pkc() construction time", () => {
+// not describe.concurrent: timing runs must not overlap with the other configs constructing/destroying
+// instances on the same runner, which inflates timings on slow CI machines
+describe("Pkc() construction time", () => {
     configs.forEach((config) => {
+        const maxMs = MAX_MS_PER_CONFIG[config.testConfigCode] ?? DEFAULT_MAX_MS;
         describe(`${config.name} (${config.testConfigCode})`, () => {
-            it(`constructs in under ${MAX_MS}ms (median of ${TIMED_RUNS} runs)`, async () => {
+            it(`constructs in under ${maxMs}ms (min of ${TIMED_RUNS} runs)`, async () => {
                 const warmup = await config.pkcInstancePromise();
                 await warmup.destroy();
 
@@ -21,10 +27,12 @@ describe.concurrent("Pkc() construction time", () => {
                     await pkc.destroy();
                 }
 
-                const sorted = [...timings].sort((a, b) => a - b);
-                const median = sorted[Math.floor(sorted.length / 2)];
-                console.log({ config: config.testConfigCode, timings, median });
-                expect(median).to.be.lessThan(MAX_MS);
+                // assert on the minimum: noise (CI contention, GC) only ever adds time, so min-of-N is the
+                // lowest-variance estimator of the true construction cost. A real eager-load regression adds
+                // hundreds of ms to every run, which the minimum still catches
+                const min = Math.min(...timings);
+                console.log({ config: config.testConfigCode, timings, min });
+                expect(min).to.be.lessThan(maxMs);
             }, 30_000);
         });
     });


### PR DESCRIPTION
Closes #131

## Problem

The Firefox CI jobs intermittently fail on the construction-timing test for the `remote-libp2pjs` config, e.g. run 27324689374 failed both `firefox-remote-kubo-rpc` and `firefox-remote-libp2pjs` with:

```
AssertionError: expected 105 to be below 100
```

## Root cause

Not a perf regression:

- `remote-libp2pjs` constructs a real Helia/libp2p node per run (keypair generation, transports), measured at 40-110ms on Firefox CI runners, vs 10-34ms for the thin kubo-rpc/gateway clients. The flat 100ms budget had no headroom.
- `describe.concurrent` made all configs time themselves while the other configs' instances constructed/destroyed on the same runner, inflating timings.
- Median-of-3 is noise sensitive: observed Firefox libp2pjs samples were [109, 84, 105] and [103, 101, 40]; the minimum (84, 40) would have passed both times.

## Fix

Single test-file change that keeps the eager-load regression guard from #126 intact (a real regression adds hundreds of ms to every run, which the test still catches):

1. Drop `describe.concurrent` so the per-config timing tests run sequentially.
2. Increase timed runs from 3 to 5.
3. Assert on the minimum of the runs instead of the median: noise only ever adds time, so min-of-N is the lowest-variance estimator of true construction cost.
4. Give `remote-libp2pjs` its own 200ms budget; other configs stay at 100ms.

## Verification

- `npx tsc --project test/tsconfig.json --noEmit` passes.
- Ran locally under the node config (`remote-kubo-rpc,remote-pkc-rpc`): all 5 configs pass with min timings of 1.2-10.2ms, far under budget.
- The test logs the full timings array plus the min per config, so headroom stays visible in CI logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced PKC construction timing validation with improved performance benchmarking and more granular configuration-specific timing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->