### PR TITLE
fix: eliminate abort-listener and pending-map memory leaks (#144–#148)

### DIFF
--- a/src/clients/base-client-manager.ts
+++ b/src/clients/base-client-manager.ts
@@ -2,7 +2,6 @@ import { PKC } from "../pkc/pkc.js";
 import assert from "assert";
 import {
     calculateIpfsCidV0,
-    createAbortError,
     extractNetworkErrorDetails,
     hideClassPrivateProps,
     isAbortError,
@@ -10,6 +9,7 @@ import {
     isIpfsPath,
     isIpnsPath,
     isStringDomain,
+    raceAgainstAbort,
     throwIfAbortSignalAborted
 } from "../util.js";
 import { sha256 } from "js-sha256";
@@ -879,33 +879,10 @@ export class BaseClientsManager {
             this.preResolveNameResolver({ address: name, resolveType, resolverKey: nameResolver.key });
             try {
                 throwIfAbortSignalAborted(abortSignal);
-                const resolvePromise = nameResolver.resolve({ name, abortSignal });
-                // Race resolve() against abort signal so resolvers that ignore the signal still get interrupted.
-                // The abort listener MUST be detached once the race settles, regardless of who wins — `{ once: true }`
-                // only removes it when `abort` actually fires, so in the common case (resolve wins) it would otherwise
-                // leak on the long-lived stop signal, one listener per successful resolution (see issue #144). Mirror
-                // the `onParentAbort` cleanup pattern used in fetchFromMultipleGateways.
-                let result: Awaited<typeof resolvePromise>;
-                if (abortSignal) {
-                    let onAbort: (() => void) | undefined;
-                    try {
-                        result = await Promise.race([
-                            resolvePromise,
-                            new Promise<never>((_, reject) => {
-                                if (abortSignal.aborted) {
-                                    reject(createAbortError());
-                                    return;
-                                }
-                                onAbort = () => reject(createAbortError());
-                                abortSignal.addEventListener("abort", onAbort, { once: true });
-                            })
-                        ]);
-                    } finally {
-                        if (onAbort) abortSignal.removeEventListener("abort", onAbort);
-                    }
-                } else {
-                    result = await resolvePromise;
-                }
+                // Race resolve() against the abort signal so resolvers that ignore the signal still get
+                // interrupted. raceAgainstAbort detaches its abort listener once the race settles regardless
+                // of who wins, so it never leaks on the long-lived stop signal (see issue #144).
+                const result = await raceAgainstAbort(nameResolver.resolve({ name, abortSignal }), abortSignal);
                 throwIfAbortSignalAborted(abortSignal);
                 value = result?.publicKey;
             } catch (e) {

--- a/src/clients/base-client-manager.ts
+++ b/src/clients/base-client-manager.ts
@@ -880,16 +880,32 @@ export class BaseClientsManager {
             try {
                 throwIfAbortSignalAborted(abortSignal);
                 const resolvePromise = nameResolver.resolve({ name, abortSignal });
-                // Race resolve() against abort signal so resolvers that ignore the signal still get interrupted
-                const result = abortSignal
-                    ? await Promise.race([
-                          resolvePromise,
-                          new Promise<never>((_, reject) => {
-                              if (abortSignal.aborted) reject(createAbortError());
-                              else abortSignal.addEventListener("abort", () => reject(createAbortError()), { once: true });
-                          })
-                      ])
-                    : await resolvePromise;
+                // Race resolve() against abort signal so resolvers that ignore the signal still get interrupted.
+                // The abort listener MUST be detached once the race settles, regardless of who wins — `{ once: true }`
+                // only removes it when `abort` actually fires, so in the common case (resolve wins) it would otherwise
+                // leak on the long-lived stop signal, one listener per successful resolution (see issue #144). Mirror
+                // the `onParentAbort` cleanup pattern used in fetchFromMultipleGateways.
+                let result: Awaited<typeof resolvePromise>;
+                if (abortSignal) {
+                    let onAbort: (() => void) | undefined;
+                    try {
+                        result = await Promise.race([
+                            resolvePromise,
+                            new Promise<never>((_, reject) => {
+                                if (abortSignal.aborted) {
+                                    reject(createAbortError());
+                                    return;
+                                }
+                                onAbort = () => reject(createAbortError());
+                                abortSignal.addEventListener("abort", onAbort, { once: true });
+                            })
+                        ]);
+                    } finally {
+                        if (onAbort) abortSignal.removeEventListener("abort", onAbort);
+                    }
+                } else {
+                    result = await resolvePromise;
+                }
                 throwIfAbortSignalAborted(abortSignal);
                 value = result?.publicKey;
             } catch (e) {

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -27,6 +27,7 @@ import {
     isIpnsPath,
     isStringDomain,
     pubsubTopicToDhtKey,
+    sleepUntilTimeoutOrAbort,
     throwIfAbortSignalAborted,
     timestamp
 } from "../util.js";
@@ -295,20 +296,9 @@ export class CommunityClientsManager extends PKCClientsManager {
             } catch (e) {
                 log.error(`Failed to update community ${this._community.address} for this iteration, will retry later`, e);
             } finally {
-                await new Promise<void>((resolve) => {
-                    const stopSignal = this._community._getStopAbortSignal();
-                    if (stopSignal?.aborted) return resolve();
-                    // Detach the abort listener on BOTH outcomes (timer elapsed or aborted). `{ once: true }`
-                    // alone only removes it when abort fires, so the normal timer-elapsed path would otherwise
-                    // leak one listener per iteration on the long-lived stop signal (see issue #145).
-                    const onAbortOrTimeout = () => {
-                        clearTimeout(timer);
-                        stopSignal?.removeEventListener("abort", onAbortOrTimeout);
-                        resolve();
-                    };
-                    const timer = setTimeout(onAbortOrTimeout, updateInterval);
-                    stopSignal?.addEventListener("abort", onAbortOrTimeout, { once: true });
-                });
+                // Re-read the stop signal each iteration; sleepUntilTimeoutOrAbort detaches its abort
+                // listener on both outcomes so it never leaks on the long-lived signal (see issue #145).
+                await sleepUntilTimeoutOrAbort(updateInterval, this._community._getStopAbortSignal());
             }
         }
 

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -298,15 +298,16 @@ export class CommunityClientsManager extends PKCClientsManager {
                 await new Promise<void>((resolve) => {
                     const stopSignal = this._community._getStopAbortSignal();
                     if (stopSignal?.aborted) return resolve();
-                    const timer = setTimeout(resolve, updateInterval);
-                    stopSignal?.addEventListener(
-                        "abort",
-                        () => {
-                            clearTimeout(timer);
-                            resolve();
-                        },
-                        { once: true }
-                    );
+                    // Detach the abort listener on BOTH outcomes (timer elapsed or aborted). `{ once: true }`
+                    // alone only removes it when abort fires, so the normal timer-elapsed path would otherwise
+                    // leak one listener per iteration on the long-lived stop signal (see issue #145).
+                    const onAbortOrTimeout = () => {
+                        clearTimeout(timer);
+                        stopSignal?.removeEventListener("abort", onAbortOrTimeout);
+                        resolve();
+                    };
+                    const timer = setTimeout(onAbortOrTimeout, updateInterval);
+                    stopSignal?.addEventListener("abort", onAbortOrTimeout, { once: true });
                 });
             }
         }

--- a/src/publications/comment/comment.ts
+++ b/src/publications/comment/comment.ts
@@ -709,7 +709,12 @@ export class Comment
     private _scheduleParallelCommunityConnect(log: Logger) {
         if (!this.communityName && !this.communityPublicKey) return;
         const stopSignal = this._getStopAbortSignal();
+        // Detach onAbort when the timer fires normally too. `{ once: true }` only removes it when abort
+        // fires, so without this it would leak one listener per call on the long-lived comment stop
+        // signal (see issue #147).
+        const onAbort = () => clearTimeout(timer);
         const timer = setTimeout(async () => {
+            stopSignal?.removeEventListener("abort", onAbort);
             if (this.raw.comment) return;
             if (this._isStopAbortRequested() || this._pkc.destroyed) return;
             log("Starting parallel pkc.getCommunity for", this.cid, "so bitswap can fetch the comment block from community peers");
@@ -721,7 +726,7 @@ export class Comment
         }, 5_000);
         if (stopSignal) {
             if (stopSignal.aborted) clearTimeout(timer);
-            else stopSignal.addEventListener("abort", () => clearTimeout(timer), { once: true });
+            else stopSignal.addEventListener("abort", onAbort, { once: true });
         }
     }
 

--- a/src/publications/comment/comment.ts
+++ b/src/publications/comment/comment.ts
@@ -5,7 +5,8 @@ import {
     hideClassPrivateProps,
     isAbortError,
     retryKuboIpfsAdd,
-    shortifyCid
+    shortifyCid,
+    sleepUntilTimeoutOrAbort
 } from "../../util.js";
 import Publication from "../publication.js";
 import { getCommunityAddressFromRecord, getCommunityPublicKeyFromWire, getCommunityNameFromWire } from "../publication-community.js";
@@ -709,12 +710,10 @@ export class Comment
     private _scheduleParallelCommunityConnect(log: Logger) {
         if (!this.communityName && !this.communityPublicKey) return;
         const stopSignal = this._getStopAbortSignal();
-        // Detach onAbort when the timer fires normally too. `{ once: true }` only removes it when abort
-        // fires, so without this it would leak one listener per call on the long-lived comment stop
-        // signal (see issue #147).
-        const onAbort = () => clearTimeout(timer);
-        const timer = setTimeout(async () => {
-            stopSignal?.removeEventListener("abort", onAbort);
+        // Fire-and-forget: wait 5s (or until stopped), then connect. sleepUntilTimeoutOrAbort detaches its
+        // abort listener on both outcomes so it never leaks on the long-lived stop signal (see issue #147).
+        void (async () => {
+            await sleepUntilTimeoutOrAbort(5_000, stopSignal);
             if (this.raw.comment) return;
             if (this._isStopAbortRequested() || this._pkc.destroyed) return;
             log("Starting parallel pkc.getCommunity for", this.cid, "so bitswap can fetch the comment block from community peers");
@@ -723,11 +722,7 @@ export class Comment
             } catch (err) {
                 if (!isAbortError(err as Error)) log.error("Parallel pkc.getCommunity failed for", this.cid, err);
             }
-        }, 5_000);
-        if (stopSignal) {
-            if (stopSignal.aborted) clearTimeout(timer);
-            else stopSignal.addEventListener("abort", onAbort, { once: true });
-        }
+        })();
     }
 
     async _attemptToFetchCommentIpfsIfNeeded(log: Logger) {

--- a/src/runtime/node/community/challenges/exclude/exclude.ts
+++ b/src/runtime/node/community/challenges/exclude/exclude.ts
@@ -170,6 +170,8 @@ const commentUpdateCache = new TinyCache();
 type CommentUpdateCacheType = { author: Pick<Comment["author"], "community"> };
 const commentUpdateCacheTime = 1000 * 60 * 60;
 const getCommentPending: Record<string, boolean> = {}; // cid -> boolean if it's loading or not
+// Test-only: lets the issue #148 regression test verify finished entries are pruned, not left behind.
+export const _getCommentPendingKeyCountForTesting = (): number => Object.keys(getCommentPending).length;
 const shouldExcludeChallengeCommentCids = async (
     communityChallenge: CommunityChallenge,
     challengeRequestMessage: DecryptedChallengeRequestMessageTypeWithCommunityAuthor,
@@ -262,7 +264,10 @@ const shouldExcludeChallengeCommentCids = async (
         } catch (e) {
             throw e;
         } finally {
-            getCommentPending[pendingKey] = false;
+            // Delete (not set to false) so finished entries are pruned — the `=== true` guard above
+            // treats a missing key the same as false, and leaving keys behind grows this module-level
+            // map unboundedly over the process lifetime (see issue #148).
+            delete getCommentPending[pendingKey];
         }
     };
 

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -3,7 +3,7 @@ import * as remeda from "remeda";
 import { LRUCache } from "lru-cache";
 import { PKCError } from "../../../../pkc-error.js";
 import env from "../../../../version.js";
-import { removeMfsFilesSafely } from "../../../../util.js";
+import { removeMfsFilesSafely, sleepUntilTimeoutOrAbort } from "../../../../util.js";
 import { moveCommunityDbToDeletedDirectory } from "../../util.js";
 import { getCommunityChallengeFromCommunityChallengeSettings } from "../challenges/index.js";
 import {
@@ -322,20 +322,9 @@ export async function updateLoop(community: LocalCommunity) {
             log.error("Error in update loop", e);
             community.emit("error", e as PKCError | Error);
         } finally {
-            await new Promise<void>((resolve) => {
-                const signal = community._updateLoopAbortController?.signal;
-                if (signal?.aborted) return resolve();
-                // Detach the abort listener on BOTH outcomes (timer elapsed or aborted). `{ once: true }`
-                // alone only removes it when abort fires, so the normal timer-elapsed path would otherwise
-                // leak one listener per iteration on the long-lived update-loop signal (see issue #146).
-                const onAbortOrTimeout = () => {
-                    clearTimeout(timer);
-                    signal?.removeEventListener("abort", onAbortOrTimeout);
-                    resolve();
-                };
-                const timer = setTimeout(onAbortOrTimeout, community._pkc.updateInterval);
-                signal?.addEventListener("abort", onAbortOrTimeout, { once: true });
-            });
+            // Re-read the update-loop signal each iteration; sleepUntilTimeoutOrAbort detaches its abort
+            // listener on both outcomes so it never leaks on the long-lived signal (see issue #146).
+            await sleepUntilTimeoutOrAbort(community._pkc.updateInterval, community._updateLoopAbortController?.signal);
         }
     }
 }

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -323,16 +323,18 @@ export async function updateLoop(community: LocalCommunity) {
             community.emit("error", e as PKCError | Error);
         } finally {
             await new Promise<void>((resolve) => {
-                if (community._updateLoopAbortController?.signal.aborted) return resolve();
-                const timer = setTimeout(resolve, community._pkc.updateInterval);
-                community._updateLoopAbortController?.signal.addEventListener(
-                    "abort",
-                    () => {
-                        clearTimeout(timer);
-                        resolve();
-                    },
-                    { once: true }
-                );
+                const signal = community._updateLoopAbortController?.signal;
+                if (signal?.aborted) return resolve();
+                // Detach the abort listener on BOTH outcomes (timer elapsed or aborted). `{ once: true }`
+                // alone only removes it when abort fires, so the normal timer-elapsed path would otherwise
+                // leak one listener per iteration on the long-lived update-loop signal (see issue #146).
+                const onAbortOrTimeout = () => {
+                    clearTimeout(timer);
+                    signal?.removeEventListener("abort", onAbortOrTimeout);
+                    resolve();
+                };
+                const timer = setTimeout(onAbortOrTimeout, community._pkc.updateInterval);
+                signal?.addEventListener("abort", onAbortOrTimeout, { once: true });
             });
         }
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -75,6 +75,49 @@ export function throwIfAbortSignalAborted(signal?: AbortSignal): void {
     throw createAbortError();
 }
 
+// Sleep for `ms`, resolving early if `signal` aborts. The abort listener is detached on BOTH
+// outcomes (timer elapsed or aborted), so it never leaks on a long-lived signal — `{ once: true }`
+// alone only removes it when abort fires, which leaks one listener per call on the normal
+// timer-elapsed path (see issues #145, #146). Used by the community update loops' inter-iteration
+// sleep and the comment parallel-connect timer.
+export function sleepUntilTimeoutOrAbort(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve) => {
+        if (signal?.aborted) return resolve();
+        const onAbortOrTimeout = () => {
+            clearTimeout(timer);
+            signal?.removeEventListener("abort", onAbortOrTimeout);
+            resolve();
+        };
+        const timer = setTimeout(onAbortOrTimeout, ms);
+        signal?.addEventListener("abort", onAbortOrTimeout, { once: true });
+    });
+}
+
+// Race `promise` against `signal` aborting, rejecting with an AbortError if the signal fires first.
+// The abort listener is detached once the race settles regardless of who wins, so it never leaks on
+// a long-lived signal — `{ once: true }` alone only removes it when abort fires, which leaks one
+// listener per call in the common case (the promise wins; see issue #144). Mirrors the onParentAbort
+// cleanup pattern in fetchFromMultipleGateways.
+export async function raceAgainstAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+    if (!signal) return promise;
+    let onAbort: (() => void) | undefined;
+    try {
+        return await Promise.race([
+            promise,
+            new Promise<never>((_, reject) => {
+                if (signal.aborted) {
+                    reject(createAbortError());
+                    return;
+                }
+                onAbort = () => reject(createAbortError());
+                signal.addEventListener("abort", onAbort, { once: true });
+            })
+        ]);
+    } finally {
+        if (onAbort) signal.removeEventListener("abort", onAbort);
+    }
+}
+
 export function replaceXWithY(obj: Record<string, any>, x: any, y: any): any {
     // obj is a JS object
     if (!remeda.isPlainObject(obj)) return obj;

--- a/test/node/clients/name-resolver-abort-listener-leak.test.ts
+++ b/test/node/clients/name-resolver-abort-listener-leak.test.ts
@@ -1,0 +1,76 @@
+import { getEventListeners } from "events";
+import { afterEach, expect, it } from "vitest";
+import { v4 as uuidv4 } from "uuid";
+import signers from "../../fixtures/signers.js";
+import { createMockNameResolver, mockPKCV2 } from "../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import type { PKC } from "../../../dist/node/pkc/pkc.js";
+
+// Reproduction for https://github.com/pkcprotocol/pkc-js/issues/144
+//
+// `_resolveViaNameResolvers` races the resolver against the abort signal by
+// attaching an `abort` listener with `{ once: true }`. `{ once: true }` only
+// detaches the listener when the abort event *fires*. In the common case the
+// resolver wins the race and `abort` never fires, so the listener stays bound
+// to the (long-lived) abort signal forever — one leak per successful
+// resolution. Over a remote-community update loop these pile up into the tens
+// of thousands and pin a CPU core (O(n^2) EventTarget churn), wedging the
+// daemon.
+//
+// We drive the exact same code path the update loop uses
+// (resolveCommunityNameIfNeeded on a single long-lived signal) and assert the
+// number of `abort` listeners on that signal does not grow with the number of
+// resolutions.
+
+// Custom resolvers + the local cache aren't controllable under a remote PKC RPC
+// server, so this assertion is only meaningful in-process.
+describeSkipIfRpc("issue #144: _resolveViaNameResolvers leaks an abort listener per resolution", () => {
+    let pkc: PKC;
+    afterEach(async () => {
+        if (pkc) await pkc.destroy();
+    });
+
+    it("does not accumulate `abort` listeners on the long-lived stop signal", async () => {
+        // Resolver always succeeds → the resolve promise wins the race, abort never fires.
+        const resolver = createMockNameResolver({
+            key: `leak-resolver-${uuidv4()}`,
+            provider: "mock://leak",
+            records: { "leaky.bso": signers[3].address }
+        });
+
+        pkc = await mockPKCV2({
+            stubStorage: true,
+            remotePKC: true,
+            mockResolve: false,
+            pkcOptions: {
+                // noData → LRU storage falls back to in-memory SQLite
+                noData: true,
+                nameResolvers: [resolver]
+            }
+        });
+
+        // A single long-lived signal, mirroring community._getStopAbortSignal().
+        const stopController = new AbortController();
+        const stopSignal = stopController.signal;
+
+        const RESOLUTIONS = 50;
+        for (let i = 0; i < RESOLUTIONS; i++) {
+            // cache: { maxAge: 0 } bypasses the persistent cache so every call reaches
+            // the resolver + the abort-race block (same as a cache miss in the loop).
+            const resolved = await pkc._clientsManager.resolveCommunityNameIfNeeded({
+                communityName: "leaky.bso",
+                abortSignal: stopSignal,
+                cache: { maxAge: 0 }
+            });
+            expect(resolved).to.equal(signers[3].address);
+        }
+
+        const leakedAbortListeners = getEventListeners(stopSignal, "abort").length;
+
+        // With the bug present this equals RESOLUTIONS (~50). After the fix it
+        // should stay at ~0 regardless of how many resolutions ran.
+        expect(leakedAbortListeners).to.be.lessThanOrEqual(2);
+
+        stopController.abort();
+    });
+});

--- a/test/node/comment/parallel-connect-abort-listener-leak.test.ts
+++ b/test/node/comment/parallel-connect-abort-listener-leak.test.ts
@@ -1,0 +1,72 @@
+import { getEventListeners } from "events";
+import { expect, it, vi } from "vitest";
+import { mockPKCV2 } from "../../../dist/node/test/test-util.js";
+
+// Reproduction for https://github.com/pkcprotocol/pkc-js/issues/147
+//
+// Comment._scheduleParallelCommunityConnect schedules a 5s timer and registers
+//   stopSignal.addEventListener("abort", () => clearTimeout(timer), { once: true })
+// to cancel that timer if the comment is stopped early. `{ once: true }` only
+// detaches the listener when abort FIRES. In the common case the 5s timer fires
+// normally, the callback runs, and the listener is never removed — so it leaks
+// on the long-lived comment stop signal, one per call. Same class as #144.
+//
+// The method is private and only touches a handful of `this` members, so we
+// pull it off a real Comment instance (importing the Comment class directly
+// trips a module-init cycle) and drive it with a minimal stub plus fake timers
+// (no 5s wait, no network). raw.comment is truthy so the timer callback
+// short-circuits before any getCommunity call.
+
+type SchedulerThis = {
+    communityName?: string;
+    communityPublicKey?: string;
+    cid?: string;
+    raw: { comment?: unknown };
+    _pkc: { destroyed: boolean; getCommunity: () => Promise<unknown> };
+    _getStopAbortSignal: () => AbortSignal | undefined;
+    _isStopAbortRequested: () => boolean;
+};
+
+it("issue #147: _scheduleParallelCommunityConnect does not leak an abort listener per call", async () => {
+    const pkc = await mockPKCV2({
+        stubStorage: true,
+        remotePKC: true,
+        mockResolve: false,
+        pkcOptions: { noData: true, kuboRpcClientsOptions: [], pubsubKuboRpcClientsOptions: [], httpRoutersOptions: [] }
+    });
+    const realComment = await pkc.createComment({ cid: "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG" });
+    const scheduleParallelCommunityConnect = (
+        realComment as unknown as { _scheduleParallelCommunityConnect: (this: SchedulerThis, log: unknown) => void }
+    )._scheduleParallelCommunityConnect;
+    await pkc.destroy();
+
+    vi.useFakeTimers();
+    try {
+        const stopController = new AbortController();
+        // Never invoked (raw.comment short-circuits the callback), but shaped like a Logger.
+        const log = Object.assign(() => {}, { error: () => {}, trace: () => {} });
+        const comment: SchedulerThis = {
+            communityName: "leaky.bso",
+            cid: "QmTestCidForParallelConnectLeak",
+            raw: { comment: { ok: true } }, // truthy → timer callback returns before any getCommunity
+            _pkc: { destroyed: false, getCommunity: async () => undefined },
+            _getStopAbortSignal: () => stopController.signal,
+            _isStopAbortRequested: () => stopController.signal.aborted
+        };
+
+        const CALLS = 5;
+        for (let i = 0; i < CALLS; i++) scheduleParallelCommunityConnect.call(comment, log);
+
+        // While the 5s timers are pending, one listener per call is attached (true for buggy and fixed code).
+        expect(getEventListeners(stopController.signal, "abort").length).to.equal(CALLS);
+
+        // Fire all the parallel-connect timers. The fix detaches each listener when its timer fires;
+        // the bug leaves them attached on the long-lived stop signal forever.
+        await vi.advanceTimersByTimeAsync(5_000);
+
+        const remaining = getEventListeners(stopController.signal, "abort").length;
+        expect(remaining).to.be.lessThanOrEqual(1);
+    } finally {
+        vi.useRealTimers();
+    }
+});

--- a/test/node/community/community-update-loop-abort-listener-leak.test.ts
+++ b/test/node/community/community-update-loop-abort-listener-leak.test.ts
@@ -1,0 +1,73 @@
+import { getEventListeners } from "events";
+import { afterEach, expect, it } from "vitest";
+import signers from "../../fixtures/signers.js";
+import { mockPKCV2 } from "../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import type { PKC } from "../../../dist/node/pkc/pkc.js";
+import type { RemoteCommunity } from "../../../dist/node/community/remote-community.js";
+
+// Reproduction for https://github.com/pkcprotocol/pkc-js/issues/145
+//
+// The remote-community update loop sleeps between iterations with:
+//   stopSignal.addEventListener("abort", () => { clearTimeout(timer); resolve() }, { once: true })
+// `{ once: true }` only detaches the listener when abort FIRES. The normal outcome
+// of the sleep is the timer firing (the interval elapses), so the listener is never
+// removed and one leaks onto the long-lived community stop signal per iteration
+// (~1/sec). This is the same class as issue #144.
+//
+// We drive startUpdatingLoop() directly with a no-op updateOnce so the loop spins
+// fast through the inter-iteration sleep, then assert the abort-listener count on
+// the stop signal does not grow with the number of iterations.
+
+// Custom resolvers/loops aren't controllable under a remote PKC RPC server.
+describeSkipIfRpc("issue #145: RemoteCommunity update loop leaks an abort listener per iteration", () => {
+    let pkc: PKC;
+    afterEach(async () => {
+        if (pkc) await pkc.destroy();
+    });
+
+    it("does not accumulate `abort` listeners on the stop signal across update iterations", async () => {
+        pkc = await mockPKCV2({
+            stubStorage: true,
+            remotePKC: true,
+            mockResolve: false,
+            pkcOptions: {
+                noData: true,
+                // No kubo/helia clients → startUpdatingLoop uses pkc.updateInterval (not the hardcoded 1000ms),
+                // so we can make the loop spin quickly.
+                updateInterval: 25,
+                kuboRpcClientsOptions: [],
+                pubsubKuboRpcClientsOptions: [],
+                httpRoutersOptions: []
+            }
+        });
+
+        const community = (await pkc.createCommunity({ address: signers[0].address })) as RemoteCommunity;
+
+        // Replace the (networked) update with a no-op so each iteration is just the inter-iteration sleep.
+        let iterations = 0;
+        community._clientsManager.updateOnce = async () => {
+            iterations++;
+        };
+
+        community._setState("updating");
+        const loopPromise = community._clientsManager.startUpdatingLoop();
+
+        const TARGET_ITERATIONS = 12;
+        const deadline = Date.now() + 10_000;
+        while (iterations < TARGET_ITERATIONS && Date.now() < deadline) await new Promise((r) => setTimeout(r, 10));
+
+        const stopSignal = community._getStopAbortSignal();
+        const leakedAbortListeners = stopSignal ? getEventListeners(stopSignal, "abort").length : 0;
+
+        // Stop the loop before asserting so a failure doesn't leave it spinning.
+        community._setState("stopped");
+        community._abortStopOperations("test finished");
+        await loopPromise;
+
+        expect(iterations).to.be.greaterThanOrEqual(TARGET_ITERATIONS);
+        // With the bug this grows ~1 per iteration (>= ~11). After the fix at most one
+        // listener is attached at any instant (the in-flight sleep), independent of iteration count.
+        expect(leakedAbortListeners).to.be.lessThanOrEqual(2);
+    });
+});

--- a/test/node/community/exclude-pending-map-growth.test.ts
+++ b/test/node/community/exclude-pending-map-growth.test.ts
@@ -1,0 +1,49 @@
+import { expect, it } from "vitest";
+import { v4 as uuidv4 } from "uuid";
+import {
+    shouldExcludeChallengeCommentCids,
+    _getCommentPendingKeyCountForTesting
+} from "../../../dist/node/runtime/node/community/challenges/exclude/exclude.js";
+import type { PKC } from "../../../dist/node/pkc/pkc.js";
+import type { CommunityChallenge } from "../../../dist/node/community/types.js";
+import type { DecryptedChallengeRequestMessageTypeWithCommunityAuthor } from "../../../dist/node/pubsub-messages/types.js";
+
+// Reproduction for https://github.com/pkcprotocol/pkc-js/issues/148
+//
+// The `exclude` challenge's module-level `getCommentPending` map is used as a
+// per-comment concurrency guard. When a comment finishes loading the entry is
+// set to `false` instead of being deleted, so the map gains one permanently
+// retained key per unique comment-CID/provider combination for the whole
+// process lifetime — an unbounded growth leak.
+//
+// We drive the real shouldExcludeChallengeCommentCids path with a pkc whose
+// getComment rejects (the pending-key cleanup happens in a `finally`, so it runs
+// regardless), then assert the pending-key count does not grow across the call.
+
+it("issue #148: exclude getCommentPending map does not retain finished entries", async () => {
+    const commentCids = [uuidv4(), uuidv4(), uuidv4()]; // distinct → distinct pending keys
+
+    const communityChallenge = {
+        exclude: [{ community: { addresses: ["friendly-community-addr"], maxCommentCids: 3 } }]
+    } as unknown as CommunityChallenge;
+
+    const challengeRequestMessage = {
+        comment: { author: { address: "author-addr" } },
+        challengeCommentCids: commentCids
+    } as unknown as DecryptedChallengeRequestMessageTypeWithCommunityAuthor;
+
+    const pkc = {
+        getComment: async () => {
+            throw new Error("mock getComment rejects so the loader fails fast (cleanup still runs in finally)");
+        },
+        parsedPKCOptions: { ipfsGatewayUrls: ["http://gw"], kuboRpcClientsOptions: [{ url: "http://kubo" }] }
+    } as unknown as PKC;
+
+    const before = _getCommentPendingKeyCountForTesting();
+    await shouldExcludeChallengeCommentCids(communityChallenge, challengeRequestMessage, pkc);
+    const after = _getCommentPendingKeyCountForTesting();
+
+    // With the bug, each of the 3 comments leaves a key behind (after === before + 3).
+    // After the fix the keys are deleted in the finally (after === before).
+    expect(after).to.equal(before);
+});

--- a/test/node/community/local-community-update-loop-abort-listener-leak.test.ts
+++ b/test/node/community/local-community-update-loop-abort-listener-leak.test.ts
@@ -1,0 +1,61 @@
+import { getEventListeners } from "events";
+import { expect, it } from "vitest";
+import { updateLoop } from "../../../dist/node/runtime/node/community/local-community/lifecycle.js";
+import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
+
+// Reproduction for https://github.com/pkcprotocol/pkc-js/issues/146
+//
+// The LocalCommunity update loop (lifecycle.ts `updateLoop`) sleeps between
+// iterations with:
+//   community._updateLoopAbortController.signal.addEventListener("abort", () => {...}, { once: true })
+// `{ once: true }` only detaches the listener when abort FIRES. The normal
+// outcome of the sleep is the timer elapsing, so the listener is never removed
+// and one leaks onto the long-lived update-loop signal per iteration. Same leak
+// class as issues #144 and #145.
+//
+// `updateLoop` is a module-level function that calls the module-level
+// `updateOnce(community)` by closure, so we drive it directly with a minimal
+// community driver. `updateOnce` throws immediately on this stub (no
+// initDbHandlerIfNeeded) and the loop's try/catch swallows it, so the loop
+// spins fast straight through the inter-iteration sleep. We then assert the
+// abort-listener count on the update-loop signal does not grow with iterations.
+
+it("issue #146: LocalCommunity update loop does not accumulate `abort` listeners per iteration", async () => {
+    const updateLoopAbortController = new AbortController();
+    let iterations = 0;
+
+    // updateLoop + the inter-iteration sleep only touch these members. The
+    // updateInterval getter doubles as a per-iteration counter (it is read once
+    // per sleep, and updateOnce throws before reaching any _pkc access).
+    const community = {
+        state: "updating" as string,
+        _stopHasBeenCalled: false,
+        _updateLoopAbortController: updateLoopAbortController,
+        _pkc: {
+            get updateInterval() {
+                iterations++;
+                return 20;
+            }
+        },
+        emit: () => true
+    };
+
+    const loopPromise = updateLoop(community as unknown as LocalCommunity);
+
+    const TARGET_ITERATIONS = 12;
+    const deadline = Date.now() + 10_000;
+    while (iterations < TARGET_ITERATIONS && Date.now() < deadline) await new Promise((r) => setTimeout(r, 10));
+
+    const leakedAbortListeners = getEventListeners(updateLoopAbortController.signal, "abort").length;
+
+    // Stop the loop before asserting so a failure doesn't leave it spinning.
+    community.state = "stopped";
+    community._stopHasBeenCalled = true;
+    updateLoopAbortController.abort();
+    await loopPromise;
+
+    expect(iterations).to.be.greaterThanOrEqual(TARGET_ITERATIONS);
+    // With the bug this grows ~1 per iteration. After the fix at most one listener
+    // is attached at any instant (the in-flight sleep), independent of iteration count.
+    expect(leakedAbortListeners).to.be.lessThanOrEqual(2);
+});

--- a/test/node/util/abort-helpers.test.ts
+++ b/test/node/util/abort-helpers.test.ts
@@ -1,0 +1,120 @@
+import { getEventListeners } from "events";
+import { describe, expect, it, vi } from "vitest";
+import { isAbortError, raceAgainstAbort, sleepUntilTimeoutOrAbort } from "../../../dist/node/util.js";
+
+// Unit tests for the shared abort helpers extracted from the issue #144-#147 fixes
+// (follow-up to https://github.com/pkcprotocol/pkc-js/pull/149). The four call-site
+// regression tests cover each usage; these pin the helper contract directly, including
+// the reject-on-abort and no-signal paths the call-site tests don't isolate.
+//
+// The core invariant for both helpers: the abort listener is detached on EVERY outcome
+// (timer elapsed / promise settled / aborted), so repeated calls on a long-lived signal
+// never accumulate listeners.
+
+describe("sleepUntilTimeoutOrAbort", () => {
+    it("resolves after the timeout and leaves no abort listener", async () => {
+        vi.useFakeTimers();
+        try {
+            const controller = new AbortController();
+            const sleep = sleepUntilTimeoutOrAbort(1000, controller.signal);
+            expect(getEventListeners(controller.signal, "abort").length).to.equal(1);
+            await vi.advanceTimersByTimeAsync(1000);
+            await sleep;
+            expect(getEventListeners(controller.signal, "abort").length).to.equal(0);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("resolves early (does not reject) when the signal aborts, and detaches the listener", async () => {
+        const controller = new AbortController();
+        const sleep = sleepUntilTimeoutOrAbort(60_000, controller.signal);
+        expect(getEventListeners(controller.signal, "abort").length).to.equal(1);
+        controller.abort();
+        await sleep; // resolves, never rejects
+        expect(getEventListeners(controller.signal, "abort").length).to.equal(0);
+    });
+
+    it("resolves immediately when the signal is already aborted and never attaches a listener", async () => {
+        const controller = new AbortController();
+        controller.abort();
+        await sleepUntilTimeoutOrAbort(60_000, controller.signal);
+        expect(getEventListeners(controller.signal, "abort").length).to.equal(0);
+    });
+
+    it("does not accumulate listeners across many concurrent sleeps on one long-lived signal", async () => {
+        vi.useFakeTimers();
+        try {
+            const controller = new AbortController();
+            const N = 50;
+            const sleeps = Array.from({ length: N }, () => sleepUntilTimeoutOrAbort(1000, controller.signal));
+            expect(getEventListeners(controller.signal, "abort").length).to.equal(N);
+            await vi.advanceTimersByTimeAsync(1000);
+            await Promise.all(sleeps);
+            expect(getEventListeners(controller.signal, "abort").length).to.equal(0);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("resolves after the timeout when no signal is given", async () => {
+        vi.useFakeTimers();
+        try {
+            let resolved = false;
+            const sleep = sleepUntilTimeoutOrAbort(1000).then(() => (resolved = true));
+            await vi.advanceTimersByTimeAsync(1000);
+            await sleep;
+            expect(resolved).to.equal(true);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
+describe("raceAgainstAbort", () => {
+    it("returns the promise's value when it wins, and detaches the listener", async () => {
+        const controller = new AbortController();
+        const result = await raceAgainstAbort(Promise.resolve("ok"), controller.signal);
+        expect(result).to.equal("ok");
+        expect(getEventListeners(controller.signal, "abort").length).to.equal(0);
+    });
+
+    it("rejects with an AbortError when the signal wins, and detaches the listener", async () => {
+        const controller = new AbortController();
+        const never = new Promise<string>(() => {}); // never settles on its own
+        const raced = raceAgainstAbort(never, controller.signal);
+        expect(getEventListeners(controller.signal, "abort").length).to.equal(1);
+        controller.abort();
+        let err: unknown;
+        try {
+            await raced;
+        } catch (e) {
+            err = e;
+        }
+        expect(isAbortError(err)).to.equal(true);
+        expect(getEventListeners(controller.signal, "abort").length).to.equal(0);
+    });
+
+    it("rejects immediately when the signal is already aborted", async () => {
+        const controller = new AbortController();
+        controller.abort();
+        let err: unknown;
+        try {
+            await raceAgainstAbort(new Promise<string>(() => {}), controller.signal);
+        } catch (e) {
+            err = e;
+        }
+        expect(isAbortError(err)).to.equal(true);
+        expect(getEventListeners(controller.signal, "abort").length).to.equal(0);
+    });
+
+    it("does not accumulate listeners across many resolutions on one long-lived signal", async () => {
+        const controller = new AbortController();
+        for (let i = 0; i < 50; i++) expect(await raceAgainstAbort(Promise.resolve(i), controller.signal)).to.equal(i);
+        expect(getEventListeners(controller.signal, "abort").length).to.equal(0);
+    });
+
+    it("passes the promise through unchanged when no signal is given", async () => {
+        expect(await raceAgainstAbort(Promise.resolve(42))).to.equal(42);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes a family of memory leaks, all variations of the same anti-pattern: registering an `abort` listener with `{ once: true }` on a **long-lived** `AbortSignal` for an operation whose **normal** outcome is *not* an abort. `{ once: true }` only detaches the listener when the abort event fires, so on the normal path the listener stays attached forever. In the per-second update loops these accumulate into tens of thousands, and Node's O(n) `EventTarget.add/removeEventListener` go O(n²), pinning a CPU core and wedging the daemon (the symptom reported in #144).

Each issue is fixed in its **own commit**, each paired with a regression test written test-first (red against the unfixed code, green after the fix). The tests assert listener/key counts via `events.getEventListeners` so they fail loudly if the leak returns.

## Fixes

| Commit | Issue | Leak |
|---|---|---|
| `fix(clients)` | #144 | `_resolveViaNameResolvers` race leaks an abort listener per successful name resolution on the community stop signal |
| `fix(community)` | #145 | RemoteCommunity update-loop inter-iteration sleep leaks one listener per iteration (~1/sec) on the stop signal |
| `fix(community)` | #146 | LocalCommunity update-loop sleep — same pattern on `_updateLoopAbortController.signal` |
| `fix(comment)` | #147 | `Comment._scheduleParallelCommunityConnect` never detaches its `clearTimeout` abort listener when the 5s timer fires |
| `fix(challenges)` | #148 | `exclude` challenge `getCommentPending` map sets finished entries to `false` instead of deleting them → unbounded growth |

The first four share one root cause; the fix in each mirrors the existing `onParentAbort` cleanup pattern in `fetchFromMultipleGateways` (named handler + `removeEventListener` on every completion path). #148 is a different class (unbounded `Record` growth) fixed by `delete` instead of `= false`.

## How the leaks were found

A repo-wide audit for this class:
- **Static**: `{ once: true }` on long-lived signals, per-file `addEventListener` vs `removeEventListener` imbalance, `setMaxListeners` as a smell, `= false` where `delete` was meant.
- **Runtime proof**: the `getEventListeners(signal, "abort").length` snapshot test (run an operation N times, assert the listener count doesn't grow) — now codified as the regression tests in this PR.

The rest of the codebase (timers, EventEmitter subscriptions, undestroyed clients/db/helia, LRU caches, tracked-instance registries) traced clean.

## Tests

5 new regression tests, all green; existing `resolver.abort` and `name-resolution-cache` suites still pass (no behavior change to the abort/cache paths).

```
node test/run-test-config.js --pkc-config "local-kubo-rpc" \
  test/node/clients/name-resolver-abort-listener-leak.test.ts \
  test/node/community/community-update-loop-abort-listener-leak.test.ts \
  test/node/community/local-community-update-loop-abort-listener-leak.test.ts \
  test/node/comment/parallel-connect-abort-listener-leak.test.ts \
  test/node/community/exclude-pending-map-growth.test.ts
```

## Follow-up (not in this PR)

The four abort-listener sites are hand-rolled copies of "sleep until timeout-or-abort" / "race against abort". A shared `sleepUntilTimeoutOrAbort(ms, signal)` + `raceAgainstAbort(promise, signal)` helper that always cleans up would collapse the whole class and prevent regressions — left out here to keep each fix minimal and reviewable.

Closes #144, #145, #146, #147, #148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory leaks caused by event listeners not being properly detached in critical background operations: name resolution, community update loops, and parallel comment operations. Listeners would accumulate over time, impacting application stability and performance.

* **Tests**
  * Added comprehensive regression tests to verify proper event listener cleanup and prevent similar issues in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->