### PR TITLE
fix(destroy): force-reset libp2p sockets and abort pending re-publish on destroy

### DIFF
--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -422,6 +422,23 @@ export async function createLibp2pJsClientOrUseExistingOne(
                     }
 
                     for (const topic of helia.libp2p.services.pubsub.getTopics()) helia.libp2p.services.pubsub.unsubscribe(topic);
+
+                    // Force-reset open transport connections before stopping helia. helia.stop()
+                    // closes them gracefully (the TCP transport calls socket.destroySoon(), which waits
+                    // for the peer's FIN), so a slow or unresponsive remote peer can leave the underlying
+                    // socket lingering in FIN_WAIT for tens of seconds — long enough to keep the Node
+                    // process alive past pkc.destroy()'s teardown budget (see test/node/pkc/hanging.pkc.test.ts).
+                    // abort() sends RST and destroys the socket immediately, making teardown bounded
+                    // regardless of peer responsiveness. This only runs on the final release of the helia
+                    // instance (countOfUsesOfInstance === 0), so no other consumer needs these connections.
+                    for (const connection of helia.libp2p.getConnections()) {
+                        try {
+                            connection.abort(new Error("pkc-js libp2p instance is stopping"));
+                        } catch (e) {
+                            log.error("Error aborting libp2p connection during stop", e);
+                        }
+                    }
+
                     try {
                         await helia.stop();
                     } catch (e) {

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -1118,6 +1118,12 @@ class Publication extends TypedEmitter<PublicationEvents> {
                 }
                 await sleepUntilTimeoutOrAbort(this._setProviderFailureThresholdSeconds * 1000, this._pkc._getDestroyAbortSignal());
                 if (this._pkc.destroyed) return;
+                // A plain publication.stop() does not abort the wait above (only destroy does), so it
+                // resumes here. Bail out the same way the earlier branch does, otherwise we'd treat an
+                // intentionally-stopped publication as a failure and emit ERR_ALL_PUBSUB_PROVIDERS_THROW_ERRORS.
+                // The enclosing `else` narrowed `this.state` to exclude "stopped", but stop() during the
+                // awaited wait above can have set it since, so widen back to the field's declared type.
+                if ((this.state as Publication["state"]) === "stopped") return;
                 if (this._isAllAttemptsExhausted(providers.length)) {
                     await this._postSucessOrFailurePublishing();
                     const allAttemptsFailedError = new PKCError("ERR_ALL_PUBSUB_PROVIDERS_THROW_ERRORS", {

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -30,7 +30,14 @@ import {
     verifyChallengeMessage,
     verifyChallengeVerification
 } from "../signer/signatures.js";
-import { deepMergeRuntimeFields, hideClassPrivateProps, isStringDomain, shortifyAddress, timestamp } from "../util.js";
+import {
+    deepMergeRuntimeFields,
+    hideClassPrivateProps,
+    isStringDomain,
+    shortifyAddress,
+    sleepUntilTimeoutOrAbort,
+    timestamp
+} from "../util.js";
 import { TypedEmitter } from "tiny-typed-emitter";
 import { Comment } from "./comment/comment.js";
 import { PKCError } from "../pkc-error.js";
@@ -1022,8 +1029,13 @@ class Publication extends TypedEmitter<PublicationEvents> {
         currentPubsubProviderIndex: number;
         acceptedChallengeTypes: DecryptedChallengeRequestMessageType["acceptedChallengeTypes"];
     }) {
-        await new Promise((resolve) => setTimeout(resolve, this._publishToDifferentProviderThresholdSeconds * 1000));
+        await sleepUntilTimeoutOrAbort(this._publishToDifferentProviderThresholdSeconds * 1000, this._pkc._getDestroyAbortSignal());
 
+        // pkc.destroy() aborts the sleep above so teardown isn't blocked waiting it out. Bail before
+        // doing any re-publish work — otherwise we'd create a signer on a destroyed pkc (throwing
+        // ERR_PKC_IS_DESTROYED) and re-subscribe/re-dial peers that nothing is left to tear down.
+        // (state === "stopped" is handled by the existing branch below.)
+        if (this._pkc.destroyed) return;
         if (this._didWeReceiveChallengeOrChallengeVerification()) return;
 
         // this provider did not get us a challenge or challenge verification
@@ -1098,9 +1110,14 @@ class Publication extends TypedEmitter<PublicationEvents> {
                     log(`Published a challenge request of publication`, this.getType(), "with provider", providerUrl);
                     this.emit("challengerequest", decryptedRequest);
                     if (currentPubsubProviderIndex !== providers.length)
-                        await new Promise((resolve) => setTimeout(resolve, this._publishToDifferentProviderThresholdSeconds * 1000));
+                        await sleepUntilTimeoutOrAbort(
+                            this._publishToDifferentProviderThresholdSeconds * 1000,
+                            this._pkc._getDestroyAbortSignal()
+                        );
+                    if (this._pkc.destroyed) return;
                 }
-                await new Promise((resolve) => setTimeout(resolve, this._setProviderFailureThresholdSeconds * 1000));
+                await sleepUntilTimeoutOrAbort(this._setProviderFailureThresholdSeconds * 1000, this._pkc._getDestroyAbortSignal());
+                if (this._pkc.destroyed) return;
                 if (this._isAllAttemptsExhausted(providers.length)) {
                     await this._postSucessOrFailurePublishing();
                     const allAttemptsFailedError = new PKCError("ERR_ALL_PUBSUB_PROVIDERS_THROW_ERRORS", {

--- a/test/node-and-browser/publications/comment/publish/errors.publish.test.ts
+++ b/test/node-and-browser/publications/comment/publish/errors.publish.test.ts
@@ -280,4 +280,64 @@ describeSkipIfRpc.concurrent(`Publishing resilience and errors of gateways and p
         await mockPost.stop();
         await offlinePubsubPKC.destroy();
     });
+    it.sequential(
+        `comment does not emit ERR_ALL_PUBSUB_PROVIDERS_THROW_ERRORS when publication.stop() is called during the final provider-failure wait`,
+        async () => {
+            // Regression for PR #168 (CodeRabbit finding): both providers accept the publish but never
+            // relay a challenge, so publishing reaches the final `_setProviderFailureThresholdSeconds`
+            // wait in `_handleNotReceivingResponseToChallengeRequest`. A plain `publication.stop()`
+            // does NOT abort that wait (only `pkc.destroy()` does), so it used to resume and fall
+            // through to the exhaustion check, wrongly emitting ERR_ALL_PUBSUB_PROVIDERS_THROW_ERRORS
+            // on an intentionally-stopped publication. The fix bails out on `this.state === "stopped"`.
+            const nonRespondingUrlA = "http://localhost:23425";
+            const nonRespondingUrlB = "http://localhost:23426";
+            const offlinePubsubPKC = await mockRemotePKC({
+                pkcOptions: { pubsubKuboRpcClientsOptions: [nonRespondingUrlA, nonRespondingUrlB] }
+            });
+
+            // Make both providers accept publish/subscribe but never relay a challenge (non-responding).
+            for (const url of [nonRespondingUrlA, nonRespondingUrlB]) {
+                offlinePubsubPKC.clients.pubsubKuboRpcClients[url]._client.pubsub.publish = async () => {};
+                offlinePubsubPKC.clients.pubsubKuboRpcClients[url]._client.pubsub.subscribe = async () => {};
+            }
+
+            const mockPost = await generateMockPost({ communityAddress: signers[1].address, pkc: offlinePubsubPKC });
+            // Pre-set _community to skip the network IPNS fetch in _initCommunity(),
+            // which is flaky in CI. This isolates the test to only exercise the pubsub failure path.
+            (mockPost as any)._community = {
+                encryption: { type: "ed25519-aes-gcm", publicKey: signers[1].publicKey },
+                pubsubTopic: signers[1].address,
+                address: signers[1].address
+            };
+            (mockPost as unknown as CommentWithInternals)._publishToDifferentProviderThresholdSeconds = 1;
+            (mockPost as unknown as CommentWithInternals)._setProviderFailureThresholdSeconds = 3;
+
+            const errors: PKCError[] = [];
+            mockPost.on("error", (err) => errors.push(err as PKCError));
+
+            // Stop the publication once we've re-published to the 2nd provider, i.e. we're now inside
+            // the final provider-failure wait at the bottom of _handleNotReceivingResponseToChallengeRequest.
+            const stopped = new Promise<void>((resolve) => {
+                mockPost.clients.pubsubKuboRpcClients[nonRespondingUrlB].on("statechange", (newState: string) => {
+                    if (newState === "waiting-challenge") mockPost.stop().then(resolve);
+                });
+            });
+
+            try {
+                await mockPost.publish();
+                await stopped;
+
+                // Wait past the final _setProviderFailureThresholdSeconds wait so the (buggy) error
+                // would have fired by now if the stop() bailout were missing.
+                await new Promise((r) =>
+                    setTimeout(r, (mockPost as unknown as CommentWithInternals)._setProviderFailureThresholdSeconds * 1000 + 2000)
+                );
+
+                expect(errors, "stop() during the final wait must not emit an error: " + errors.map((e) => e.code).join(",")).to.be.empty;
+                expect(mockPost.publishingState).to.equal("stopped");
+            } finally {
+                await offlinePubsubPKC.destroy();
+            }
+        }
+    );
 });

--- a/test/node-and-browser/publications/comment/publish/errors.publish.test.ts
+++ b/test/node-and-browser/publications/comment/publish/errors.publish.test.ts
@@ -323,9 +323,19 @@ describeSkipIfRpc.concurrent(`Publishing resilience and errors of gateways and p
                 });
             });
 
+            // Bound the wait so a state-machine regression that never reaches "waiting-challenge"
+            // fails fast with a clear message instead of hanging until the suite timeout.
+            let stoppedGuardTimer: ReturnType<typeof setTimeout> | undefined;
+            const stoppedGuard = new Promise<never>((_, reject) => {
+                stoppedGuardTimer = setTimeout(
+                    () => reject(new Error("Timed out waiting for second provider to enter waiting-challenge")),
+                    10_000
+                );
+            });
+
             try {
                 await mockPost.publish();
-                await stopped;
+                await Promise.race([stopped, stoppedGuard]);
 
                 // Wait past the final _setProviderFailureThresholdSeconds wait so the (buggy) error
                 // would have fired by now if the stop() bailout were missing.
@@ -336,6 +346,7 @@ describeSkipIfRpc.concurrent(`Publishing resilience and errors of gateways and p
                 expect(errors, "stop() during the final wait must not emit an error: " + errors.map((e) => e.code).join(",")).to.be.empty;
                 expect(mockPost.publishingState).to.equal("stopped");
             } finally {
+                clearTimeout(stoppedGuardTimer);
                 await offlinePubsubPKC.destroy();
             }
         }


### PR DESCRIPTION
## Problem

The `hanging.pkc.test.ts` scenario *"publish a comment over pubsub without succeeding and instead hanging, then destroy pkc"* (Libp2pJS / remote config) intermittently times out on slower CI runners (observed on `macos-latest`; the same `node-local` config passed on `ubuntu-latest` in the same run).

The harness spawns a child process that publishes a comment, calls `pkc.destroy()`, and asserts the process exits with no lingering handles. On the failing run the child never exited within the 30s budget and was SIGKILL'd.

## Root cause

`pkc.destroy()` → `helia.stop()` closes libp2p connections **gracefully**: the TCP transport calls `socket.destroySoon()`, which waits for the peer's FIN, and `helia.stop()` returns **without awaiting the sockets actually closing**. Against a slow/unresponsive remote relay peer the socket lingers in `FIN_WAIT` for tens of seconds, keeping the Node event loop alive past the teardown budget.

A handle probe of the exact scenario confirmed the mechanism:

```
libp2p connections BEFORE destroy: [ 2 ]   (3 open sockets)
destroy() returned after 7ms
libp2p connections AFTER destroy:  [ 0 ]    ← protocol layer closed
sockets IMMEDIATELY after destroy:  still open, destroyed=false
cleared at +21ms                            ← OS sockets close asynchronously
```

On loopback the sockets clear in ~21ms; against a real, slow peer the graceful FIN can hang well past 30s. The 10s re-publish timer firing post-destroy was a *symptom* (the process was alive because of the socket, so the unref'd timer ran), not the cause.

## Fixes

**1. `helia-for-pkc.ts`** — force-abort open transport connections before `helia.stop()`. `connection.abort()` sends RST and destroys the socket immediately, making teardown bounded regardless of peer responsiveness. Only runs on the final release of the helia instance (`countOfUsesOfInstance === 0`).

**2. `publication.ts`** — `_handleNotReceivingResponseToChallengeRequest` is launched fire-and-forget and slept on bare `setTimeout()`s that `destroy()` could not cancel, so it woke 10s later and re-signed on a destroyed pkc (`ERR_PKC_IS_DESTROYED`). Its sleeps now use `sleepUntilTimeoutOrAbort()` wired to the destroy abort signal, with a `this._pkc.destroyed` guard after each so destroy short-circuits the re-publish loop cleanly.

## Validation

- `npm run build` ✅
- `hanging.pkc.test.ts` — all 30 pass, including the previously-failing `comment-publish-pending` / Libp2pJS scenario.
- Direct hanging-runner ×5 for `remote-libp2pjs` — clean exit, 0 re-publish attempts, 0 `ERR_PKC_IS_DESTROYED` (was firing before).
- `errors.publish.test.ts` — all 7 resilience tests pass, including the multi-provider re-publish path that the abortable sleeps touch, so normal behavior is intact.
- `pubsub.test.ts` — 8 pass.

The timing itself is a macOS+internet-latency flake not reproducible on a fast loopback runner (graceful and abort both clear in ~10–21ms there), but the mechanism is reproduced and root-caused.

## Regression coverage

The existing `comment-publish-pending` hanging scenario is the deterministic regression test for the teardown path; it now passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior by force-closing active transport connections earlier, reducing cases where the app would linger while stopping.
  * Made publication retry delays abortable during teardown and prevented additional re-publish/signing work while stopping.
  * Ensured publication state transitions avoid emitting failure errors after shutdown has begun.
* **Tests**
  * Added a sequential regression test to verify no provider-publish error is emitted when stopping during the final challenge-reply wait.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->