### PR TITLE
test: run start.community suites sequentially to reduce Kubo MFS contention

### DIFF
--- a/test/node/community/start.community.test.ts
+++ b/test/node/community/start.community.test.ts
@@ -23,7 +23,11 @@ import type { RpcLocalCommunity } from "../../../dist/node/community/rpc-local-c
 import type { PKCError } from "../../../dist/node/pkc-error.js";
 import type { Comment } from "../../../dist/node/publications/comment/comment.js";
 
-describe(`community.start`, async () => {
+// Suites run sequentially: each one starts local communities whose sync loops write postUpdates to
+// Kubo MFS, and teardowns rm/mv community MFS dirs. Running them concurrently (on top of vitest file
+// parallelism) wedges Kubo's MFS on slow Windows CI runners (ipfs/kubo#10842) and times out the
+// whole node-local job.
+describe.sequential(`community.start`, async () => {
     let pkc: PKCType;
     let community: LocalCommunity | RpcLocalCommunity;
     beforeAll(async () => {
@@ -146,7 +150,7 @@ describe(`community.start`, async () => {
     });
 });
 
-describe(`community.started`, async () => {
+describe.sequential(`community.started`, async () => {
     let pkc: PKCType;
     let community: LocalCommunity | RpcLocalCommunity;
     beforeAll(async () => {
@@ -194,7 +198,7 @@ describe(`community.started`, async () => {
         expect(anotherCommunity.started).to.be.false;
     });
 });
-describe(`Start lock`, async () => {
+describe.sequential(`Start lock`, async () => {
     let pkc: PKCType;
     let dataPath: string;
     beforeAll(async () => {
@@ -447,7 +451,7 @@ describe(`Start lock`, async () => {
     });
 });
 
-describe(`Publish loop resiliency`, async () => {
+describe.sequential(`Publish loop resiliency`, async () => {
     let pkc: PKCType;
     let community: LocalCommunity | RpcLocalCommunity;
     let remotePKC: PKCType;


### PR DESCRIPTION
## Context

CI run 27325912632 (\`test-pkc-js-node-local (windows-latest)\`) timed out at the 28-min step cap with zero test failures. Tracing the Kubo daemon golog (\`incoming API request\` lines, grep -a due to NUL bytes) showed the port-15001 daemon's MFS wedging at ~05:42:20 — the documented ipfs/kubo#10842 deadlock, still present on Kubo 0.42.0.

The wedge-onset window interleaved mutating MFS ops from three parallel test files sharing the daemon:

- \`incoming.community.address.rejection.community.test.ts\` — teardown \`files/rm -r\` (already \`.sequential\`)
- \`pendingapproval.modqueue.community.test.ts\` — postUpdates \`files/write …flush=true\` storm + teardown rm (already \`.sequential\`)
- \`start.community.test.ts\` — \`files/mv\` rename to \`sub-does-not-exist-*.bso\` + \`files/rm\` (Publish loop resiliency) — **not sequential**

After the wedge, every \`files/*\`/\`repo gc\` request was received but never answered (\`ERR_TIMED_OUT_RM_MFS_FILE\`, \`UND_ERR_HEADERS_TIMEOUT\`), and the auto-nuke recovery rm in \`ipns-publishing.ts\` hung too.

## Change

Set the 4 top-level describes in \`test/node/community/start.community.test.ts\` to \`describe.sequential\`, matching the precedent in \`approved.modqueue.community.test.ts\` / \`pendingapproval.modqueue.community.test.ts\`, with a comment referencing kubo#10842.

Note: vitest already runs sibling describes sequentially within a file by default; the 05:42 collision was cross-file (\`--fileParallelism\`, maxForks 3 on Windows), so this is a consistency/mitigation measure, not a guaranteed fix for the wedge.

## Verification

- \`npx tsc --project test/tsconfig.json --noEmit\` passes
- \`node test/run-test-config.js --pkc-config "local-kubo-rpc,remote-pkc-rpc" test/node/community/start.community.test.ts\`: 19 passed, 11 skipped, 1 todo, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution stability on continuous integration infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->