### PR TITLE
fix(kubo): strip /p2p suffix and dedupe addrs in rewriter proxy

### DIFF
--- a/src/runtime/node/addresses-rewriter-proxy-server.ts
+++ b/src/runtime/node/addresses-rewriter-proxy-server.ts
@@ -11,6 +11,16 @@ import { AddressRewriterDatabase, RequestLogEntry } from "./address-rewriter-db.
 const debug = Logger("pkc-js:addresses-rewriter");
 const MAX_BODY_PREVIEW_BYTES = 4096;
 
+// `ipfs id` returns self-addresses with a trailing `/p2p/<peerId>` while `swarm addrs`
+// returns the same transports without it, so unioning them yields each address twice plus
+// non-standard `/p2p`-suffixed entries. The `/routing/v1` provider schema carries the peer id
+// in the separate `ID` field and expects transport-only `Addrs`, so strip the trailing
+// `/p2p/<peerId>` and dedupe before announcing.
+export function normalizeSelfAddrsForProvider(addrs: string[], peerId: string): string[] {
+    const suffix = `/p2p/${peerId}`;
+    return remeda.unique(addrs.map((addr) => (addr.endsWith(suffix) ? addr.slice(0, -suffix.length) : addr)));
+}
+
 type AddressesRewriterOptions = {
     kuboClients: PKC["clients"]["kuboRpcClients"][string]["_client"][];
     port: number;
@@ -380,10 +390,15 @@ export class AddressesRewriterProxyServer {
 
                         const swarmListeningAddresses = swarmAddrsRes.filter((swarmAddr) => swarmAddr.id.toString() === peerId);
 
-                        const addresses: string[] = remeda.unique([
-                            ...idRes.addresses.map((addr) => addr.toString()),
-                            ...remeda.flatten(swarmListeningAddresses.map((swarmAddr) => swarmAddr.addrs.map((addr) => addr.toString())))
-                        ]);
+                        const addresses: string[] = normalizeSelfAddrsForProvider(
+                            [
+                                ...idRes.addresses.map((addr) => addr.toString()),
+                                ...remeda.flatten(
+                                    swarmListeningAddresses.map((swarmAddr) => swarmAddr.addrs.map((addr) => addr.toString()))
+                                )
+                            ],
+                            peerId
+                        );
 
                         if (addresses.length === 0) {
                             throw Error(`Failed to get any addresses for peer ${peerId}`);

--- a/test/node/kubo-address-rewriter.unit.test.ts
+++ b/test/node/kubo-address-rewriter.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { normalizeSelfAddrsForProvider } from "../../dist/node/runtime/node/addresses-rewriter-proxy-server.js";
+
+const PEER_ID = "12D3KooWLNoZZe8n3UtsvRUcRPa4gmWLZsb5mF9Auns9NBhKXV9x";
+const WSS_BASE = "/dns4/89-36-231-48.k51qzi5uqu5dk3d0w8k7950ie0sbol9jr8i1fd3dzflsm2n0pvtypbd2ydmxtz.libp2p.direct/tcp/4001/tls/ws";
+const WEBRTC_BASE = "/ip4/89.36.231.48/udp/4001/webrtc-direct/certhash/uEiCanSXSJpjWxic9SBulYAKbexD5MitQemB-RUJJkC2BDw";
+
+describe("normalizeSelfAddrsForProvider", () => {
+    it("strips the trailing /p2p/<peerId> suffix", () => {
+        expect(normalizeSelfAddrsForProvider([`${WSS_BASE}/p2p/${PEER_ID}`], PEER_ID)).toEqual([WSS_BASE]);
+        expect(normalizeSelfAddrsForProvider([`${WEBRTC_BASE}/p2p/${PEER_ID}`], PEER_ID)).toEqual([WEBRTC_BASE]);
+    });
+
+    it("dedupes the `ipfs id` (/p2p-suffixed) and `swarm addrs` (bare) forms into one", () => {
+        // mirrors the real union: id() returns /p2p-suffixed, swarm.addrs() returns bare
+        const raw = [`${WSS_BASE}/p2p/${PEER_ID}`, `${WEBRTC_BASE}/p2p/${PEER_ID}`, WSS_BASE, WEBRTC_BASE];
+        expect(normalizeSelfAddrsForProvider(raw, PEER_ID)).toEqual([WSS_BASE, WEBRTC_BASE]);
+    });
+
+    it("leaves transport-only addrs (no /p2p) untouched", () => {
+        const raw = ["/ip4/89.36.231.48/tcp/4001", "/ip4/89.36.231.48/udp/4001/quic-v1"];
+        expect(normalizeSelfAddrsForProvider(raw, PEER_ID)).toEqual(raw);
+    });
+
+    it("only strips this node's own trailing peer id, not a different one", () => {
+        const otherPeer = "12D3KooWRPuT67gVCnaoEMt6w3DuvtkusUz2EdXYuiUUpEkm88nC";
+        const addr = `${WSS_BASE}/p2p/${otherPeer}`;
+        expect(normalizeSelfAddrsForProvider([addr], PEER_ID)).toEqual([addr]);
+    });
+
+    it("returns an empty array for empty input", () => {
+        expect(normalizeSelfAddrsForProvider([], PEER_ID)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Why

Follow-up to #155. That PR restored the address rewriter proxy, but the proxy
unioned `ipfs id` addresses (suffixed with `/p2p/<peerId>`) with `swarm addrs`
(bare transport), so every provider record carried **each address twice** plus
non-standard `/p2p`-suffixed entries (verified on a live node: 10 addrs where 5
had `/p2p`).

The `/routing/v1` provider schema puts the peer id in the separate `ID` field
and expects transport-only `Addrs`; some browser libp2p clients don't parse the
`/p2p`-suffixed form.

## How

Add `normalizeSelfAddrsForProvider(addrs, peerId)` — strips the trailing
`/p2p/<peerId>` and dedupes — applied where the proxy gathers live addrs in
`tryUpdateAddressesForClient`. Records now carry the clean 5-address set
(tcp, quic-v1, webtransport, webrtc-direct w/ current certhash, WSS).

## Tests

- `npm run build` ✅, `tsc --project test/tsconfig.json --noEmit` ✅
- New `test/node/kubo-address-rewriter.unit.test.ts` (5 cases) ✅
- `test/node/httprouter.test.ts` proxy integration ✅ 8/8 (verified before merge of #155)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved how announced network addresses are normalized and deduplicated before being shared.
  * Added a new helper to remove self peer-ID suffixes from multiaddresses and keep only unique entries.

* **Bug Fixes**
  * Prevented duplicate provider addresses caused by both suffix and non-suffix address forms.
  * Ensured self-address announcements use a consistent, canonical format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->