### PR TITLE
feat(kubo): force-announce browser-dialable addrs via AppendAnnounce (workaround kubo#11369)

### DIFF
--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -197,6 +197,9 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     private _destroyAbortController?: AbortController;
 
     private _httpRouterSetupPromise?: Promise<void>;
+    // Part of the kubo#11369 workaround (see src/runtime/node/setup-kubo-http-routers.ts).
+    // Delete this field, _runAppendAnnounceSyncAndReschedule, and the destroy() cleanup once
+    // ipfs/kubo#11369 is fixed.
     private _appendAnnounceTimer?: ReturnType<typeof setTimeout>;
     destroyed = false;
     private _promiseToWaitForFirstCommunitieschangeEvent: Promise<string[]>;

--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -118,7 +118,7 @@ import type {
     CommentModerationTypeJson,
     CreateCommentModerationOptions
 } from "../publications/comment-moderation/types.js";
-import { setupKuboHttpRouters } from "../runtime/node/setup-kubo-http-routers.js";
+import { setupKuboHttpRouters, syncKuboAppendAnnounce } from "../runtime/node/setup-kubo-http-routers.js";
 import CommunityEdit from "../publications/community-edit/community-edit.js";
 import type {
     CreateCommunityEditPublicationOptions,
@@ -197,6 +197,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     private _destroyAbortController?: AbortController;
 
     private _httpRouterSetupPromise?: Promise<void>;
+    private _appendAnnounceTimer?: ReturnType<typeof setTimeout>;
     destroyed = false;
     private _promiseToWaitForFirstCommunitieschangeEvent: Promise<string[]>;
 
@@ -399,9 +400,14 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         if (this.httpRoutersOptions?.length && this.kuboRpcClientsOptions?.length && this._canCreateNewLocalCommunity()) {
             // only for node
             const setupPromise = setupKuboHttpRouters(this)
-                .then(() => {
+                .then(async () => {
                     if (this.destroyed) return;
                     log("Set http router options successfully on all connected ipfs", Object.keys(this.clients.kuboRpcClients));
+                    // Workaround for ipfs/kubo#11369: force-announce the node's browser-dialable
+                    // addresses (webrtc-direct + AutoTLS WSS) via AppendAnnounce so they reach the
+                    // HTTP routers. Runs once here; the AutoTLS WSS may not be provisioned yet, so
+                    // _scheduleAppendAnnounceSync re-checks every 10 min until it lands.
+                    await this._runAppendAnnounceSyncAndReschedule();
                 })
                 .catch((e: Error) => {
                     if (this.destroyed) return;
@@ -411,6 +417,27 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
 
             this._httpRouterSetupPromise = setupPromise;
         }
+    }
+
+    // Workaround for ipfs/kubo#11369. Sync browser-dialable addresses into the kubo nodes'
+    // AppendAnnounce, then re-check every 10 minutes until the (slow-to-provision) AutoTLS WSS
+    // has landed — then stop. The timer is unref'd and cleared on destroy().
+    private async _runAppendAnnounceSyncAndReschedule(): Promise<void> {
+        const log = Logger("pkc-js:pkc:_runAppendAnnounceSyncAndReschedule");
+        const RECHECK_MS = 10 * 60 * 1000;
+        if (this.destroyed) return;
+        let allDone = false;
+        try {
+            ({ allDone } = await syncKuboAppendAnnounce(this));
+        } catch (e) {
+            log.error("AppendAnnounce sync failed; will retry", e);
+        }
+        if (this.destroyed || allDone) return;
+        this._appendAnnounceTimer = setTimeout(() => {
+            this._runAppendAnnounceSyncAndReschedule().catch((e) => log.error("AppendAnnounce re-sync failed", e));
+        }, RECHECK_MS);
+        // Don't keep the Node event loop alive solely for this re-check timer.
+        this._appendAnnounceTimer.unref?.();
     }
 
     async _init() {
@@ -1168,6 +1195,10 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
 
         if (this._communityFsWatchAbort) this._communityFsWatchAbort.abort();
 
+        if (this._appendAnnounceTimer) {
+            clearTimeout(this._appendAnnounceTimer);
+            this._appendAnnounceTimer = undefined;
+        }
         if (this._httpRouterSetupPromise) {
             await this._httpRouterSetupPromise;
             this._httpRouterSetupPromise = undefined;

--- a/src/runtime/browser/setup-kubo-http-routers.ts
+++ b/src/runtime/browser/setup-kubo-http-routers.ts
@@ -1,3 +1,14 @@
+// Node-only stubs. The browser build is a string-replace copy of dist/node that rewrites
+// `runtime/node/` imports to `runtime/browser/`, so every export the shared code (src/pkc/)
+// imports from the node module must also exist here, or esbuild fails to bundle it. Neither is
+// ever invoked in a browser (the callers are guarded by _canCreateNewLocalCommunity()).
+//
+// `syncKuboAppendAnnounce` is part of the kubo#11369 workaround — delete this stub together
+// with the node implementation and its pkc.ts wiring once ipfs/kubo#11369 is fixed.
 export function setupKuboHttpRouters() {
+    throw Error("Should not be called in browser");
+}
+
+export function syncKuboAppendAnnounce() {
     throw Error("Should not be called in browser");
 }

--- a/src/runtime/node/setup-kubo-http-routers.ts
+++ b/src/runtime/node/setup-kubo-http-routers.ts
@@ -4,6 +4,18 @@ import Logger from "../../logger.js";
 import { PKCError } from "../../pkc-error.js";
 import * as remeda from "remeda";
 
+// fetch() resolves even on HTTP 4xx/5xx — it only rejects on a network failure — so a kubo RPC
+// error response would otherwise be treated as success and skip our retries. POST to the kubo
+// RPC and throw on a non-2xx status (reading the body for kubo's own error message). Each caller
+// wraps the throw into its specific PKCError. Shared by every kubo RPC POST in this file.
+async function _postToKuboRpc(kuboClient: PKC["clients"]["kuboRpcClients"][string], url: string): Promise<void> {
+    const res = await fetch(url, { method: "POST", headers: kuboClient._clientOptions.headers });
+    if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw Error(`kubo RPC responded with non-2xx status ${res.status} ${res.statusText}${body ? `: ${body}` : ""}`);
+    }
+}
+
 function _mergeRouterConfigs(existingConfig: any, newConfig: any) {
     if (!existingConfig?.Routers) return newConfig;
 
@@ -40,7 +52,7 @@ async function _setProvideDhtSweepEnabledOnKuboNode(kuboClient: PKC["clients"]["
     const configKey = "Provide.DHT.SweepEnabled";
     const url = `${kuboClient._clientOptions.url}/config?arg=${configKey}&arg=${JSON.stringify(sweepEnabled)}&json=true`;
     try {
-        await fetch(url, { method: "POST", headers: kuboClient._clientOptions.headers });
+        await _postToKuboRpc(kuboClient, url);
     } catch (e) {
         const error = new PKCError("ERR_FAILED_TO_SET_CONFIG_ON_KUBO_NODE", {
             fullUrl: url,
@@ -76,7 +88,7 @@ async function _setHttpRouterOptionsOnKuboNode(kuboClient: PKC["clients"]["kuboR
 
     const url = `${kuboClient._clientOptions.url}/config?arg=${routingKey}&arg=${JSON.stringify(mergedRoutingValue)}&json=true`;
     try {
-        await fetch(url, { method: "POST", headers: kuboClient._clientOptions.headers });
+        await _postToKuboRpc(kuboClient, url);
     } catch (e) {
         const error = new PKCError("ERR_FAILED_TO_SET_CONFIG_ON_KUBO_NODE", {
             fullUrl: url,
@@ -106,7 +118,7 @@ async function _setHttpRouterOptionsOnKuboNode(kuboClient: PKC["clients"]["kuboR
         );
         const shutdownUrl = `${kuboClient._clientOptions.url}/shutdown`;
         try {
-            await fetch(shutdownUrl, { method: "POST", headers: kuboClient._clientOptions.headers });
+            await _postToKuboRpc(kuboClient, shutdownUrl);
         } catch (e) {
             const error = new PKCError("ERR_FAILED_TO_SHUTDOWN_KUBO_NODE", {
                 actualError: e,
@@ -119,14 +131,24 @@ async function _setHttpRouterOptionsOnKuboNode(kuboClient: PKC["clients"]["kuboR
     }
 }
 
-// ---- Workaround for ipfs/kubo#11369 ----
-// A publicly-reachable kubo node advertises its browser-dialable transports (AutoTLS
-// Secure-WebSocket `/tls/ws` and `webrtc-direct/certhash`) in `ipfs id`, but kubo does NOT
-// announce those two address types to delegated HTTP routers once AutoNAT v2 has confirmed
+// ============================================================================================
+// TODO(kubo#11369): DELETE THIS ENTIRE WORKAROUND once ipfs/kubo#11369 is fixed.
+// Everything from here to the end of this file that concerns AppendAnnounce — the IP/host
+// helpers (_isPrivateOrLoopbackIpv4/Ipv6, _hasPublicHost), selectBrowserDialableAddrsToAppendAnnounce,
+// _setKuboConfigJson, _syncAppendAnnounceOnKuboNode, syncKuboAppendAnnounce — plus the
+// browser stub (src/runtime/browser/setup-kubo-http-routers.ts), the scheduler/timer wiring in
+// src/pkc/pkc.ts (_appendAnnounceTimer, _runAppendAnnounceSyncAndReschedule, the destroy()
+// cleanup), and test/node/kubo-append-announce.unit.test.ts exist ONLY to compensate for that
+// kubo bug. When kubo#11369 ships a fix, remove all of it.
+// --------------------------------------------------------------------------------------------
+// Why it exists: a publicly-reachable kubo node advertises its browser-dialable transports
+// (AutoTLS Secure-WebSocket `/tls/ws` and `webrtc-direct/certhash`) in `ipfs id`, but kubo does
+// NOT announce those two address types to delegated HTTP routers once AutoNAT v2 has confirmed
 // reachability — it only announces tcp/quic-v1/webtransport. Browser libp2p/helia clients
 // therefore never learn a dialable address. We force-announce the node's own browser-dialable
 // addresses via `Addresses.AppendAnnounce`, which go-libp2p applies AFTER the reachability
-// filter, so they survive into provider records. Remove once kubo#11369 is fixed.
+// filter, so they survive into provider records.
+// ============================================================================================
 
 function _isPrivateOrLoopbackIpv4(ip: string): boolean {
     if (/^(10|127|0)\./.test(ip) || /^169\.254\./.test(ip) || /^192\.168\./.test(ip)) return true;
@@ -170,7 +192,12 @@ export function selectBrowserDialableAddrsToAppendAnnounce(idAddrs: string[]): {
         const addr = String(raw).replace(/\/p2p\/[^/]+$/, "");
         if (!_hasPublicHost(addr)) continue;
         if (addr.includes("/webrtc-direct/") && addr.includes("/certhash/")) webrtcDirect.add(addr);
-        else if (addr.includes("/tls/ws") || addr.includes("libp2p.direct")) wss.add(addr);
+        // Only real browser-dialable Secure-WebSocket forms: the plain `.../tls/ws` and the
+        // AutoTLS IP+SNI `.../tls/sni/<*.libp2p.direct>/ws`. Matching any `libp2p.direct` substring
+        // would be too broad — a non-`/ws` address on that domain could falsely satisfy `wssPresent`
+        // and stop the retry loop before the WSS address actually lands.
+        else if (addr.endsWith("/ws") && (addr.includes("/tls/ws") || (addr.includes("/tls/sni/") && addr.includes("libp2p.direct"))))
+            wss.add(addr);
     }
     return { webrtcDirect: [...webrtcDirect], wss: [...wss], all: [...webrtcDirect, ...wss] };
 }
@@ -179,7 +206,7 @@ async function _setKuboConfigJson(kuboClient: PKC["clients"]["kuboRpcClients"][s
     const log = Logger("pkc-js:pkc:_init:syncKuboAppendAnnounce:setConfig");
     const url = `${kuboClient._clientOptions.url}/config?arg=${configKey}&arg=${JSON.stringify(value)}&json=true`;
     try {
-        await fetch(url, { method: "POST", headers: kuboClient._clientOptions.headers });
+        await _postToKuboRpc(kuboClient, url);
     } catch (e) {
         const error = new PKCError("ERR_FAILED_TO_SET_CONFIG_ON_KUBO_NODE", {
             fullUrl: url,
@@ -197,6 +224,7 @@ async function _setKuboConfigJson(kuboClient: PKC["clients"]["kuboRpcClients"][s
 // Sync one kubo node's AppendAnnounce. Returns whether it changed, whether the AutoTLS WSS is
 // now present, and whether AutoTLS is enabled (so the caller can decide when to stop re-checking).
 async function _syncAppendAnnounceOnKuboNode(
+    pkc: PKC,
     kuboClient: PKC["clients"]["kuboRpcClients"][string]
 ): Promise<{ changed: boolean; wssPresent: boolean; autoTlsEnabled: boolean }> {
     const log = Logger("pkc-js:pkc:_init:syncKuboAppendAnnounce");
@@ -226,7 +254,9 @@ async function _syncAppendAnnounceOnKuboNode(
             changed = true;
         }
 
-    if (changed) {
+    // Don't mutate the node (config write + shutdown) if pkc was destroyed while we were reading
+    // its `ipfs id` / config above — destroy() must stop the sync from touching kubo any further.
+    if (changed && !pkc.destroyed) {
         await _setKuboConfigJson(kuboClient, "Addresses.AppendAnnounce", merged);
         // AppendAnnounce is only read at kubo startup (verified: a running daemon ignores a live
         // config.set until restart). Shut down so the operator's supervisor restarts the node and
@@ -239,7 +269,7 @@ async function _syncAppendAnnounceOnKuboNode(
         );
         const shutdownUrl = `${kuboClient._clientOptions.url}/shutdown`;
         try {
-            await fetch(shutdownUrl, { method: "POST", headers: kuboClient._clientOptions.headers });
+            await _postToKuboRpc(kuboClient, shutdownUrl);
         } catch (e) {
             const error = new PKCError("ERR_FAILED_TO_SHUTDOWN_KUBO_NODE", {
                 actualError: e,
@@ -263,8 +293,9 @@ export async function syncKuboAppendAnnounce(pkc: PKC): Promise<{ allDone: boole
     if (pkc.destroyed) return { allDone: true };
     let allDone = true;
     for (const kuboClient of Object.values(pkc.clients.kuboRpcClients)) {
+        if (pkc.destroyed) return { allDone: true }; // destroyed mid-sync — stop touching nodes
         try {
-            const { wssPresent, autoTlsEnabled } = await _syncAppendAnnounceOnKuboNode(kuboClient);
+            const { wssPresent, autoTlsEnabled } = await _syncAppendAnnounceOnKuboNode(pkc, kuboClient);
             // Keep re-checking while AutoTLS is enabled but its (slow to provision) /tls/ws hasn't
             // landed in AppendAnnounce yet. When AutoTLS is off there is no WSS to wait for.
             if (autoTlsEnabled && !wssPresent) allDone = false;

--- a/src/runtime/node/setup-kubo-http-routers.ts
+++ b/src/runtime/node/setup-kubo-http-routers.ts
@@ -119,6 +119,163 @@ async function _setHttpRouterOptionsOnKuboNode(kuboClient: PKC["clients"]["kuboR
     }
 }
 
+// ---- Workaround for ipfs/kubo#11369 ----
+// A publicly-reachable kubo node advertises its browser-dialable transports (AutoTLS
+// Secure-WebSocket `/tls/ws` and `webrtc-direct/certhash`) in `ipfs id`, but kubo does NOT
+// announce those two address types to delegated HTTP routers once AutoNAT v2 has confirmed
+// reachability — it only announces tcp/quic-v1/webtransport. Browser libp2p/helia clients
+// therefore never learn a dialable address. We force-announce the node's own browser-dialable
+// addresses via `Addresses.AppendAnnounce`, which go-libp2p applies AFTER the reachability
+// filter, so they survive into provider records. Remove once kubo#11369 is fixed.
+
+function _isPrivateOrLoopbackIpv4(ip: string): boolean {
+    if (/^(10|127|0)\./.test(ip) || /^169\.254\./.test(ip) || /^192\.168\./.test(ip)) return true;
+    const m172 = ip.match(/^172\.(\d{1,3})\./); // 172.16.0.0 - 172.31.255.255
+    if (m172 && Number(m172[1]) >= 16 && Number(m172[1]) <= 31) return true;
+    const m100 = ip.match(/^100\.(\d{1,3})\./); // 100.64.0.0/10 (CGNAT)
+    if (m100 && Number(m100[1]) >= 64 && Number(m100[1]) <= 127) return true;
+    return false;
+}
+
+function _isPrivateOrLoopbackIpv6(ip: string): boolean {
+    const l = ip.toLowerCase();
+    return l === "::1" || l === "::" || l.startsWith("fe80") || l.startsWith("fc") || l.startsWith("fd");
+}
+
+// Is the address rooted at a public host (public IP, or a DNS name like the AutoTLS
+// `*.libp2p.direct` domain)? Private/loopback/link-local/CGNAT addresses are excluded so we
+// never force-announce an undialable LAN address.
+function _hasPublicHost(addr: string): boolean {
+    const parts = addr.split("/"); // ["", "ip4", "1.2.3.4", ...]
+    const proto = parts[1];
+    const host = parts[2] ?? "";
+    if (proto === "ip4") return !_isPrivateOrLoopbackIpv4(host);
+    if (proto === "ip6") return !_isPrivateOrLoopbackIpv6(host);
+    if (proto === "dns" || proto === "dns4" || proto === "dns6" || proto === "dnsaddr") return true;
+    return false;
+}
+
+// Pure: from the multiaddrs reported by `ipfs id`, pick the node's own public browser-dialable
+// addresses that kubo withholds from provider records — webrtc-direct (with certhash) and the
+// AutoTLS Secure-WebSocket (`/tls/ws`, on a `libp2p.direct` domain). `/p2p/...` suffixes are
+// stripped (AppendAnnounce entries are addresses; kubo appends the peer id).
+export function selectBrowserDialableAddrsToAppendAnnounce(idAddrs: string[]): {
+    webrtcDirect: string[];
+    wss: string[];
+    all: string[];
+} {
+    const webrtcDirect = new Set<string>();
+    const wss = new Set<string>();
+    for (const raw of idAddrs) {
+        const addr = String(raw).replace(/\/p2p\/[^/]+$/, "");
+        if (!_hasPublicHost(addr)) continue;
+        if (addr.includes("/webrtc-direct/") && addr.includes("/certhash/")) webrtcDirect.add(addr);
+        else if (addr.includes("/tls/ws") || addr.includes("libp2p.direct")) wss.add(addr);
+    }
+    return { webrtcDirect: [...webrtcDirect], wss: [...wss], all: [...webrtcDirect, ...wss] };
+}
+
+async function _setKuboConfigJson(kuboClient: PKC["clients"]["kuboRpcClients"][string], configKey: string, value: unknown) {
+    const log = Logger("pkc-js:pkc:_init:syncKuboAppendAnnounce:setConfig");
+    const url = `${kuboClient._clientOptions.url}/config?arg=${configKey}&arg=${JSON.stringify(value)}&json=true`;
+    try {
+        await fetch(url, { method: "POST", headers: kuboClient._clientOptions.headers });
+    } catch (e) {
+        const error = new PKCError("ERR_FAILED_TO_SET_CONFIG_ON_KUBO_NODE", {
+            fullUrl: url,
+            actualError: e,
+            kuboEndpoint: kuboClient._clientOptions.url,
+            configKey,
+            configValueToBeSet: value
+        });
+        log.error(e);
+        throw error;
+    }
+    log.trace("Set config key", configKey, "on node", kuboClient._clientOptions.url);
+}
+
+// Sync one kubo node's AppendAnnounce. Returns whether it changed, whether the AutoTLS WSS is
+// now present, and whether AutoTLS is enabled (so the caller can decide when to stop re-checking).
+async function _syncAppendAnnounceOnKuboNode(
+    kuboClient: PKC["clients"]["kuboRpcClients"][string]
+): Promise<{ changed: boolean; wssPresent: boolean; autoTlsEnabled: boolean }> {
+    const log = Logger("pkc-js:pkc:_init:syncKuboAppendAnnounce");
+
+    const idResult = await kuboClient._client.id();
+    const idAddrs = (idResult.addresses ?? []).map((a) => String(a));
+    const desired = selectBrowserDialableAddrsToAppendAnnounce(idAddrs);
+
+    let autoTlsEnabled = false;
+    try {
+        // config.get returns the JSON value (a boolean here) typed loosely as string | object
+        autoTlsEnabled = String(await kuboClient._client.config.get("AutoTLS.Enabled")) === "true";
+    } catch {
+        // older kubo / key absent — treat as disabled
+    }
+
+    const current = ((await kuboClient._client.config.get("Addresses.AppendAnnounce")) ?? []) as unknown as string[];
+    const currentArr = Array.isArray(current) ? current.map((a) => String(a)) : [];
+    const currentSet = new Set(currentArr);
+
+    const merged = [...currentArr];
+    let changed = false;
+    for (const addr of desired.all)
+        if (!currentSet.has(addr)) {
+            merged.push(addr);
+            currentSet.add(addr);
+            changed = true;
+        }
+
+    if (changed) {
+        await _setKuboConfigJson(kuboClient, "Addresses.AppendAnnounce", merged);
+        // AppendAnnounce is only read at kubo startup (verified: a running daemon ignores a live
+        // config.set until restart). Shut down so the operator's supervisor restarts the node and
+        // the addresses go live — same mechanism setupKuboHttpRouters uses for Routing changes.
+        log(
+            "Added browser-dialable addresses to AppendAnnounce on kubo node",
+            kuboClient._clientOptions.url,
+            desired.all,
+            "- sending shutdown so the node restarts and announces them"
+        );
+        const shutdownUrl = `${kuboClient._clientOptions.url}/shutdown`;
+        try {
+            await fetch(shutdownUrl, { method: "POST", headers: kuboClient._clientOptions.headers });
+        } catch (e) {
+            const error = new PKCError("ERR_FAILED_TO_SHUTDOWN_KUBO_NODE", {
+                actualError: e,
+                kuboEndpoint: kuboClient._clientOptions.url,
+                shutdownUrl
+            });
+            log.error(e);
+            throw error;
+        }
+    }
+
+    const wssPresent = desired.wss.length > 0 && desired.wss.every((a) => currentSet.has(a));
+    return { changed, wssPresent, autoTlsEnabled };
+}
+
+// Sync AppendAnnounce on every connected kubo node. Returns allDone = true once every node has
+// its AutoTLS WSS announced (or has AutoTLS disabled, in which case the one-shot webrtc-direct
+// sync is all there is to do) — the caller stops the 10-minute re-check loop when allDone.
+export async function syncKuboAppendAnnounce(pkc: PKC): Promise<{ allDone: boolean }> {
+    const log = Logger("pkc-js:pkc:_init:syncKuboAppendAnnounce");
+    if (pkc.destroyed) return { allDone: true };
+    let allDone = true;
+    for (const kuboClient of Object.values(pkc.clients.kuboRpcClients)) {
+        try {
+            const { wssPresent, autoTlsEnabled } = await _syncAppendAnnounceOnKuboNode(kuboClient);
+            // Keep re-checking while AutoTLS is enabled but its (slow to provision) /tls/ws hasn't
+            // landed in AppendAnnounce yet. When AutoTLS is off there is no WSS to wait for.
+            if (autoTlsEnabled && !wssPresent) allDone = false;
+        } catch (e) {
+            log.error("Failed to sync AppendAnnounce on kubo node", kuboClient._clientOptions.url, e);
+            allDone = false; // retry on the next tick
+        }
+    }
+    return { allDone };
+}
+
 export async function setupKuboHttpRouters(pkc: PKC): Promise<void> {
     if (pkc.destroyed) return;
     if (!Array.isArray(pkc.kuboRpcClientsOptions) || pkc.kuboRpcClientsOptions.length <= 0)

--- a/test/node/kubo-append-announce.unit.test.ts
+++ b/test/node/kubo-append-announce.unit.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { selectBrowserDialableAddrsToAppendAnnounce } from "../../dist/node/runtime/node/setup-kubo-http-routers.js";
+
+// Unit test for the kubo#11369 workaround: from `ipfs id` addresses, pick the node's own
+// public browser-dialable transports (webrtc-direct/certhash + AutoTLS /tls/ws) that kubo
+// withholds from provider records, so pkc-js can force-announce them via AppendAnnounce.
+const PEER = "12D3KooWGu4BNg4SqXRgDdnL5tiqUAD7aaMNTxSgnp8sfAo718Tt";
+
+describe("selectBrowserDialableAddrsToAppendAnnounce (kubo#11369 workaround)", () => {
+    it("selects the node's public webrtc-direct/certhash and AutoTLS /tls/ws, strips /p2p, dedupes", () => {
+        const wss = `/dns4/89-36-231-48.k51qzi5uqu5diszlj48aqp4kldhv4m84b9cnfy9cwf1lgz3yobt98djpepn4ab.libp2p.direct/tcp/4001/tls/ws`;
+        const webrtc = `/ip4/89.36.231.48/udp/4001/webrtc-direct/certhash/uEiCGYtKZoGvQeZsFO4gvYJA_yaO0M-VpdDPOlt5YjFNhSw`;
+        const idAddrs = [
+            `${wss}/p2p/${PEER}`,
+            `${webrtc}/p2p/${PEER}`,
+            `${webrtc}/p2p/${PEER}`, // duplicate -> deduped
+            `/ip4/89.36.231.48/tcp/4001/p2p/${PEER}`, // not browser-dialable
+            `/ip4/89.36.231.48/udp/4001/quic-v1/p2p/${PEER}`, // not browser-dialable
+            `/ip4/89.36.231.48/udp/4001/quic-v1/webtransport/certhash/uEiA/certhash/uEiB/p2p/${PEER}` // already announced by kubo
+        ];
+        const r = selectBrowserDialableAddrsToAppendAnnounce(idAddrs);
+        expect(r.webrtcDirect).to.deep.equal([webrtc]);
+        expect(r.wss).to.deep.equal([wss]);
+        expect(r.all).to.deep.equal([webrtc, wss]); // webrtc-direct first, then wss; deduped; tcp/quic/webtransport excluded
+    });
+
+    it("excludes private / loopback / link-local / CGNAT addresses", () => {
+        const r = selectBrowserDialableAddrsToAppendAnnounce([
+            `/ip4/192.168.0.10/udp/4001/webrtc-direct/certhash/uEiPRIV`,
+            `/ip4/10.1.2.3/udp/4001/webrtc-direct/certhash/uEiPRIV`,
+            `/ip4/172.17.0.1/udp/4001/webrtc-direct/certhash/uEiPRIV`,
+            `/ip4/127.0.0.1/udp/4001/webrtc-direct/certhash/uEiLOOP`,
+            `/ip4/169.254.1.2/udp/4001/webrtc-direct/certhash/uEiLINK`,
+            `/ip4/100.100.0.1/udp/4001/webrtc-direct/certhash/uEiCGNAT`,
+            `/ip6/::1/udp/4001/webrtc-direct/certhash/uEiLOOP6`
+        ]);
+        expect(r.all).to.deep.equal([]);
+    });
+
+    it("excludes webrtc-direct without a certhash (undialable from a browser)", () => {
+        const r = selectBrowserDialableAddrsToAppendAnnounce([`/ip4/89.36.231.48/udp/4001/webrtc-direct`]);
+        expect(r.all).to.deep.equal([]);
+    });
+
+    it("recognizes the IP+SNI AutoTLS WSS form via the libp2p.direct domain", () => {
+        const addr = `/ip4/194.11.226.35/tcp/4001/tls/sni/peer.libp2p.direct/ws`;
+        const r = selectBrowserDialableAddrsToAppendAnnounce([`${addr}/p2p/${PEER}`]);
+        expect(r.wss).to.deep.equal([addr]);
+    });
+
+    it("returns empty when there are no browser-dialable public addresses", () => {
+        const r = selectBrowserDialableAddrsToAppendAnnounce([
+            `/ip4/89.36.231.48/tcp/4001`,
+            `/ip4/89.36.231.48/udp/4001/quic-v1`,
+            `/ip4/89.36.231.48/udp/4001/quic-v1/webtransport/certhash/uEiA/certhash/uEiB`
+        ]);
+        expect(r.all).to.deep.equal([]);
+    });
+});

--- a/test/node/kubo-append-announce.unit.test.ts
+++ b/test/node/kubo-append-announce.unit.test.ts
@@ -48,6 +48,18 @@ describe("selectBrowserDialableAddrsToAppendAnnounce (kubo#11369 workaround)", (
         expect(r.wss).to.deep.equal([addr]);
     });
 
+    it("does not classify a non-/ws libp2p.direct address as WSS (would falsely satisfy wssPresent)", () => {
+        // Only `.../tls/ws` and `.../tls/sni/<*.libp2p.direct>/ws` are browser-dialable WSS. A
+        // libp2p.direct address that isn't a websocket must not be picked, or it would prematurely
+        // stop the retry loop before the real AutoTLS /ws address lands.
+        const r = selectBrowserDialableAddrsToAppendAnnounce([
+            `/dns4/peer.libp2p.direct/tcp/4001/p2p/${PEER}`,
+            `/dnsaddr/peer.libp2p.direct/p2p/${PEER}`
+        ]);
+        expect(r.wss).to.deep.equal([]);
+        expect(r.all).to.deep.equal([]);
+    });
+
     it("returns empty when there are no browser-dialable public addresses", () => {
         const r = selectBrowserDialableAddrsToAppendAnnounce([
             `/ip4/89.36.231.48/tcp/4001`,


### PR DESCRIPTION
## What

Workaround for **ipfs/kubo#11369**: a publicly-reachable kubo node advertises its
browser-dialable transports (AutoTLS Secure-WebSocket `/tls/ws` and `webrtc-direct/certhash`)
in `ipfs id`, but kubo does **not** announce those two address types to delegated HTTP routers
once AutoNAT v2 has confirmed reachability — it only announces `tcp`/`quic-v1`/`webtransport`.
Browser libp2p/helia clients therefore query the routers, get back only undialable addresses,
and can never connect (the `connectToPubsubPeers` warmup never finds a dialable peer; dials
throw `Couldn't find a certhash component`).

pkc-js already configures the kubo node's `Routing` over RPC on startup. This PR extends that
flow to **force-announce** the node's own browser-dialable addresses via
`Addresses.AppendAnnounce`, which go-libp2p applies *after* the reachability filter, so they
survive into provider records.

## How

- `selectBrowserDialableAddrsToAppendAnnounce(idAddrs)` — pure: from `ipfs id`, pick the node's
  own **public** `webrtc-direct/certhash` and AutoTLS `/tls/ws` (`libp2p.direct`) addresses;
  drop private/loopback/link-local/CGNAT; require certhash on webrtc-direct; strip `/p2p/...`.
- `syncKuboAppendAnnounce(pkc)` — per connected kubo node: union the desired addresses into the
  existing `Addresses.AppendAnnounce`; write only on change; on change POST `/shutdown` so the
  operator's supervisor restarts kubo and the addresses go live (AppendAnnounce only takes
  effect on restart — verified empirically). Idempotent, so it converges with no restart loop.
- Scheduler in `pkc.ts`: runs once after `setupKuboHttpRouters`, then re-checks **every 10
  minutes until the (slow-to-provision) AutoTLS `/tls/ws` lands, then stops**. If the node has
  `AutoTLS.Enabled=false`, the one-shot `webrtc-direct` sync is all there is. Timer is `unref`'d
  and cleared in `destroy()`.

Node-only (runs where `setupKuboHttpRouters` runs: kubo RPC connected + can create a local
community). Remove once kubo#11369 is fixed.

## Tests

`test/node/kubo-append-announce.unit.test.ts` covers the pure selection: public webrtc-direct +
AutoTLS WSS selection, `/p2p` stripping + dedupe, private/loopback/CGNAT exclusion, missing
certhash exclusion, the IP+SNI `libp2p.direct` WSS form, and the empty case. (5 passing.)

## Notes / context

Root-caused with a mock-router + kubo-0.42 reproduction harness: routers don't strip these
addresses and kubo has no static address-type filter — the withholding is gated on AutoNAT v2
reachability confirmation, and `webrtc-direct` is never probed by AutoNAT v2 (`go-libp2p`
`addrs_manager.go`). See ipfs/kubo#11369.

Closes #150.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node startup so Kubo `AppendAnnounce` stays synced with browser-dialable addresses using periodic retries until completion.
  * Ensures sync retries stop cleanly on shutdown to prevent background activity after the app is closed.
  * Updates HTTP handling so non-success responses are treated as failures for correct retry behavior.
* **Tests**
  * Added unit tests covering selection/filtering of browser-dialable addresses, including ordering, deduplication, and exclusion of private/unsupported transports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->