### PR TITLE
fix(community): skip purged comments in postUpdates MFS sync

### DIFF
--- a/src/runtime/node/community/db-handler.ts
+++ b/src/runtime/node/community/db-handler.ts
@@ -2143,6 +2143,10 @@ export class DbHandler {
         return this._parseCommentsTableRow(row);
     }
 
+    commentExistsInDb(cid: string): boolean {
+        return this._db.prepare(`SELECT 1 FROM ${TABLES.COMMENTS} WHERE cid = ? LIMIT 1`).get(cid) !== undefined;
+    }
+
     queryPseudonymityAliasByCommentCid(commentCid: string): PseudonymityAliasRow | undefined {
         const row = this._db
             .prepare(

--- a/src/runtime/node/community/local-community/comment-updates.ts
+++ b/src/runtime/node/community/local-community/comment-updates.ts
@@ -256,13 +256,24 @@ export async function syncPostUpdatesWithIpfs(
     if (commentUpdatesWithLocalPath.length === 0)
         throw Error("No comment updates of posts to publish to postUpdates directory. This is a critical bug");
 
+    // Drop post updates whose comment was purged after this sync cycle captured it. A concurrent
+    // purge (storeCommentModeration) deletes the comment from the DB and removes its postUpdates MFS
+    // entry; writing the captured update back here would resurrect the purged post in postUpdates, and
+    // since it is gone from the DB nothing would ever clean it up again. See pkc-js issue #142.
+    const liveCommentUpdates = commentUpdatesWithLocalPath.filter((row) =>
+        community._dbHandler.commentExistsInDb(row.newCommentUpdate.cid)
+    );
+    const purgedMidSyncCount = commentUpdatesWithLocalPath.length - liveCommentUpdates.length;
+    if (purgedMidSyncCount > 0)
+        log(`Skipping ${purgedMidSyncCount} post CommentUpdate(s) for community ${community.address} whose comment was purged mid-sync`);
+
     const kuboRpc = community._clientsManager.getDefaultKuboRpcClient();
     const removedMfsPaths: string[] = await rmUnneededMfsPaths(community);
     let postUpdatesDirectoryCid: Awaited<ReturnType<typeof kuboRpc._client.files.flush>> | undefined;
 
     const BATCH_SIZE = 50;
-    for (let index = 0; index < commentUpdatesWithLocalPath.length; index += BATCH_SIZE) {
-        const batch = commentUpdatesWithLocalPath.slice(index, index + BATCH_SIZE);
+    for (let index = 0; index < liveCommentUpdates.length; index += BATCH_SIZE) {
+        const batch = liveCommentUpdates.slice(index, index + BATCH_SIZE);
 
         await Promise.all(
             batch.map(async (row) => {
@@ -297,7 +308,7 @@ export async function syncPostUpdatesWithIpfs(
         "Community",
         community.address,
         "Synced",
-        commentUpdatesWithLocalPath.length,
+        liveCommentUpdates.length,
         "post CommentUpdates",
         "with MFS postUpdates directory",
         postUpdatesDirectoryCidString

--- a/test/node/community/purge-postupdates-sync-race.test.ts
+++ b/test/node/community/purge-postupdates-sync-race.test.ts
@@ -1,0 +1,102 @@
+import { mockPKC, publishRandomPost, createSubWithNoChallenge, resolveWhenConditionIsTrue } from "../../../dist/node/test/test-util.js";
+import { itSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { describe, beforeAll, afterAll, expect } from "vitest";
+import {
+    calculateNewCommentUpdate,
+    syncPostUpdatesWithIpfs
+} from "../../../dist/node/runtime/node/community/local-community/comment-updates.js";
+import {
+    addAllCidsUnderPurgedCommentToBeRemoved,
+    rmUnneededMfsPaths
+} from "../../../dist/node/runtime/node/community/local-community/cleanup.js";
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
+
+// Reproduces the TOCTOU race between comment purge (storeCommentModeration) and the postUpdates
+// MFS sync (syncPostUpdatesWithIpfs). A sync cycle can capture a post's CommentUpdate while the
+// post is still live, then a concurrent purge deletes the post from the DB and removes its
+// postUpdates MFS entry — and finally the in-flight sync writes the stale captured update back to
+// MFS, resurrecting the purged post permanently (it is gone from the DB, so nothing cleans it up).
+// See pkc-js issue #142.
+describe("Purge vs postUpdates sync race", () => {
+    let pkc: PKCType;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+    });
+
+    afterAll(async () => {
+        await pkc.destroy();
+    });
+
+    const mfsPathExists = async (community: LocalCommunity, path: string): Promise<boolean> => {
+        const kuboClient = community._clientsManager.getDefaultKuboRpcClient()._client;
+        try {
+            await kuboClient.files.stat(path);
+            return true;
+        } catch (e) {
+            expect((e as Error).message).to.equal("file does not exist");
+            return false;
+        }
+    };
+
+    // RPC skipped: the test reaches into LocalCommunity internals (_dbHandler, _clientsManager) and
+    // calls the low-level postUpdates sync/purge helpers directly. These only exist on the Node
+    // LocalCommunity, not on the RPC community wrapper.
+    itSkipIfRpc("an in-flight postUpdates sync that captured a post before it was purged must not resurrect it in MFS", async () => {
+        const community = (await createSubWithNoChallenge({}, pkc)) as LocalCommunity;
+        await community.start();
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => typeof community.updatedAt === "number"
+        });
+
+        const post = await publishRandomPost({ communityAddress: community.address, pkc });
+        const postCid = post.cid;
+        expect(postCid).to.be.a("string");
+
+        // Wait until the community's sync loop has written the post's CommentUpdate to the
+        // postUpdates MFS tree (mirrors the production state at purge time).
+        let mfsPath: string | undefined;
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => {
+                const bucket = community.postUpdates && Object.keys(community.postUpdates)[0];
+                if (!bucket) return false;
+                const candidate = `/${community.address}/postUpdates/${bucket}/${postCid}/update`;
+                const exists = await mfsPathExists(community, candidate);
+                if (exists) mfsPath = candidate;
+                return exists;
+            }
+        });
+        expect(mfsPath).to.be.a("string");
+
+        // 1. Simulate a sync cycle that captured the post's CommentUpdate while it was still live
+        //    (updateCommentsThatNeedToBeUpdated → calculateNewCommentUpdate).
+        const commentRow = community._dbHandler.queryComment(postCid!);
+        expect(commentRow, "post should still be in the DB before purge").to.exist;
+        const capturedRow = await calculateNewCommentUpdate(community, commentRow!);
+        expect(capturedRow.localMfsPath, "captured row should target the post's postUpdates MFS path").to.equal(mfsPath);
+
+        // 2. A purge moderation arrives and runs to completion (what storeCommentModeration does
+        //    on commentModeration.purged=true): delete the post from the DB, queue its MFS path,
+        //    and remove it from the postUpdates MFS tree.
+        const purgedRows = community._dbHandler.purgeComment(postCid!);
+        for (const purgedRow of purgedRows) await addAllCidsUnderPurgedCommentToBeRemoved(community, purgedRow);
+        await rmUnneededMfsPaths(community);
+
+        // The purge must have removed the post's postUpdates MFS entry.
+        expect(await mfsPathExists(community, mfsPath!), "purge should have removed the postUpdates MFS entry").to.equal(false);
+
+        // 3. The in-flight sync from step 1 now finishes and writes the captured (pre-purge) row.
+        await syncPostUpdatesWithIpfs(community, [capturedRow]);
+
+        // 4. The purged post must NOT be resurrected in the postUpdates MFS tree.
+        expect(
+            await mfsPathExists(community, mfsPath!),
+            `purged post ${postCid} was resurrected in postUpdates MFS at ${mfsPath}`
+        ).to.equal(false);
+
+        await community.delete();
+    });
+});


### PR DESCRIPTION
## Problem

A TOCTOU race between comment purge and the postUpdates MFS sync can leave a purged post's `CommentUpdate` permanently in a community's `postUpdates` MFS tree.

`syncIpnsWithDb` (sync loop) and `storeCommentModeration` (pubsub challenge handler) run concurrently with no mutual exclusion:

1. A sync cycle calculates a post's `CommentUpdate` (post still in DB), producing a row with `localMfsPath = /<addr>/postUpdates/<bucket>/<postCid>/update`.
2. A purge moderation arrives: the post is deleted from the DB, its MFS path is queued and removed (`rmUnneededMfsPaths`, which also drains `_mfsPathsToRemove`).
3. The in-flight sync from step 1 reaches `syncPostUpdatesWithIpfs` and writes the captured (pre-purge) row back to MFS.

Because the post is now gone from the DB it is never recalculated or re-purged, and nothing scans the MFS tree against the DB (`calculateNewPostUpdates` only reads bucket dirs), so the resurrected entry persists indefinitely.

This surfaced as a flaky failure in the `remote-libp2pjs` CI config (the slower client transport widens the timing window so the purge lands mid-sync); the Kubo-RPC / gateway configs run the same community-side code and pass:

```
AssertionError: MFS path /<community>/postUpdates/86400/<postCid>/update still exists after 30s - purge cleanup did not complete
  at test/node-and-browser/publications/comment-moderation/purged.test.ts:292
```

## Fix

`syncPostUpdatesWithIpfs` now filters out post-update rows whose comment no longer exists in the DB (new lightweight `DbHandler.commentExistsInDb(cid)`) before writing to MFS. A row captured before a mid-cycle purge is skipped instead of resurrecting the purged post. When every captured post was purged, it writes nothing instead of throwing.

## Test

`test/node/community/purge-postupdates-sync-race.test.ts` drives the exact racy ordering (capture row -> purge -> stale sync write) and asserts the purged post is not resurrected in MFS. It is red against unmodified `src/` and green with the fix. The happy-path `local.publishing.community.test.ts` (posting -> postUpdates sync) still passes.

Fixes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition that could cause deleted comments to be incorrectly restored during synchronization operations.

* **Tests**
  * Added integration tests for comment purge and synchronization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->