### PR TITLE
feat(local-community): re-provide connection CIDs when browser-dialable addresses rotate

### DIFF
--- a/src/runtime/node/community/local-community.ts
+++ b/src/runtime/node/community/local-community.ts
@@ -116,6 +116,11 @@ export class LocalCommunity extends RpcLocalCommunity implements CreateNewLocalC
     _firstUpdateAfterStart: boolean = true;
     _internalStateUpdateId: InternalCommunityRecordBeforeFirstUpdateType["_internalStateUpdateId"] = "";
     _lastPubsubTopicRoutingProvideAt?: number = undefined;
+    // Browser-dialable (WSS/WebRTC) self-addresses last announced for the connection-critical CIDs.
+    // When this set changes (checked once per publish-loop cycle, throttled) we re-provide so HTTP routers
+    // stop serving stale addresses (see reprovide-on-address-change.ts).
+    _lastProvidedBrowserDialableSelfAddrs?: string[] = undefined;
+    _lastAddressReprovideCheckAt?: number = undefined;
     _mirroredStartedOrUpdatingCommunity?: { community: LocalCommunity } & Pick<
         CommunityEvents,
         | "error"

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -20,6 +20,7 @@ import { LocalCommunity } from "../local-community.js";
 import { processStartedCommunities } from "./registry.js";
 import { pubsubTopicWithfallback } from "./comment-updates.js";
 import { providePubsubTopicRoutingCidsIfNeeded } from "./pubsub.js";
+import { reprovideOnAddressChangeIfDue } from "./reprovide-on-address-change.js";
 import { repinCommentUpdateIfNeeded, unpinStaleCids } from "./cleanup.js";
 import {
     importCommunitySignerIntoIpfsIfNeeded,
@@ -58,6 +59,12 @@ export async function publishLoop(community: LocalCommunity, syncIntervalMs: num
     while (!shouldStopPublishLoop()) {
         try {
             await syncIpnsWithDb(community);
+            // Re-announce browser-dialable (WSS/WebRTC) addresses to HTTP routers when they rotate, so browsers
+            // don't hit NoValidAddressesError against stale addresses. Throttled internally; runs inside the
+            // publish loop so it's torn down with the loop on stop(). Its own failures must not break publishing.
+            await reprovideOnAddressChangeIfDue(community).catch((e) =>
+                log.error("Failed to re-provide connection CIDs on address change", e)
+            );
         } catch (e) {
             community.emit("error", e as Error);
         } finally {
@@ -102,6 +109,9 @@ export async function start(community: LocalCommunity) {
         throw new PKCError("ERR_NEED_TO_STOP_UPDATING_COMMUNITY_BEFORE_STARTING", { address: community.address });
     community._stopHasBeenCalled = false;
     community._firstUpdateAfterStart = true;
+    // Re-baseline address-change re-provide for this run (start() provides everything fresh below).
+    community._lastProvidedBrowserDialableSelfAddrs = undefined;
+    community._lastAddressReprovideCheckAt = undefined;
     if (!community._clientsManager.getDefaultKuboRpcClientOrHelia())
         throw Error("You need to define an IPFS client in your pkc instance to be able to start a local community");
     await community.initDbHandlerIfNeeded();

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -139,6 +139,8 @@ export async function start(community: LocalCommunity) {
         await setChallengesToDefaultIfNotDefined(community, log);
         // Import community keys onto ipfs node
         await importCommunitySignerIntoIpfsIfNeeded(community);
+        // Force-provides the never-changing pubsub-topic routing CIDs (the connection-critical CIDs the
+        // address-change re-provide watches) with the node's current browser-dialable addresses on start.
         await providePubsubTopicRoutingCidsIfNeeded(community, true);
 
         community._communityUpdateTrigger = true;

--- a/src/runtime/node/community/local-community/pubsub.ts
+++ b/src/runtime/node/community/local-community/pubsub.ts
@@ -20,7 +20,7 @@ export async function listenToIncomingRequests(community: LocalCommunity) {
 
 export async function providePubsubTopicRoutingCidsIfNeeded(community: LocalCommunity, force = false) {
     const log = Logger("pkc-js:local-community:_providePubsubTopicRoutingCidsIfNeeded");
-    const reprovideIntervalMs = 6 * 60 * 60 * 1000;
+    const reprovideIntervalMs = 1 * 60 * 60 * 1000; // re-provide the pubsub-topic routing CIDs hourly so their HTTP-router records keep fresh addresses
     const now = Date.now();
     if (!force && community._lastPubsubTopicRoutingProvideAt && now - community._lastPubsubTopicRoutingProvideAt < reprovideIntervalMs)
         return;

--- a/src/runtime/node/community/local-community/reprovide-on-address-change.ts
+++ b/src/runtime/node/community/local-community/reprovide-on-address-change.ts
@@ -20,7 +20,6 @@ export type ReprovideKuboRpcClient = {
 // LocalCommunity satisfies this, and it keeps the function testable in isolation.
 export type AddressChangeReprovidable = {
     address: string;
-    updateCid?: string;
     pubsubTopicRoutingCid?: string;
     ipnsPubsubTopicRoutingCid?: string;
     _lastProvidedBrowserDialableSelfAddrs?: string[];
@@ -56,12 +55,13 @@ export async function getBrowserDialableSelfAddrs(client: ReprovideKuboRpcClient
 }
 
 // The CIDs a browser needs a fresh provider record for in order to bootstrap a connection to the community:
-// the community record itself, plus the pubsub-topic routing blocks used to find challenge / ipns-over-pubsub peers.
+// the pubsub-topic routing blocks used to find challenge / ipns-over-pubsub peers. These are derived
+// deterministically from the (never-changing) topics, so their router records are exactly what goes stale
+// when the node's addresses rotate. updateCid is intentionally excluded: it rotates every <=15 min and is
+// re-provided with fresh addresses on every publish, so it is already self-healing.
 function connectionCriticalCids(community: AddressChangeReprovidable): string[] {
     return remeda.unique(
-        [community.updateCid, community.pubsubTopicRoutingCid, community.ipnsPubsubTopicRoutingCid].filter(
-            (cid): cid is string => typeof cid === "string"
-        )
+        [community.pubsubTopicRoutingCid, community.ipnsPubsubTopicRoutingCid].filter((cid): cid is string => typeof cid === "string")
     );
 }
 
@@ -70,26 +70,24 @@ function connectionCriticalCids(community: AddressChangeReprovidable): string[] 
  * have changed since the last provide. This pushes the current addresses to the HTTP routers (via the
  * address-rewriter proxy) so browsers don't get NoValidAddressesError against stale/dead addresses.
  *
- * The first observation only establishes a baseline (start() already provided everything with fresh
- * addresses); subsequent changes trigger a re-provide. Pass force=true to provide regardless.
+ * The first observation only establishes a baseline (start() already force-provides these CIDs with fresh
+ * addresses via providePubsubTopicRoutingCidsIfNeeded); subsequent changes trigger a re-provide.
  */
 export async function reprovideConnectionCidsIfBrowserAddrsChanged(
-    community: AddressChangeReprovidable,
-    force = false
+    community: AddressChangeReprovidable
 ): Promise<{ reprovided: boolean; providedCids: string[]; browserAddrs: string[] }> {
     const log = Logger("pkc-js:local-community:_reprovideConnectionCidsIfBrowserAddrsChanged");
     const client = community._clientsManager.getDefaultKuboRpcClient()._client;
     const current = await getBrowserDialableSelfAddrs(client);
     const previous = community._lastProvidedBrowserDialableSelfAddrs;
 
-    const baselineOnly = previous === undefined && !force;
-    if (baselineOnly) {
+    if (previous === undefined) {
+        // First observation: just establish the baseline; start() already provided these CIDs with fresh addresses.
         community._lastProvidedBrowserDialableSelfAddrs = current;
         return { reprovided: false, providedCids: [], browserAddrs: current };
     }
 
-    const changed = previous === undefined || !remeda.isDeepEqual(previous, current);
-    if (!force && !changed) return { reprovided: false, providedCids: [], browserAddrs: current };
+    if (remeda.isDeepEqual(previous, current)) return { reprovided: false, providedCids: [], browserAddrs: current };
 
     // Record the snapshot before providing so a slow/failing provide doesn't make us re-announce every tick.
     community._lastProvidedBrowserDialableSelfAddrs = current;

--- a/src/runtime/node/community/local-community/reprovide-on-address-change.ts
+++ b/src/runtime/node/community/local-community/reprovide-on-address-change.ts
@@ -1,0 +1,138 @@
+import Logger from "../../../../logger.js";
+import * as remeda from "remeda";
+import { CID } from "multiformats/cid";
+import { normalizeSelfAddrsForProvider } from "../../addresses-rewriter-proxy-server.js";
+
+// How often LocalCommunity polls its own node for browser-dialable address changes.
+// Matches the address-rewriter proxy's own 60s refresh so a rotation is noticed within one cycle.
+export const ADDRESS_REPROVIDE_POLL_INTERVAL_MS = 60 * 1000;
+
+// Minimal structural view of the kubo rpc client used here. Kept narrow so the core logic can be
+// unit-tested with a fake client without dragging in the full kubo-rpc-client surface. The real
+// LocalCommunity client is structurally assignable to this.
+export type ReprovideKuboRpcClient = {
+    id: () => Promise<{ id: { toString: () => string }; addresses: Array<{ toString: () => string }> }>;
+    swarm: { addrs: () => Promise<Array<{ id: { toString: () => string }; addrs: Array<{ toString: () => string }> }>> };
+    routing: { provide: (cid: CID, options?: { recursive?: boolean }) => AsyncIterable<unknown> };
+};
+
+// Minimal structural view of LocalCommunity needed to detect address changes and re-provide. The full
+// LocalCommunity satisfies this, and it keeps the function testable in isolation.
+export type AddressChangeReprovidable = {
+    address: string;
+    updateCid?: string;
+    pubsubTopicRoutingCid?: string;
+    ipnsPubsubTopicRoutingCid?: string;
+    _lastProvidedBrowserDialableSelfAddrs?: string[];
+    _lastAddressReprovideCheckAt?: number;
+    _clientsManager: { getDefaultKuboRpcClient: () => { _client: ReprovideKuboRpcClient } };
+};
+
+// Transports a browser can actually dial. These are exactly the addresses that rotate/expire frequently
+// (WebRTC-direct certhash rotation, AutoTLS WSS) and that kubo prunes from HTTP-router announces, so they
+// are the ones whose change must trigger a fresh provide. Plain TCP/QUIC changes are irrelevant to browsers.
+export function isBrowserDialableAddr(addr: string): boolean {
+    return addr.includes("/webrtc") || addr.includes("/ws");
+}
+
+// Fetch the node's current browser-dialable self-addresses, normalized the same way the address-rewriter
+// proxy normalizes them before announcing (strip the trailing /p2p/<peerId>, dedupe), then sorted so the
+// result can be compared by value across calls.
+export async function getBrowserDialableSelfAddrs(client: ReprovideKuboRpcClient): Promise<string[]> {
+    const idRes = await client.id();
+    const peerId = idRes.id.toString();
+    const swarmAddrsRes = await client.swarm.addrs();
+    const swarmListeningAddresses = swarmAddrsRes.filter((swarmAddr) => swarmAddr.id.toString() === peerId);
+
+    const normalized = normalizeSelfAddrsForProvider(
+        [
+            ...idRes.addresses.map((addr) => addr.toString()),
+            ...remeda.flatten(swarmListeningAddresses.map((swarmAddr) => swarmAddr.addrs.map((addr) => addr.toString())))
+        ],
+        peerId
+    );
+
+    return remeda.unique(normalized.filter(isBrowserDialableAddr)).sort();
+}
+
+// The CIDs a browser needs a fresh provider record for in order to bootstrap a connection to the community:
+// the community record itself, plus the pubsub-topic routing blocks used to find challenge / ipns-over-pubsub peers.
+function connectionCriticalCids(community: AddressChangeReprovidable): string[] {
+    return remeda.unique(
+        [community.updateCid, community.pubsubTopicRoutingCid, community.ipnsPubsubTopicRoutingCid].filter(
+            (cid): cid is string => typeof cid === "string"
+        )
+    );
+}
+
+/**
+ * Re-provide the connection-critical CIDs when the node's browser-dialable (WSS/WebRTC) self-addresses
+ * have changed since the last provide. This pushes the current addresses to the HTTP routers (via the
+ * address-rewriter proxy) so browsers don't get NoValidAddressesError against stale/dead addresses.
+ *
+ * The first observation only establishes a baseline (start() already provided everything with fresh
+ * addresses); subsequent changes trigger a re-provide. Pass force=true to provide regardless.
+ */
+export async function reprovideConnectionCidsIfBrowserAddrsChanged(
+    community: AddressChangeReprovidable,
+    force = false
+): Promise<{ reprovided: boolean; providedCids: string[]; browserAddrs: string[] }> {
+    const log = Logger("pkc-js:local-community:_reprovideConnectionCidsIfBrowserAddrsChanged");
+    const client = community._clientsManager.getDefaultKuboRpcClient()._client;
+    const current = await getBrowserDialableSelfAddrs(client);
+    const previous = community._lastProvidedBrowserDialableSelfAddrs;
+
+    const baselineOnly = previous === undefined && !force;
+    if (baselineOnly) {
+        community._lastProvidedBrowserDialableSelfAddrs = current;
+        return { reprovided: false, providedCids: [], browserAddrs: current };
+    }
+
+    const changed = previous === undefined || !remeda.isDeepEqual(previous, current);
+    if (!force && !changed) return { reprovided: false, providedCids: [], browserAddrs: current };
+
+    // Record the snapshot before providing so a slow/failing provide doesn't make us re-announce every tick.
+    community._lastProvidedBrowserDialableSelfAddrs = current;
+
+    const cidStrings = connectionCriticalCids(community);
+    const providedCids: string[] = [];
+    for (const cidString of cidStrings) {
+        let cid: CID;
+        try {
+            cid = CID.parse(cidString);
+        } catch (e) {
+            log.error(`Failed to parse connection-critical CID (${cidString}) for community (${community.address})`, e);
+            continue;
+        }
+        try {
+            const provideEvents = client.routing.provide(cid, { recursive: true });
+            for await (const event of provideEvents) log.trace(`Provide event for ${cidString}:`, event);
+            providedCids.push(cidString);
+        } catch (e) {
+            log.error(`Failed to re-provide connection-critical CID (${cidString}) for community (${community.address})`, e);
+        }
+    }
+
+    log(
+        `Browser-dialable addresses of community (${community.address}) changed; re-provided ${providedCids.length}/${cidStrings.length} connection-critical CIDs`,
+        { browserAddrs: current }
+    );
+
+    return { reprovided: providedCids.length > 0, providedCids, browserAddrs: current };
+}
+
+/**
+ * Publish-loop entry point. The publish loop runs once per sync cycle (and faster during bursts), so this
+ * throttles the kubo id()/swarm.addrs() poll to ADDRESS_REPROVIDE_POLL_INTERVAL_MS before delegating to the
+ * core change-detection. Lives inside the publish loop so it's torn down together with the loop on stop().
+ */
+export async function reprovideOnAddressChangeIfDue(community: AddressChangeReprovidable): Promise<void> {
+    const now = Date.now();
+    if (
+        typeof community._lastAddressReprovideCheckAt === "number" &&
+        now - community._lastAddressReprovideCheckAt < ADDRESS_REPROVIDE_POLL_INTERVAL_MS
+    )
+        return;
+    community._lastAddressReprovideCheckAt = now;
+    await reprovideConnectionCidsIfBrowserAddrsChanged(community);
+}

--- a/test/node/community/reprovide-on-address-change.unit.test.ts
+++ b/test/node/community/reprovide-on-address-change.unit.test.ts
@@ -12,9 +12,12 @@ import type {
 // connect: when the node's browser-dialable (WSS/WebRTC) self-addresses rotate, the connection-critical
 // CIDs must be re-provided so the address-rewriter proxy re-injects the fresh addresses into the HTTP
 // routers. A pure-TCP/quic address change must NOT trigger a re-provide (browsers can't dial those).
+//
+// The connection-critical CIDs are the two *never-changing* pubsub-topic routing CIDs (challenge topic +
+// ipns-over-pubsub topic). updateCid is intentionally NOT here: it rotates every <=15 min and is re-provided
+// with fresh addresses on every publish, so it is already self-healing.
 
-// Three valid CIDv1 strings standing in for updateCid / pubsubTopicRoutingCid / ipnsPubsubTopicRoutingCid.
-const UPDATE_CID = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+// Two valid CIDv1 strings standing in for pubsubTopicRoutingCid / ipnsPubsubTopicRoutingCid.
 const PUBSUB_ROUTING_CID = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku";
 const IPNS_PUBSUB_ROUTING_CID = "bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354";
 
@@ -52,7 +55,6 @@ function makeClient(initialIdAddrs: string[]): {
 function makeCommunity(client: ReprovideKuboRpcClient): AddressChangeReprovidable {
     return {
         address: "test.community",
-        updateCid: UPDATE_CID,
         pubsubTopicRoutingCid: PUBSUB_ROUTING_CID,
         ipnsPubsubTopicRoutingCid: IPNS_PUBSUB_ROUTING_CID,
         _lastProvidedBrowserDialableSelfAddrs: undefined,
@@ -98,12 +100,12 @@ describe("reprovideConnectionCidsIfBrowserAddrsChanged", () => {
         expect(provideCalls).toEqual([]);
     });
 
-    it("re-provides the connection-critical CIDs when a WSS address rotates", async () => {
+    it("re-provides the pubsub routing CIDs when a WSS address rotates", async () => {
         await reprovideConnectionCidsIfBrowserAddrsChanged(community); // baseline with WSS_ADDR_A
         setIdAddrs([TCP_ADDR, WSS_ADDR_B]); // AutoTLS WSS rotated
         const res = await reprovideConnectionCidsIfBrowserAddrsChanged(community);
         expect(res.reprovided).toBe(true);
-        expect(provideCalls).toEqual([UPDATE_CID, PUBSUB_ROUTING_CID, IPNS_PUBSUB_ROUTING_CID]);
+        expect(provideCalls).toEqual([PUBSUB_ROUTING_CID, IPNS_PUBSUB_ROUTING_CID]);
         expect(community._lastProvidedBrowserDialableSelfAddrs).toEqual([WSS_ADDR_B]);
     });
 
@@ -112,7 +114,7 @@ describe("reprovideConnectionCidsIfBrowserAddrsChanged", () => {
         setIdAddrs([TCP_ADDR, WSS_ADDR_A, WEBRTC_ADDR]);
         const res = await reprovideConnectionCidsIfBrowserAddrsChanged(community);
         expect(res.reprovided).toBe(true);
-        expect(provideCalls).toEqual([UPDATE_CID, PUBSUB_ROUTING_CID, IPNS_PUBSUB_ROUTING_CID]);
+        expect(provideCalls).toEqual([PUBSUB_ROUTING_CID, IPNS_PUBSUB_ROUTING_CID]);
     });
 
     it("does NOT re-provide when only a non-browser-dialable (TCP) address changes", async () => {
@@ -123,19 +125,12 @@ describe("reprovideConnectionCidsIfBrowserAddrsChanged", () => {
         expect(provideCalls).toEqual([]);
     });
 
-    it("skips CIDs that are not yet known (e.g. updateCid before first publish)", async () => {
-        community.updateCid = undefined;
+    it("skips routing CIDs that are not yet known", async () => {
+        community.pubsubTopicRoutingCid = undefined;
         await reprovideConnectionCidsIfBrowserAddrsChanged(community); // baseline
         setIdAddrs([TCP_ADDR, WSS_ADDR_B]);
         const res = await reprovideConnectionCidsIfBrowserAddrsChanged(community);
         expect(res.reprovided).toBe(true);
-        expect(provideCalls).toEqual([PUBSUB_ROUTING_CID, IPNS_PUBSUB_ROUTING_CID]);
-    });
-
-    it("force re-provides even when addresses are unchanged", async () => {
-        await reprovideConnectionCidsIfBrowserAddrsChanged(community); // baseline
-        const res = await reprovideConnectionCidsIfBrowserAddrsChanged(community, true);
-        expect(res.reprovided).toBe(true);
-        expect(provideCalls).toEqual([UPDATE_CID, PUBSUB_ROUTING_CID, IPNS_PUBSUB_ROUTING_CID]);
+        expect(provideCalls).toEqual([IPNS_PUBSUB_ROUTING_CID]);
     });
 });

--- a/test/node/community/reprovide-on-address-change.unit.test.ts
+++ b/test/node/community/reprovide-on-address-change.unit.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+    isBrowserDialableAddr,
+    reprovideConnectionCidsIfBrowserAddrsChanged
+} from "../../../dist/node/runtime/node/community/local-community/reprovide-on-address-change.js";
+import type {
+    AddressChangeReprovidable,
+    ReprovideKuboRpcClient
+} from "../../../dist/node/runtime/node/community/local-community/reprovide-on-address-change.js";
+
+// Pure unit test (no kubo / no PKC). Pins down the publisher-side behaviour that keeps browsers able to
+// connect: when the node's browser-dialable (WSS/WebRTC) self-addresses rotate, the connection-critical
+// CIDs must be re-provided so the address-rewriter proxy re-injects the fresh addresses into the HTTP
+// routers. A pure-TCP/quic address change must NOT trigger a re-provide (browsers can't dial those).
+
+// Three valid CIDv1 strings standing in for updateCid / pubsubTopicRoutingCid / ipnsPubsubTopicRoutingCid.
+const UPDATE_CID = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+const PUBSUB_ROUTING_CID = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku";
+const IPNS_PUBSUB_ROUTING_CID = "bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354";
+
+const PEER_ID = "12D3KooWBy7Vn1ofw2Rou8PMVuTpfNUMfQjcGZb6T8aZ3X2D6oQg";
+const TCP_ADDR = `/ip4/1.2.3.4/tcp/4001`;
+const WSS_ADDR_A = `/dns4/example-a.libp2p.direct/tcp/443/tls/ws`;
+const WSS_ADDR_B = `/dns4/example-b.libp2p.direct/tcp/443/tls/ws`;
+const WEBRTC_ADDR = `/ip4/1.2.3.4/udp/4001/webrtc-direct/certhash/uEiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`;
+
+function makeClient(initialIdAddrs: string[]): {
+    client: ReprovideKuboRpcClient;
+    provideCalls: string[];
+    setIdAddrs: (a: string[]) => void;
+} {
+    let idAddrs = initialIdAddrs;
+    const provideCalls: string[] = [];
+    const client: ReprovideKuboRpcClient = {
+        id: async () => ({
+            id: { toString: () => PEER_ID },
+            addresses: idAddrs.map((a) => ({ toString: () => `${a}/p2p/${PEER_ID}` }))
+        }),
+        swarm: {
+            addrs: async () => []
+        },
+        routing: {
+            provide: async function* (cid) {
+                provideCalls.push(cid.toString());
+                // yield nothing
+            }
+        }
+    };
+    return { client, provideCalls, setIdAddrs: (a: string[]) => (idAddrs = a) };
+}
+
+function makeCommunity(client: ReprovideKuboRpcClient): AddressChangeReprovidable {
+    return {
+        address: "test.community",
+        updateCid: UPDATE_CID,
+        pubsubTopicRoutingCid: PUBSUB_ROUTING_CID,
+        ipnsPubsubTopicRoutingCid: IPNS_PUBSUB_ROUTING_CID,
+        _lastProvidedBrowserDialableSelfAddrs: undefined,
+        _clientsManager: {
+            getDefaultKuboRpcClient: () => ({ _client: client })
+        }
+    };
+}
+
+describe("isBrowserDialableAddr", () => {
+    it("keeps WSS and WebRTC addresses", () => {
+        expect(isBrowserDialableAddr(WSS_ADDR_A)).toBe(true);
+        expect(isBrowserDialableAddr(WEBRTC_ADDR)).toBe(true);
+    });
+    it("rejects plain TCP/QUIC addresses a browser cannot dial", () => {
+        expect(isBrowserDialableAddr(TCP_ADDR)).toBe(false);
+        expect(isBrowserDialableAddr("/ip4/1.2.3.4/udp/4001/quic-v1")).toBe(false);
+    });
+});
+
+describe("reprovideConnectionCidsIfBrowserAddrsChanged", () => {
+    let client: ReprovideKuboRpcClient;
+    let provideCalls: string[];
+    let setIdAddrs: (a: string[]) => void;
+    let community: AddressChangeReprovidable;
+
+    beforeEach(() => {
+        ({ client, provideCalls, setIdAddrs } = makeClient([TCP_ADDR, WSS_ADDR_A]));
+        community = makeCommunity(client);
+    });
+
+    it("establishes a baseline on the first observation without re-providing", async () => {
+        const res = await reprovideConnectionCidsIfBrowserAddrsChanged(community);
+        expect(res.reprovided).toBe(false);
+        expect(provideCalls).toEqual([]);
+        expect(community._lastProvidedBrowserDialableSelfAddrs).toEqual([WSS_ADDR_A]);
+    });
+
+    it("does not re-provide when the browser-dialable addresses are unchanged", async () => {
+        await reprovideConnectionCidsIfBrowserAddrsChanged(community); // baseline
+        const res = await reprovideConnectionCidsIfBrowserAddrsChanged(community);
+        expect(res.reprovided).toBe(false);
+        expect(provideCalls).toEqual([]);
+    });
+
+    it("re-provides the connection-critical CIDs when a WSS address rotates", async () => {
+        await reprovideConnectionCidsIfBrowserAddrsChanged(community); // baseline with WSS_ADDR_A
+        setIdAddrs([TCP_ADDR, WSS_ADDR_B]); // AutoTLS WSS rotated
+        const res = await reprovideConnectionCidsIfBrowserAddrsChanged(community);
+        expect(res.reprovided).toBe(true);
+        expect(provideCalls).toEqual([UPDATE_CID, PUBSUB_ROUTING_CID, IPNS_PUBSUB_ROUTING_CID]);
+        expect(community._lastProvidedBrowserDialableSelfAddrs).toEqual([WSS_ADDR_B]);
+    });
+
+    it("re-provides when a WebRTC address appears", async () => {
+        await reprovideConnectionCidsIfBrowserAddrsChanged(community); // baseline
+        setIdAddrs([TCP_ADDR, WSS_ADDR_A, WEBRTC_ADDR]);
+        const res = await reprovideConnectionCidsIfBrowserAddrsChanged(community);
+        expect(res.reprovided).toBe(true);
+        expect(provideCalls).toEqual([UPDATE_CID, PUBSUB_ROUTING_CID, IPNS_PUBSUB_ROUTING_CID]);
+    });
+
+    it("does NOT re-provide when only a non-browser-dialable (TCP) address changes", async () => {
+        await reprovideConnectionCidsIfBrowserAddrsChanged(community); // baseline
+        setIdAddrs(["/ip4/9.9.9.9/tcp/4001", WSS_ADDR_A]); // TCP changed, WSS same
+        const res = await reprovideConnectionCidsIfBrowserAddrsChanged(community);
+        expect(res.reprovided).toBe(false);
+        expect(provideCalls).toEqual([]);
+    });
+
+    it("skips CIDs that are not yet known (e.g. updateCid before first publish)", async () => {
+        community.updateCid = undefined;
+        await reprovideConnectionCidsIfBrowserAddrsChanged(community); // baseline
+        setIdAddrs([TCP_ADDR, WSS_ADDR_B]);
+        const res = await reprovideConnectionCidsIfBrowserAddrsChanged(community);
+        expect(res.reprovided).toBe(true);
+        expect(provideCalls).toEqual([PUBSUB_ROUTING_CID, IPNS_PUBSUB_ROUTING_CID]);
+    });
+
+    it("force re-provides even when addresses are unchanged", async () => {
+        await reprovideConnectionCidsIfBrowserAddrsChanged(community); // baseline
+        const res = await reprovideConnectionCidsIfBrowserAddrsChanged(community, true);
+        expect(res.reprovided).toBe(true);
+        expect(provideCalls).toEqual([UPDATE_CID, PUBSUB_ROUTING_CID, IPNS_PUBSUB_ROUTING_CID]);
+    });
+});


### PR DESCRIPTION
Closes #161

## Problem

Consumers connect to a community via `createCommunity({name, publicKey})` → helia → HTTP routers. To find peers for the community's pubsub topics, browsers look up the **pubsub-topic routing CIDs** on the routers and dial the announced multiaddrs, which must be **browser-dialable** (WSS / WebRTC-direct).

Those addresses rotate/expire frequently (WebRTC-direct certhash rotation, AutoTLS WSS), and kubo prunes WSS/webrtc-direct from HTTP-router announces shortly after boot. The address-rewriter proxy refreshes the node's addresses in memory every 60s, but those fresh addresses only reach the routers when a `routing.provide` actually fires.

The two pubsub-topic routing CIDs are derived **deterministically from the (never-changing) topics**, so previously they were only re-provided at start and then every **6 hours**. When the node's WSS/WebRTC addresses rotate in between, the routers keep serving stale/dead addresses for those CIDs, and browsers get `NoValidAddressesError`.

(`updateCid` is intentionally out of scope: it rotates every ≤15 min and is re-provided with fresh addresses on every publish, so its provider record is already self-healing.)

## Fix

Two complementary mechanisms for the never-changing pubsub-topic routing CIDs (`pubsubTopicRoutingCid`, `ipnsPubsubTopicRoutingCid`):

1. **Reactive (address-change-triggered).** The publish loop checks the node's browser-dialable self-addresses once per sync cycle (throttled to 60s). When that set changes, it re-provides the two CIDs so the address-rewriter proxy re-injects the current addresses into the routers.
   - Only **browser-dialable** address changes trigger a re-provide; plain TCP/QUIC churn does not.
   - Runs **inside the publish loop**, so it is torn down with the loop on `community.stop()` — no separate interval to track.
   - `start()` already force-provides these two CIDs with fresh addresses via `providePubsubTopicRoutingCidsIfNeeded(community, true)`; the publish loop seeds its address baseline on the first observation and re-announces on subsequent changes.

2. **Fixed-cadence backstop.** Lowered the `providePubsubTopicRoutingCidsIfNeeded` re-provide interval from **6h → 1h**, so even if address-change detection misses a rotation, the records are refreshed at least hourly.

## Implementation

- New `reprovide-on-address-change.ts`: pure change-detection core (`reprovideConnectionCidsIfBrowserAddrsChanged`) + a throttled publish-loop entry point (`reprovideOnAddressChangeIfDue`). The core takes a narrow structural type so it is unit-tested in isolation (no kubo / no PKC, fully typed, no `any`).
- `lifecycle.ts`: call `reprovideOnAddressChangeIfDue` each publish-loop iteration (its failures are logged and never break publishing); re-baseline on `start()`.
- `local-community.ts`: two small state fields (`_lastProvidedBrowserDialableSelfAddrs`, `_lastAddressReprovideCheckAt`).
- `pubsub.ts`: `reprovideIntervalMs` 6h → 1h.

## Testing

- New `test/node/community/reprovide-on-address-change.unit.test.ts` (8 cases): baseline-on-first-observation, no re-provide when unchanged, re-provide on WSS rotation, re-provide on WebRTC appearance, **no** re-provide on TCP-only change, and skipping not-yet-known routing CIDs. Written test-first (red against absent module, green after).
- `npm run build` passes; `tsc --project test/tsconfig.json --noEmit` passes.
- `create.community` and `local.publishing.community` integration suites pass (start/stop/publish path unaffected).