### PR TITLE
fix(rpc): survive boot-time Kubo restart during auto-start (#158)

### DIFF
--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -422,6 +422,15 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         }
     }
 
+    // Resolves once the background HTTP-router / address-rewriter reconcile has finished. On Node
+    // with an embedded Kubo this reconcile may POST /shutdown to the node to force a restart (see
+    // setup-kubo-address-rewriter-and-http-router.ts), so callers that need to talk to a stable
+    // Kubo immediately after boot (e.g. RPC auto-start) should await this first to avoid racing the
+    // restart window. No-op when there is no router setup in flight.
+    async _waitForHttpRoutersSetupToSettle(): Promise<void> {
+        if (this._addressRewriterSetupPromise) await this._addressRewriterSetupPromise;
+    }
+
     async _init() {
         const log = Logger("pkc-js:pkc:_init");
         // Init storage

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -1,4 +1,5 @@
 import pLimit from "p-limit";
+import pRetry from "p-retry";
 import { Server as RpcWebsocketsServer } from "rpc-websockets";
 import { createReadStream, existsSync, mkdirSync, promises as fsPromises, statSync } from "fs";
 import http, { type Server as HTTPServer, type ServerResponse } from "http";
@@ -108,6 +109,29 @@ import { findStartedCommunity } from "../../pkc/tracked-instance-registry-util.j
 // store as a singleton because not possible to start the same community twice at the same time
 
 const log = Logger("pkc-js-rpc:pkc-ws-server");
+
+// Max retries when an auto-start hits a transient Kubo network blip (e.g. a boot-time restart).
+// With factor=2, minTimeout=2s, maxTimeout=15s this spans ~89s of backoff, comfortably covering a
+// ~30-60s embedded-Kubo restart window observed in production (issue #158).
+const AUTO_START_TRANSIENT_RETRIES = 8;
+
+// Transient errors thrown when a request hits a Kubo node that is restarting or briefly unreachable.
+// These are safe to retry; anything else (e.g. a bad signature, a missing community) is not.
+const _isTransientKuboError = (error: unknown): boolean => {
+    const markers = ["fetch failed", "other side closed", "socket hang up", "econnrefused", "econnreset", "und_err"];
+    const seen = new Set<unknown>();
+    let current: unknown = error;
+    // Walk the error chain (cause / details.actualError) since the network error is often wrapped.
+    while (current && typeof current === "object" && !seen.has(current)) {
+        seen.add(current);
+        const err = current as { message?: unknown; code?: unknown; cause?: unknown; details?: { actualError?: unknown } };
+        const haystack =
+            `${typeof err.message === "string" ? err.message : ""} ${typeof err.code === "string" ? err.code : ""}`.toLowerCase();
+        if (markers.some((marker) => haystack.includes(marker))) return true;
+        current = err.cause ?? err.details?.actualError;
+    }
+    return false;
+};
 
 // TODO need to think how to update PKC instance of publication after setSettings?
 
@@ -386,6 +410,13 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
         }[];
 
         const pkc = await this._getPKCInstance();
+
+        // Bug 1 (issue #158): the background HTTP-router / address-rewriter reconcile may POST
+        // /shutdown to the embedded Kubo to force a restart. If auto-start dispatches community
+        // starts while that restart is in flight, those starts hit the dying Kubo socket and throw
+        // `fetch failed`. Wait for the reconcile to settle before touching the node.
+        await pkc._waitForHttpRoutersSetupToSettle();
+
         const localCommunities = pkc.communities;
 
         // Filter phase: determine which communities need starting
@@ -419,7 +450,24 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
                 limit(async () => {
                     autoStartLog(`Auto-starting community: ${address}`);
                     try {
-                        await this._internalStartCommunity(address);
+                        // Bug 2 (issue #158): a community whose start hits a transient Kubo blip
+                        // (e.g. a boot-time restart window) must not be left permanently stopped.
+                        // Retry transient network errors with backoff; non-transient errors abort
+                        // immediately so we don't mask real failures.
+                        await pRetry(() => this._internalStartCommunity(address), {
+                            retries: AUTO_START_TRANSIENT_RETRIES,
+                            factor: 2,
+                            minTimeout: 2000,
+                            maxTimeout: 15000,
+                            shouldRetry: ({ error }) => _isTransientKuboError(error),
+                            onFailedAttempt: ({ error, attemptNumber, retriesLeft }) => {
+                                if (_isTransientKuboError(error))
+                                    autoStartLog(
+                                        `Transient failure auto-starting ${address} (attempt ${attemptNumber}, ${retriesLeft} retries left), retrying`,
+                                        error.message
+                                    );
+                            }
+                        });
                         autoStartLog(`Successfully auto-started: ${address}`);
                     } catch (e) {
                         autoStartLog.error(`Failed to auto-start community ${address}`, e);

--- a/src/rpc/test/node/rpc.auto-start-kubo-restart.test.ts
+++ b/src/rpc/test/node/rpc.auto-start-kubo-restart.test.ts
@@ -1,0 +1,197 @@
+// Regression tests for https://github.com/pkcprotocol/pkc-js/issues/158
+//
+// On RPC server boot, `_autoStartPreviousCommunities()` queues every previously-started
+// community, but a concurrent embedded-Kubo restart (triggered by the HTTP-router config
+// reconcile, which POSTs /shutdown to the node) kills any `community.start()` that is in-flight
+// during the restart window. Those communities used to fail once with `TypeError: fetch failed`
+// and were NEVER retried, so they stayed stopped even though the user never disabled them.
+//
+// Two independent bugs, one test each:
+//
+//   Bug 1 — the Kubo restart races auto-start instead of preceding it. Auto-start must await the
+//           PKC `_addressRewriterSetupPromise` (the router reconcile + shutdown) before dispatching
+//           any `community.start()`, so it never runs against a Kubo node about to be shut down.
+//
+//   Bug 2 — no retry on transient auto-start failure. A `fetch failed` / socket-closed error caused
+//           by a transient Kubo restart is exactly the case that should be retried; nothing did.
+//
+// Both tests inject the failure / timing deterministically (no reliance on a real Kubo shutdown,
+// which would break the shared test node), so each is RED against unmodified src and GREEN once
+// the ordering + bounded-retry fix lands.
+
+import { beforeAll, afterAll, describe, it, expect, vi } from "vitest";
+import PKCWsServer from "../../../../dist/node/rpc/src/index.js";
+import { mockPKC } from "../../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../../../test/helpers/conditional-tests.js";
+import { temporaryDirectory } from "tempy";
+
+import PKC from "../../../../dist/node/index.js";
+import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";
+import type { RpcLocalCommunity } from "../../../../dist/node/community/rpc-local-community.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { CreatePKCWsServerOptions } from "../../../../dist/node/rpc/src/types.js";
+
+type PKCWsServerType = Awaited<ReturnType<typeof PKCWsServer.PKCWsServer>>;
+
+// Interface for accessing private members under test
+interface PKCWsServerPrivateAccess {
+    _startedCommunities: Record<string, unknown>;
+    _autoStartOnBoot: boolean;
+    _autoStartPreviousCommunities: () => Promise<void>;
+    _internalStartCommunity: (address: string) => Promise<LocalCommunity>;
+    pkc: PKCType;
+}
+
+// `_addressRewriterSetupPromise` is private on PKC; this narrow view lets the test stub it.
+type PKCWithRewriterPromise = { _addressRewriterSetupPromise?: Promise<void> };
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// describeSkipIfRpc: these tests drive a real local Kubo through the RPC server and poke its
+// private auto-start internals; they cannot run against a remote RPC server.
+describeSkipIfRpc(`RPC auto-start survives boot-time Kubo restart (issue #158)`, async () => {
+    let basePKC: PKCType;
+
+    beforeAll(async () => {
+        basePKC = await mockPKC();
+    });
+
+    afterAll(async () => {
+        await basePKC.destroy();
+    });
+
+    // Helper: stand up an RPC server whose state DB already records `communityAddress` as
+    // wasStarted=1 / wasExplicitlyStopped=0, with auto-start NOT firing on boot (so the test
+    // controls exactly when and how `_autoStartPreviousCommunities()` runs).
+    const seedStartedCommunityState = async (dataPath: string, rpcServerPort: number): Promise<string> => {
+        const options: CreatePKCWsServerOptions = {
+            port: rpcServerPort,
+            pkcOptions: {
+                kuboRpcClientsOptions: basePKC.kuboRpcClientsOptions as CreatePKCWsServerOptions["pkcOptions"]["kuboRpcClientsOptions"],
+                httpRoutersOptions: basePKC.httpRoutersOptions,
+                dataPath
+            },
+            startStartedCommunitiesOnStartup: true
+        };
+        const rpcServer = await PKCWsServer.PKCWsServer(options);
+        const rpcUrl = `ws://localhost:${rpcServerPort}`;
+        const clientPKC = await PKC({ pkcRpcClientsOptions: [rpcUrl], dataPath: undefined, httpRoutersOptions: [] });
+        const community = (await clientPKC.createCommunity({})) as RpcLocalCommunity;
+        const communityAddress = community.address;
+        await community.start();
+        // Destroy without stopping (simulating crash/restart) -> state persisted wasStarted=1.
+        await clientPKC.destroy();
+        await rpcServer.destroy();
+        return communityAddress;
+    };
+
+    // Boot a fresh server with auto-start disabled so the boot-time fire-and-forget no-ops; the
+    // test flips `_autoStartOnBoot` on and invokes `_autoStartPreviousCommunities()` itself.
+    const bootServerWithoutAutoStart = async (dataPath: string, rpcServerPort: number): Promise<PKCWsServerType> => {
+        const options: CreatePKCWsServerOptions = {
+            port: rpcServerPort,
+            pkcOptions: {
+                kuboRpcClientsOptions: basePKC.kuboRpcClientsOptions as CreatePKCWsServerOptions["pkcOptions"]["kuboRpcClientsOptions"],
+                httpRoutersOptions: basePKC.httpRoutersOptions,
+                dataPath
+            },
+            startStartedCommunitiesOnStartup: false
+        };
+        return PKCWsServer.PKCWsServer(options);
+    };
+
+    const cleanup = async (rpcServer: PKCWsServerType, rpcServerPort: number, communityAddress: string) => {
+        const clientPKC = await PKC({
+            pkcRpcClientsOptions: [`ws://localhost:${rpcServerPort}`],
+            dataPath: undefined,
+            httpRoutersOptions: []
+        });
+        const community = (await clientPKC.createCommunity({ address: communityAddress })) as RpcLocalCommunity;
+        await community.stop().catch(() => {});
+        await community.delete().catch(() => {});
+        await clientPKC.destroy();
+        await rpcServer.destroy();
+    };
+
+    describe("Bug 1: auto-start waits for the HTTP-router / Kubo-restart reconcile before dispatching", () => {
+        it("does not dispatch community.start() until _addressRewriterSetupPromise resolves", async () => {
+            const dataPath = temporaryDirectory();
+            const rpcServerPort = 19170;
+            const communityAddress = await seedStartedCommunityState(dataPath, rpcServerPort);
+
+            const rpcServer = await bootServerWithoutAutoStart(dataPath, rpcServerPort);
+            const priv = rpcServer as unknown as PKCWsServerPrivateAccess;
+            priv._autoStartOnBoot = true;
+
+            // Simulate the background router reconcile: a promise that resolves only when we say so
+            // (in production it resolves after the /shutdown POST + Kubo restart settle).
+            let resolveRewriterSetup!: () => void;
+            (priv.pkc as unknown as PKCWithRewriterPromise)._addressRewriterSetupPromise = new Promise<void>((resolve) => {
+                resolveRewriterSetup = resolve;
+            });
+
+            let startDispatched = false;
+            const realInternalStart = priv._internalStartCommunity.bind(rpcServer);
+            vi.spyOn(
+                rpcServer as unknown as { _internalStartCommunity: (a: string) => Promise<LocalCommunity> },
+                "_internalStartCommunity"
+            ).mockImplementation(async (address: string) => {
+                startDispatched = true;
+                return realInternalStart(address);
+            });
+
+            // Kick off auto-start WITHOUT awaiting it.
+            const autoStartDone = priv._autoStartPreviousCommunities();
+
+            // Give auto-start ample time to (incorrectly) dispatch a start while the reconcile is
+            // still pending. With the fix it must block on _addressRewriterSetupPromise.
+            await sleep(1000);
+            expect(startDispatched, "auto-start dispatched community.start() before the Kubo-restart reconcile settled").to.be.false;
+
+            // Now let the reconcile settle; auto-start should proceed and start the community.
+            resolveRewriterSetup();
+            await autoStartDone;
+
+            expect(startDispatched).to.be.true;
+            expect(communityAddress in priv._startedCommunities).to.be.true;
+            expect(priv._startedCommunities[communityAddress]).to.not.equal("pending");
+
+            vi.restoreAllMocks();
+            await cleanup(rpcServer, rpcServerPort, communityAddress);
+        });
+    });
+
+    describe("Bug 2: auto-start retries a community whose start hit a transient Kubo blip", () => {
+        it("retries `fetch failed` and ends with the community started", async () => {
+            const dataPath = temporaryDirectory();
+            const rpcServerPort = 19171;
+            const communityAddress = await seedStartedCommunityState(dataPath, rpcServerPort);
+
+            const rpcServer = await bootServerWithoutAutoStart(dataPath, rpcServerPort);
+            const priv = rpcServer as unknown as PKCWsServerPrivateAccess;
+            priv._autoStartOnBoot = true;
+
+            // First two attempts fail exactly like an in-flight start hitting a dying Kubo socket;
+            // the third delegates to the real start, which succeeds against the (healthy) test node.
+            const realInternalStart = priv._internalStartCommunity.bind(rpcServer);
+            let attempts = 0;
+            vi.spyOn(
+                rpcServer as unknown as { _internalStartCommunity: (a: string) => Promise<LocalCommunity> },
+                "_internalStartCommunity"
+            ).mockImplementation(async (address: string) => {
+                attempts++;
+                if (attempts <= 2) throw new TypeError("fetch failed");
+                return realInternalStart(address);
+            });
+
+            await priv._autoStartPreviousCommunities();
+
+            expect(attempts, "auto-start did not retry the transient failure").to.be.greaterThanOrEqual(3);
+            expect(communityAddress in priv._startedCommunities, "community was left stopped after a transient failure").to.be.true;
+            expect(priv._startedCommunities[communityAddress]).to.not.equal("pending");
+
+            vi.restoreAllMocks();
+            await cleanup(rpcServer, rpcServerPort, communityAddress);
+        });
+    });
+});

--- a/src/runtime/node/address-rewriter-db.ts
+++ b/src/runtime/node/address-rewriter-db.ts
@@ -17,6 +17,10 @@ export type RequestLogEntry = {
     error?: string;
     retryCount?: number;
     bodyPreview?: string;
+    // Set true by the terminal callback (response/error/timeout) once the real outcome is known.
+    // Until then the entry is in flight and must not be flushed, otherwise its initial
+    // `success: false` placeholder would be persisted permanently (see issue #157).
+    completed?: boolean;
 };
 
 export type ReprovideLogEntry = {

--- a/src/runtime/node/addresses-rewriter-proxy-server.ts
+++ b/src/runtime/node/addresses-rewriter-proxy-server.ts
@@ -261,6 +261,7 @@ export class AddressesRewriterProxyServer {
                 requestLogEntry.success = false;
                 requestLogEntry.statusCode = 504;
                 requestLogEntry.error = "Request timeout";
+                requestLogEntry.completed = true;
                 // Add failed keys to retry set
                 if (requestLogEntry.keys) {
                     const sizeBefore = this._failedKeys.size;
@@ -288,6 +289,7 @@ export class AddressesRewriterProxyServer {
                 requestLogEntry.success = false;
                 requestLogEntry.statusCode = 500;
                 requestLogEntry.error = `Proxy error: ${e.message}`;
+                requestLogEntry.completed = true;
                 debug.trace(`Updated log entry with error for keys: ${requestLogEntry.keys.join(", ")}`);
                 // Add failed keys to retry set
                 if (requestLogEntry.keys) {
@@ -316,6 +318,7 @@ export class AddressesRewriterProxyServer {
             if (requestLogEntry) {
                 requestLogEntry.success = isSuccess;
                 requestLogEntry.statusCode = statusCode;
+                requestLogEntry.completed = true;
                 if (!isSuccess) {
                     requestLogEntry.error = `HTTP ${statusCode}`;
                     // Add failed keys to retry set
@@ -342,6 +345,7 @@ export class AddressesRewriterProxyServer {
                     requestLogEntry.success = false;
                     requestLogEntry.statusCode = 500;
                     requestLogEntry.error = `Proxy response error: ${err.message}`;
+                    requestLogEntry.completed = true;
                 }
                 proxyRes.destroy(err);
             });
@@ -466,8 +470,17 @@ export class AddressesRewriterProxyServer {
         }
 
         this._isWritingLogs = true;
-        const logsToWrite = [...this._requestLogBuffer];
-        this._requestLogBuffer = []; // Clear buffer immediately to prevent duplicates
+        // Only persist entries whose terminal callback has run; entries still in flight keep their
+        // initial `success: false` placeholder and would be persisted (and never corrected) if
+        // flushed now, so leave them buffered for a later tick. The 10s request timeout guarantees
+        // every entry eventually completes, so nothing is buffered forever. See issue #157.
+        const logsToWrite = this._requestLogBuffer.filter((entry) => entry.completed);
+        if (logsToWrite.length === 0) {
+            this._isWritingLogs = false;
+            return;
+        }
+        const inFlightLogs = this._requestLogBuffer.filter((entry) => !entry.completed);
+        this._requestLogBuffer = inFlightLogs; // Keep in-flight entries; clear flushed ones to prevent duplicates
 
         try {
             this._db.insertRequestLogs(logsToWrite);

--- a/test/node/address-rewriter-logging.unit.test.ts
+++ b/test/node/address-rewriter-logging.unit.test.ts
@@ -1,0 +1,171 @@
+// Regression test for https://github.com/pkcprotocol/pkc-js/issues/157
+//
+// The address-rewriter proxy creates a request-log entry with `success: false` and pushes it
+// to its in-memory buffer BEFORE the upstream request is sent. The buffer is flushed to SQLite
+// on a fixed 5s interval and then cleared. The real outcome is only written later, in-place, by
+// the `response`/`error`/`timeout` callbacks. If a flush lands while a request is still in flight,
+// the entry is persisted permanently as success=0 / status_code=NULL ("<empty>" failure) and is
+// NEVER corrected, even after the client receives 200. This over-reports failures.
+//
+// This test reproduces the race deterministically (no reliance on the 5s timer): it holds the
+// upstream response open, waits until the entry is buffered (request in flight), then manually
+// invokes the flush, exactly as the periodic timer would. It asserts the *correct* behaviour
+// (a request the client received 200 for must be logged success=1 / status 200), so it is RED
+// against unmodified src and GREEN once the logging is fixed.
+
+import { describe, it, expect, afterEach } from "vitest";
+import http from "node:http";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { AddressesRewriterProxyServer } from "../../dist/node/runtime/node/addresses-rewriter-proxy-server.js";
+
+const PEER_ID = "12D3KooWLNoZZe8n3UtsvRUcRPa4gmWLZsb5mF9Auns9NBhKXV9x";
+
+type RequestLogRow = {
+    success: number;
+    status_code: number | null;
+    error: string | null;
+    method: string;
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitFor = async (cond: () => boolean, label: string, timeoutMs = 5000) => {
+    const start = Date.now();
+    while (!cond()) {
+        if (Date.now() - start > timeoutMs) throw new Error(`Timed out waiting for: ${label}`);
+        await sleep(10);
+    }
+};
+
+describe("address-rewriter request logging (issue #157)", () => {
+    const cleanups: (() => Promise<void> | void)[] = [];
+
+    afterEach(async () => {
+        // Run cleanups in reverse registration order, then clear.
+        for (const cleanup of cleanups.reverse()) await cleanup();
+        cleanups.length = 0;
+    });
+
+    it("logs a successful (200) PUT as success=1 even when the flush fires while it is in flight", async () => {
+        // Logging must be enabled before the constructor reads the env var.
+        const prevEnv = process.env.ENABLE_LOGGING_OF_ADDRESS_REWRITER_PROXY;
+        process.env.ENABLE_LOGGING_OF_ADDRESS_REWRITER_PROXY = "1";
+        cleanups.push(() => {
+            if (prevEnv === undefined) delete process.env.ENABLE_LOGGING_OF_ADDRESS_REWRITER_PROXY;
+            else process.env.ENABLE_LOGGING_OF_ADDRESS_REWRITER_PROXY = prevEnv;
+        });
+
+        const dataPath = fs.mkdtempSync(path.join(os.tmpdir(), "rewriter-issue157-"));
+        cleanups.push(() => fs.rmSync(dataPath, { recursive: true, force: true }));
+
+        // 1. Upstream "HTTP router" that accepts the write but only responds 200 once we release it,
+        //    so we can deterministically keep the request in flight across the flush.
+        let releaseUpstream!: () => void;
+        const upstreamReleased = new Promise<void>((resolve) => (releaseUpstream = resolve));
+        const upstream = http.createServer((req, res) => {
+            req.resume(); // drain the body
+            req.on("end", async () => {
+                await upstreamReleased;
+                res.writeHead(200, { "Content-Type": "application/json" });
+                res.end(JSON.stringify({ ProvideResults: [] }));
+            });
+        });
+        await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+        const upstreamPort = (upstream.address() as { port: number }).port;
+        cleanups.push(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
+
+        // 2. Minimal kubo client stub: enough for the constructor + address-update loop.
+        const fakeKubo = {
+            id: async (): Promise<{ id: { toString: () => string }; addresses: string[] }> => ({
+                id: { toString: () => PEER_ID },
+                addresses: []
+            }),
+            swarm: { addrs: async (): Promise<unknown[]> => [] },
+            getEndpointConfig: () => ({ host: "127.0.0.1", port: "5001" }),
+            routing: { provide: async function* (): AsyncGenerator<never> {} }
+        };
+        const fakeStorage = {
+            setItem: async (): Promise<void> => {},
+            removeItem: async (): Promise<void> => {},
+            getItem: async (): Promise<undefined> => undefined
+        };
+
+        const proxy = new AddressesRewriterProxyServer({
+            kuboClients: [fakeKubo],
+            port: 0,
+            hostname: "127.0.0.1",
+            proxyTargetUrl: `http://127.0.0.1:${upstreamPort}`,
+            pkc: { _storage: fakeStorage, dataPath }
+        } as unknown as ConstructorParameters<typeof AddressesRewriterProxyServer>[0]);
+        await new Promise<void>((resolve) => proxy.listen(() => resolve()));
+        cleanups.push(() => proxy.destroy());
+        const proxyPort = (proxy.server.address() as { port: number }).port;
+
+        // 3. Fire a single provider-announce PUT through the proxy and track what the CLIENT sees.
+        const announceBody = JSON.stringify({
+            Providers: [
+                {
+                    Schema: "bitswap",
+                    Protocol: "transport-bitswap",
+                    Signature: "mFAKE",
+                    Payload: {
+                        ID: PEER_ID,
+                        Keys: ["bafkreie72q7iitojhbrtt576bum5wr3vu7zt5ep24e4gbazuvyzf6rzb54"],
+                        Addrs: []
+                    }
+                }
+            ]
+        });
+        let clientStatus: number | undefined;
+        const clientDone = new Promise<void>((resolve, reject) => {
+            const clientReq = http.request(
+                {
+                    host: "127.0.0.1",
+                    port: proxyPort,
+                    path: "/routing/v1/providers/",
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(announceBody) }
+                },
+                (resp) => {
+                    clientStatus = resp.statusCode;
+                    resp.resume();
+                    resp.on("end", () => resolve());
+                }
+            );
+            clientReq.on("error", reject);
+            clientReq.end(announceBody);
+        });
+
+        // 4. Wait until the entry is buffered (request created + in flight to the upstream).
+        const buffer = proxy["_requestLogBuffer"];
+        await waitFor(() => buffer.length === 1, "request log entry to be buffered");
+        expect(clientStatus, "request should still be in flight (upstream not released yet)").toBeUndefined();
+
+        // 5. Simulate the periodic 5s flush firing *while the request is in flight*.
+        await proxy["_writeRequestLogs"]();
+
+        // 6. Release the upstream so it returns 200, and wait for the client to actually receive it.
+        releaseUpstream();
+        await clientDone;
+        expect(clientStatus).toBe(200);
+
+        // 7. Flush again, mimicking the next periodic tick after completion.
+        await proxy["_writeRequestLogs"]();
+
+        // 8. Inspect what was persisted to SQLite.
+        const dbFile = path.join(dataPath, ".address-rewriter", `address_rewriter_127.0.0.1_5001_127.0.0.1_${upstreamPort}.db`);
+        const db = new Database(dbFile, { readonly: true });
+        const rows = db.prepare("SELECT success, status_code, error, method FROM request_logs").all() as RequestLogRow[];
+        db.close();
+
+        // The client received a 200, so the persisted log must reflect that, NOT a phantom failure.
+        const phantomFailures = rows.filter((row) => row.success === 0 && row.status_code === null);
+        expect(phantomFailures, "a 200 request must not be persisted as success=0 / status=NULL").toEqual([]);
+
+        const successRows = rows.filter((row) => row.success === 1 && row.status_code === 200);
+        expect(successRows.length, "the successful PUT should be logged exactly once as success=1 / status 200").toBe(1);
+    });
+});


### PR DESCRIPTION
Fixes #158.

## Problem

On RPC server boot, `_autoStartPreviousCommunities()` queues every previously-started community, but the concurrent embedded-Kubo restart (triggered by the background HTTP-router config reconcile, which POSTs `/shutdown` to the node) kills any `community.start()` that is in-flight during the restart window. Those communities failed once with `TypeError: fetch failed` and were never retried, so they stayed stopped even though the user never disabled them. In production, 11 of 65 communities were left stopped this way.

Two independent bugs combined:

1. **The Kubo restart raced auto-start instead of preceding it.** `createPKCWsServer` fired auto-start immediately while `pkc`'s background router reconcile (stored in `_addressRewriterSetupPromise`, not awaited) was still about to POST `/shutdown`. Because the rewriter proxy allocates fresh local ports on every boot, that shutdown fires on basically every boot.
2. **No retry on transient auto-start failure.** A `fetch failed` from a transient Kubo restart is exactly the case that should be retried, but nothing did.

## Fix

1. **Order the restart before auto-start.** `_autoStartPreviousCommunities()` now awaits a new `pkc._waitForHttpRoutersSetupToSettle()` before dispatching any `community.start()`, so it never runs against a Kubo node about to be shut down.
2. **Bounded retry (defense in depth).** Each per-community start is wrapped in a `p-retry` that retries transient Kubo network errors (`fetch failed` / socket closed / `ECONNREFUSED` / `ECONNRESET`) with exponential backoff (up to ~89s, covering the observed ~30-60s restart window). Non-transient errors abort immediately so real failures are not masked.

## Tests

New `src/rpc/test/node/rpc.auto-start-kubo-restart.test.ts` with one deterministic test per bug:

- **Bug 1** — stubs `_addressRewriterSetupPromise` with a controllable promise and asserts no `community.start()` is dispatched until it resolves.
- **Bug 2** — injects two `fetch failed` failures before delegating to the real start, and asserts the community ends up started (retried).

Both are RED against unmodified `src/` and GREEN with the fix. The existing `rpc.auto-start.test.ts` suite (12 tests) still passes. The tests inject the failure/timing deterministically rather than shutting down the shared test Kubo.