### PR TITLE
feat(local-community): allow mods to reply to locked posts

### DIFF
--- a/src/runtime/node/community/local-community/publication-validation.ts
+++ b/src/runtime/node/community/local-community/publication-validation.ts
@@ -227,7 +227,12 @@ async function checkParentAndPostState(
 
         if (isPostDeletedQueryRes?.deleted && !request.commentModeration) return messages.ERR_COMMUNITY_PUBLICATION_POST_HAS_BEEN_DELETED;
 
-        if (postFlags.locked && !request.commentModeration) return messages.ERR_COMMUNITY_PUBLICATION_POST_IS_LOCKED;
+        if (postFlags.locked && !request.commentModeration) {
+            // A locked post is closed to regular users, not to mods. Like Reddit, owners/admins/moderators
+            // can still reply (and otherwise publish) under a locked post.
+            const isAuthorMod = await isPublicationAuthorPartOfRoles(community, publication, ["owner", "admin", "moderator"]);
+            if (!isAuthorMod) return messages.ERR_COMMUNITY_PUBLICATION_POST_IS_LOCKED;
+        }
 
         if (postFlags.archived && !request.commentModeration) return messages.ERR_COMMUNITY_PUBLICATION_POST_IS_ARCHIVED;
 

--- a/src/runtime/node/community/local-community/publication-validation.ts
+++ b/src/runtime/node/community/local-community/publication-validation.ts
@@ -229,9 +229,11 @@ async function checkParentAndPostState(
 
         if (postFlags.locked && !request.commentModeration) {
             // A locked post is closed to regular users, not to mods. Like Reddit, owners/admins/moderators
-            // can still reply (and otherwise publish) under a locked post.
-            const isAuthorMod = await isPublicationAuthorPartOfRoles(community, publication, ["owner", "admin", "moderator"]);
-            if (!isAuthorMod) return messages.ERR_COMMUNITY_PUBLICATION_POST_IS_LOCKED;
+            // can still reply to (and edit their comments under) a locked post. Voting stays disabled for
+            // everyone, mods included.
+            const authorCanBypassLock =
+                !request.vote && (await isPublicationAuthorPartOfRoles(community, publication, ["owner", "admin", "moderator"]));
+            if (!authorCanBypassLock) return messages.ERR_COMMUNITY_PUBLICATION_POST_IS_LOCKED;
         }
 
         if (postFlags.archived && !request.commentModeration) return messages.ERR_COMMUNITY_PUBLICATION_POST_IS_ARCHIVED;

--- a/test/node-and-browser/publications/comment-moderation/locked.test.ts
+++ b/test/node-and-browser/publications/comment-moderation/locked.test.ts
@@ -224,6 +224,37 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             });
         });
 
+        // A locked post is closed to regular users, not to mods. Like Reddit, owners/admins/moderators
+        // can still reply under a locked post. These run sequentially so they execute while the post is
+        // locked (after the sequential lock test, before the sequential unlock test).
+        it.sequential(`Mod can reply to a locked post`, async () => {
+            const reply = await generateMockComment(postToBeLocked as CommentIpfsWithCidDefined, pkc, false, {
+                signer: roles[2].signer
+            });
+            await publishWithExpectedResult({ publication: reply, expectedChallengeSuccess: true });
+        });
+
+        it.sequential(`Admin can reply to a locked post`, async () => {
+            const reply = await generateMockComment(postToBeLocked as CommentIpfsWithCidDefined, pkc, false, {
+                signer: roles[1].signer
+            });
+            await publishWithExpectedResult({ publication: reply, expectedChallengeSuccess: true });
+        });
+
+        it.sequential(`Owner can reply to a locked post`, async () => {
+            const reply = await generateMockComment(postToBeLocked as CommentIpfsWithCidDefined, pkc, false, {
+                signer: roles[0].signer
+            });
+            await publishWithExpectedResult({ publication: reply, expectedChallengeSuccess: true });
+        });
+
+        it.sequential(`Mod can reply to a reply of a locked post`, async () => {
+            const reply = await generateMockComment(replyUnderPostToBeLocked as CommentIpfsWithCidDefined, pkc, false, {
+                signer: roles[2].signer
+            });
+            await publishWithExpectedResult({ publication: reply, expectedChallengeSuccess: true });
+        });
+
         it.sequential(`Mod can unlock a post`, async () => {
             const unlockEdit = await pkc.createCommentModeration({
                 communityAddress: postToBeLocked.communityAddress,

--- a/test/node-and-browser/publications/comment-moderation/locked.test.ts
+++ b/test/node-and-browser/publications/comment-moderation/locked.test.ts
@@ -27,7 +27,12 @@ const roles = [
 
 getAvailablePKCConfigsToTestAgainst().map((config) => {
     describe.concurrent(`Locking posts - ${config.name}`, async () => {
-        let pkc: PKC, postToBeLocked: Comment, replyUnderPostToBeLocked: Comment, modPost: Comment, community: RemoteCommunity;
+        let pkc: PKC,
+            postToBeLocked: Comment,
+            replyUnderPostToBeLocked: Comment,
+            modReplyUnderPostToBeLocked: Comment,
+            modPost: Comment,
+            community: RemoteCommunity;
         beforeAll(async () => {
             pkc = await mockRemotePKC();
             community = await pkc.getCommunity({ address: communityAddress });
@@ -43,6 +48,13 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             replyUnderPostToBeLocked = await publishRandomReply({
                 parentComment: postToBeLocked as CommentIpfsWithCidDefined,
                 pkc: pkc
+            });
+            // A mod's own reply, published before the post is locked, so we can later assert the mod can
+            // edit their own comment while the post is locked.
+            modReplyUnderPostToBeLocked = await publishRandomReply({
+                parentComment: postToBeLocked as CommentIpfsWithCidDefined,
+                pkc: pkc,
+                commentProps: { signer: roles[2].signer }
             });
             await modPost.update();
         });
@@ -253,6 +265,26 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
                 signer: roles[2].signer
             });
             await publishWithExpectedResult({ publication: reply, expectedChallengeSuccess: true });
+        });
+
+        // Voting stays disabled on a locked post for everyone, mods included.
+        it.sequential(`Mod can't vote on a locked post`, async () => {
+            const vote = await generateMockVote(postToBeLocked as CommentIpfsWithCidDefined, 1, pkc, roles[2].signer);
+            await publishWithExpectedResult({
+                publication: vote,
+                expectedChallengeSuccess: false,
+                expectedReason: messages.ERR_COMMUNITY_PUBLICATION_POST_IS_LOCKED
+            });
+        });
+
+        it.sequential(`Mod can edit their own comment under a locked post`, async () => {
+            const edit = await pkc.createCommentEdit({
+                communityAddress: modReplyUnderPostToBeLocked.communityAddress,
+                commentCid: modReplyUnderPostToBeLocked.cid,
+                content: "Edited mod reply under a locked post",
+                signer: roles[2].signer
+            });
+            await publishWithExpectedResult({ publication: edit, expectedChallengeSuccess: true });
         });
 
         it.sequential(`Mod can unlock a post`, async () => {


### PR DESCRIPTION
Closes #164

## Why

A locked (closed) post currently rejects **all** replies, votes, and comment-edits with `ERR_COMMUNITY_PUBLICATION_POST_IS_LOCKED`, including those from moderators. On Reddit a thread is locked to regular users but mods can still reply. A locked post should be closed to users, not to mods.

## What

In `checkParentAndPostState()` (`src/runtime/node/community/local-community/publication-validation.ts`), the locked check previously only exempted `commentModeration` requests:

```ts
if (postFlags.locked && !request.commentModeration) return messages.ERR_COMMUNITY_PUBLICATION_POST_IS_LOCKED;
```

It now also lets a publication through when its author is an owner/admin/moderator (resolved via `isPublicationAuthorPartOfRoles`) **and** the publication is not a vote:

```ts
const authorCanBypassLock =
    !request.vote && (await isPublicationAuthorPartOfRoles(community, publication, ["owner", "admin", "moderator"]));
if (!authorCanBypassLock) return messages.ERR_COMMUNITY_PUBLICATION_POST_IS_LOCKED;
```

Net behavior on a locked post:
- Mods/admins/owners **can** reply and edit their own comments.
- Voting stays disabled for **everyone**, mods included.
- Regular users still can't reply/vote/edit.

## Tests

Added to `test/node-and-browser/publications/comment-moderation/locked.test.ts` (run while the post is locked):
- Mod can reply to a locked post
- Admin can reply to a locked post
- Owner can reply to a locked post
- Mod can reply to a reply of a locked post
- Mod **can't** vote on a locked post
- Mod can edit their own comment under a locked post

Existing assertions that regular users cannot reply/vote on a locked post remain.

## Verification

- `npm run build` passes
- `npx tsc --project test/tsconfig.json --noEmit` passes
- Test suite to run against the test server: `node test/run-test-config.js --pkc-config "remote-kubo-rpc,remote-pkc-rpc" test/node-and-browser/publications/comment-moderation/locked.test.ts`