### PR TITLE
fix(local-community): re-provide pubsub-topic routing CIDs hourly

### DIFF
--- a/src/runtime/node/community/local-community/pubsub.ts
+++ b/src/runtime/node/community/local-community/pubsub.ts
@@ -20,7 +20,7 @@ export async function listenToIncomingRequests(community: LocalCommunity) {
 
 export async function providePubsubTopicRoutingCidsIfNeeded(community: LocalCommunity, force = false) {
     const log = Logger("pkc-js:local-community:_providePubsubTopicRoutingCidsIfNeeded");
-    const reprovideIntervalMs = 6 * 60 * 60 * 1000;
+    const reprovideIntervalMs = 1 * 60 * 60 * 1000; // re-provide the pubsub-topic routing CIDs hourly so their HTTP-router records keep fresh addresses
     const now = Date.now();
     if (!force && community._lastPubsubTopicRoutingProvideAt && now - community._lastPubsubTopicRoutingProvideAt < reprovideIntervalMs)
         return;


### PR DESCRIPTION
Lowers the re-provide interval for the deterministic pubsub-topic routing CIDs (challenge topic + ipns-over-pubsub topic) in `providePubsubTopicRoutingCidsIfNeeded` from **6 hours to 1 hour**.

## Why

These two CIDs never change, so their HTTP-router provider records are exactly what go stale when the node's browser-dialable (WSS/WebRTC) addresses rotate. A 6h refresh meant the routers could serve dead addresses for those CIDs for up to 6h, causing browsers (connecting via `createCommunity({name, publicKey})` → helia → HTTP routers) to hit `NoValidAddressesError`.

This is a complementary, fixed-cadence backstop to the address-change-triggered re-provide in #162: even if address-change detection misses a rotation, the records are now refreshed at least hourly.

## Change

One constant: `reprovideIntervalMs` 6h → 1h.

`npm run build` passes.