### PR TITLE
fix(helia): tolerate per-router errors in content-routing findProviders (#171)

### DIFF
--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -10,7 +10,7 @@ import { peerIdFromString } from "@libp2p/peer-id";
 import { bitswap } from "@helia/block-brokers";
 import { MemoryBlockstore } from "blockstore-core";
 import { delegatedRoutingV1HttpApiClientContentRouting } from "@helia/delegated-routing-v1-http-api-client";
-import { NotFoundError } from "@libp2p/interface";
+import { NotFoundError, type AbortOptions } from "@libp2p/interface";
 import { unixfs } from "@helia/unixfs";
 import { fetch as libp2pFetch } from "@libp2p/fetch";
 import { pubsub as createIpnsPubusubRouter } from "@helia/ipns/routing";
@@ -54,6 +54,28 @@ function getDelegatedRoutingFields(routers: string[]) {
                 throw new NotFoundError("pkc HTTP routers do not serve IPNS records");
             };
             routing.put = async () => {};
+
+            // libp2p's CompoundContentRouting.findProviders merges EVERY configured router into one
+            // async iterator (it-merge), which rejects the whole merged stream the moment ANY single
+            // router's iterator throws. So one unreachable router — e.g. a host that's up but whose
+            // service is down, returning ECONNREFUSED — aborts findProviders for the entire node,
+            // taking down IPNS-over-pubsub warmup and bitswap provider lookups even while other,
+            // healthy routers are returning providers (issue #171). Wrap each router so its errors
+            // end ITS iterator instead of throwing: a dead/erroring router degrades to "found no
+            // providers" (the harmless empty case) rather than poisoning the merged stream. The
+            // underlying client already swallows NotFoundError; this additionally covers connection
+            // and transport errors. We do not re-throw on abort either — when findProviders is
+            // aborted (subscriber found / maxPeers reached / caller signal), ending the iterator is
+            // the correct outcome and the caller handles the abort separately.
+            const routerUrl = routers[i];
+            const originalFindProviders = routing.findProviders.bind(routing);
+            routing.findProviders = async function* (cid: CID, options?: AbortOptions) {
+                try {
+                    yield* originalFindProviders(cid, options);
+                } catch (e) {
+                    log.trace("Content router", routerUrl, "errored during findProviders; treating it as returning no providers", e);
+                }
+            };
             return routing;
         };
     }

--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -194,7 +194,16 @@ export async function connectToPubsubPeers({
             }
         },
         () => {
-            // swallow timeout/abort — handled in the post-loop await below
+            // The subscriber wait ended without a subscriber (the 10s floor timeout, or the caller's
+            // signal). Abort findProviders too: most routers end their own iterator so the for-await
+            // below completes on its own, but a black-hole router (accepts the GET, never responds,
+            // never closes) never yields and never ends its it-merge source — without this abort the
+            // for-await would pull it forever and warmup would hang PAST the floor. The post-loop
+            // `await subscriberAppearedPromise` still surfaces the timeout as graftError.
+            if (!findProvidersAbort.signal.aborted) {
+                log.trace("Aborting findProviders iterator - subscriber wait ended without a subscriber for topic", pubsubTopic);
+                findProvidersAbort.abort();
+            }
         }
     );
 

--- a/src/runtime/node/test/mock-http-router.ts
+++ b/src/runtime/node/test/mock-http-router.ts
@@ -31,6 +31,17 @@ export type RecordedRequest = {
     body: string;
 };
 
+// How the provider GET handler should misbehave, for fault-tolerance tests (issue #171). Each mode
+// emulates a real-world router outage so we can prove one bad router never poisons the merged
+// findProviders stream nor slows down a lookup another router can satisfy:
+//   - "errorStatus": respond with an HTTP error status (5xx/429/401/...) instead of providers.
+//   - "malformed":   respond 200 with a body that is not valid provider JSON (parser throws).
+//   - "resetMidResponse": send headers + a partial body then destroy the socket (ECONNRESET).
+//   - "blackHole":   accept the connection then never respond and never close it (true hang,
+//                    distinct from a "slow" router that eventually replies). The handler still
+//                    resolves if the client disconnects so the server can shut down cleanly.
+export type MockHttpRouterFaultMode = "errorStatus" | "malformed" | "resetMidResponse" | "blackHole";
+
 export type MockHttpRouterOptions = {
     hostname?: string;
     port?: number;
@@ -38,6 +49,11 @@ export type MockHttpRouterOptions = {
     // router that accepts the connection then stalls (issue #171 reproduction). The delay aborts
     // early if the request is aborted by the client.
     providerGetDelayMs?: number;
+    // When set, the provider GET handler misbehaves in the given way instead of serving providers.
+    // See MockHttpRouterFaultMode. Applied after providerGetDelayMs, so a fault can also be "slow".
+    faultMode?: MockHttpRouterFaultMode;
+    // HTTP status code used when faultMode === "errorStatus" (default 500).
+    errorStatusCode?: number;
 };
 
 const PROVIDERS_PUBLISH_PATH = "/routing/v1/providers";
@@ -51,6 +67,12 @@ export class MockHttpRouter {
     private _providerRecords: Map<string, ProviderRecord[]>;
     private _requests: RecordedRequest[];
     private _providerGetDelayMs: number;
+    private _faultMode?: MockHttpRouterFaultMode;
+    private _errorStatusCode: number;
+    // Count of provider GETs the client disconnected before we finished responding. Lets a test
+    // prove that aborting findProviders (subscriber found / maxPeers reached / caller signal)
+    // actually cancels the in-flight request to a slow/black-hole router rather than leaking it.
+    private _abortedProviderGetCount: number;
 
     constructor(options: MockHttpRouterOptions = {}) {
         this._hostname = options.hostname ?? "127.0.0.1";
@@ -58,6 +80,9 @@ export class MockHttpRouter {
         this._providerRecords = new Map();
         this._requests = [];
         this._providerGetDelayMs = options.providerGetDelayMs ?? 0;
+        this._faultMode = options.faultMode;
+        this._errorStatusCode = options.errorStatusCode ?? 500;
+        this._abortedProviderGetCount = 0;
         this._server = http.createServer((req, res) => {
             this._handleRequest(req, res).catch((error) => {
                 if (!res.headersSent) {
@@ -86,6 +111,12 @@ export class MockHttpRouter {
         return [...this._requests];
     }
 
+    // Number of provider GETs the client disconnected before this router finished responding.
+    // > 0 proves an in-flight request to this (slow/black-hole) router was actually cancelled.
+    get abortedProviderGetCount(): number {
+        return this._abortedProviderGetCount;
+    }
+
     async start(): Promise<void> {
         if (this._baseUrl) return;
         await new Promise<void>((resolve) => {
@@ -100,6 +131,9 @@ export class MockHttpRouter {
     async destroy(): Promise<void> {
         await new Promise<void>((resolve, reject) => {
             this._server.close((error) => (error ? reject(error) : resolve()));
+            // A black-hole/slow handler holds its connection open, so close() would otherwise wait
+            // for it forever. Force any lingering sockets shut so cleanup always completes.
+            this._server.closeAllConnections?.();
         });
         this._baseUrl = undefined;
     }
@@ -223,22 +257,56 @@ export class MockHttpRouter {
         this._addProviderRecord(cid, { ID: provider.ID, Addrs: provider.Addrs, Protocols: provider.Protocols }, Date.now());
     }
 
-    private async _handleProviderGet(url: URL, res: http.ServerResponse, corsHeaders: Record<string, string>) {
-        if (this._providerGetDelayMs > 0) {
-            // Stall before responding to emulate a slow/hanging router. Resolve early if the client
-            // disconnects (response closes before we wrote it) so we don't keep a dangling timer or
-            // try to write to a dead socket. We key off the response lifecycle, NOT the request body
-            // stream, whose "close" fires as soon as the GET body is drained.
-            const clientGone = await new Promise<boolean>((resolve) => {
-                const timer = setTimeout(() => resolve(false), this._providerGetDelayMs);
-                res.once("close", () => {
-                    if (!res.writableEnded) {
-                        clearTimeout(timer);
-                        resolve(true);
-                    }
-                });
+    // Wait up to `delayMs` (or forever when delayMs is null, i.e. a black hole) before continuing.
+    // Resolves true if the client disconnected first — keyed off the response lifecycle, NOT the
+    // request body stream whose "close" fires as soon as the GET body is drained. Records the
+    // disconnect so a test can assert the in-flight request was cancelled.
+    private _stallUntilDelayOrClientGone(res: http.ServerResponse, delayMs: number | null): Promise<boolean> {
+        return new Promise<boolean>((resolve) => {
+            const timer = delayMs === null ? undefined : setTimeout(() => resolve(false), delayMs);
+            res.once("close", () => {
+                if (!res.writableEnded) {
+                    if (timer) clearTimeout(timer);
+                    this._abortedProviderGetCount++;
+                    resolve(true);
+                }
             });
+        });
+    }
+
+    private async _handleProviderGet(url: URL, res: http.ServerResponse, corsHeaders: Record<string, string>) {
+        // A black hole accepts the connection then never responds and never closes it — it only
+        // unblocks when the client disconnects. Distinct from "slow", which eventually replies.
+        if (this._faultMode === "blackHole") {
+            await this._stallUntilDelayOrClientGone(res, null);
+            return;
+        }
+        if (this._providerGetDelayMs > 0) {
+            // Stall before responding to emulate a slow/hanging router, then fall through to the
+            // normal (or fault) response once the delay elapses.
+            const clientGone = await this._stallUntilDelayOrClientGone(res, this._providerGetDelayMs);
             if (clientGone) return;
+        }
+        // Fault injection: misbehave instead of serving providers, to prove one bad router neither
+        // throws out of the merged findProviders stream nor slows a lookup another router satisfies.
+        if (this._faultMode === "errorStatus") {
+            res.writeHead(this._errorStatusCode, { ...corsHeaders, "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: `synthetic ${this._errorStatusCode}` }));
+            return;
+        }
+        if (this._faultMode === "malformed") {
+            // Valid 200 + content-type but a body the provider-record parser cannot read.
+            res.writeHead(200, { ...corsHeaders, "Content-Type": "application/json" });
+            res.end("{ this is not valid provider json ]]]");
+            return;
+        }
+        if (this._faultMode === "resetMidResponse") {
+            // Send headers and a partial body, then abruptly destroy the socket (ECONNRESET) so the
+            // client throws mid-stream rather than on connect.
+            res.writeHead(200, { ...corsHeaders, "Content-Type": "application/json" });
+            res.write('{ "Providers": [');
+            res.socket?.destroy();
+            return;
         }
         const cid = decodeURIComponent(url.pathname.slice(PROVIDERS_GET_PREFIX.length)).replace(/\/+$/, "");
         if (!cid) {

--- a/src/runtime/node/test/mock-http-router.ts
+++ b/src/runtime/node/test/mock-http-router.ts
@@ -34,6 +34,10 @@ export type RecordedRequest = {
 export type MockHttpRouterOptions = {
     hostname?: string;
     port?: number;
+    // When set, the provider GET handler waits this many ms before responding. Simulates a "slow"
+    // router that accepts the connection then stalls (issue #171 reproduction). The delay aborts
+    // early if the request is aborted by the client.
+    providerGetDelayMs?: number;
 };
 
 const PROVIDERS_PUBLISH_PATH = "/routing/v1/providers";
@@ -46,12 +50,14 @@ export class MockHttpRouter {
     private _baseUrl?: string;
     private _providerRecords: Map<string, ProviderRecord[]>;
     private _requests: RecordedRequest[];
+    private _providerGetDelayMs: number;
 
     constructor(options: MockHttpRouterOptions = {}) {
         this._hostname = options.hostname ?? "127.0.0.1";
         this._port = options.port ?? 0;
         this._providerRecords = new Map();
         this._requests = [];
+        this._providerGetDelayMs = options.providerGetDelayMs ?? 0;
         this._server = http.createServer((req, res) => {
             this._handleRequest(req, res).catch((error) => {
                 if (!res.headersSent) {
@@ -130,7 +136,7 @@ export class MockHttpRouter {
             return;
         }
         if (req.method === "GET" && this._isProvidersGetPath(requestUrl.pathname)) {
-            this._handleProviderGet(requestUrl, res, corsHeaders);
+            await this._handleProviderGet(requestUrl, res, corsHeaders);
             return;
         }
         res.writeHead(501, corsHeaders);
@@ -211,7 +217,29 @@ export class MockHttpRouter {
         res.end(JSON.stringify({ ok: true, stored: storedCount }));
     }
 
-    private _handleProviderGet(url: URL, res: http.ServerResponse, corsHeaders: Record<string, string>) {
+    // Seed a provider record for a CID directly, without going through the HTTP publish path.
+    // Used by tests that need a "good" router which immediately serves a known provider.
+    addProviderForTesting(cid: string, provider: { ID: string; Addrs: string[]; Protocols?: string[] }): void {
+        this._addProviderRecord(cid, { ID: provider.ID, Addrs: provider.Addrs, Protocols: provider.Protocols }, Date.now());
+    }
+
+    private async _handleProviderGet(url: URL, res: http.ServerResponse, corsHeaders: Record<string, string>) {
+        if (this._providerGetDelayMs > 0) {
+            // Stall before responding to emulate a slow/hanging router. Resolve early if the client
+            // disconnects (response closes before we wrote it) so we don't keep a dangling timer or
+            // try to write to a dead socket. We key off the response lifecycle, NOT the request body
+            // stream, whose "close" fires as soon as the GET body is drained.
+            const clientGone = await new Promise<boolean>((resolve) => {
+                const timer = setTimeout(() => resolve(false), this._providerGetDelayMs);
+                res.once("close", () => {
+                    if (!res.writableEnded) {
+                        clearTimeout(timer);
+                        resolve(true);
+                    }
+                });
+            });
+            if (clientGone) return;
+        }
         const cid = decodeURIComponent(url.pathname.slice(PROVIDERS_GET_PREFIX.length)).replace(/\/+$/, "");
         if (!cid) {
             res.writeHead(400, { ...corsHeaders, "Content-Type": "application/json" });

--- a/src/runtime/node/test/mock-http-router.ts
+++ b/src/runtime/node/test/mock-http-router.ts
@@ -263,14 +263,23 @@ export class MockHttpRouter {
     // disconnect so a test can assert the in-flight request was cancelled.
     private _stallUntilDelayOrClientGone(res: http.ServerResponse, delayMs: number | null): Promise<boolean> {
         return new Promise<boolean>((resolve) => {
-            const timer = delayMs === null ? undefined : setTimeout(() => resolve(false), delayMs);
-            res.once("close", () => {
+            let settled = false;
+            let timer: ReturnType<typeof setTimeout> | undefined;
+            const settle = (clientGone: boolean) => {
+                if (settled) return;
+                settled = true;
+                if (timer) clearTimeout(timer);
+                res.off("close", onClose);
+                resolve(clientGone);
+            };
+            const onClose = () => {
                 if (!res.writableEnded) {
-                    if (timer) clearTimeout(timer);
                     this._abortedProviderGetCount++;
-                    resolve(true);
+                    settle(true);
                 }
-            });
+            };
+            res.once("close", onClose);
+            timer = delayMs === null ? undefined : setTimeout(() => settle(false), delayMs);
         });
     }
 

--- a/test/node/helia/content-router-fault-tolerance.unit.test.ts
+++ b/test/node/helia/content-router-fault-tolerance.unit.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createLibp2pJsClientOrUseExistingOne } from "../../../dist/node/helia/helia-for-pkc.js";
+import { MockHttpRouter } from "../../../dist/node/runtime/node/test/mock-http-router.js";
+import { pubsubTopicToDhtKeyCid } from "../../../dist/node/util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { generateKeyPair } from "@libp2p/crypto/keys";
+import { peerIdFromPrivateKey } from "@libp2p/peer-id";
+import type { Libp2pJsClient } from "../../../dist/node/helia/libp2pjsClient.js";
+import type { CID } from "multiformats/cid";
+
+// Regression coverage for issue #171: a single unreachable (connection-refused) HTTP router used to
+// abort the node's ENTIRE content-routing provider lookup. IPNS-over-pubsub resolution warms up a
+// topic by calling helia.libp2p.contentRouting.findProviders(cid), which libp2p implements with
+// it-merge over every configured router — so one router's iterator throwing (e.g. ECONNREFUSED)
+// rejected the whole merged stream and every community load failed instantly, even when other healthy
+// routers were returning providers. The fix wraps each router so its errors end ITS iterator instead
+// of poisoning the merge (src/helia/helia-for-pkc.ts getDelegatedRoutingFields).
+//
+// These tests exercise contentRouting.findProviders directly (the shared mechanism behind warmup and
+// bitswap provider lookups) against synthetic routers covering every failure mode and their
+// combinations, asserting that as long as ONE router has the provider the lookup succeeds and is not
+// slowed down by the unhealthy routers. Client-side libp2p only and config-independent, so it runs
+// once under non-RPC.
+describeSkipIfRpc("Content router fault tolerance (issue #171)", () => {
+    // A "slow" router accepts the connection then stalls this long before responding. Far larger than
+    // any assertion bound below: if a lookup ever waited on the slow router the test would visibly hang.
+    const SLOW_ROUTER_STALL_MS = 30_000;
+    // Generous upper bound for "fast": a healthy local router answers in single-digit ms; this leaves
+    // huge headroom for CI jitter while staying well under SLOW_ROUTER_STALL_MS.
+    const FAST_LOOKUP_MAX_MS = 5_000;
+
+    const queryCid: CID = pubsubTopicToDhtKeyCid("content-router-fault-tolerance-test-topic");
+    let providerPeerIdStr: string;
+
+    const startedRouters: MockHttpRouter[] = [];
+    const clientsToStop: Libp2pJsClient[] = [];
+    let keyCounter = 0;
+
+    beforeAll(async () => {
+        providerPeerIdStr = peerIdFromPrivateKey(await generateKeyPair("Ed25519")).toString();
+    });
+
+    afterEach(async () => {
+        // countOfUsesOfInstance starts at 1, so a single stop() tears each helia instance down.
+        while (clientsToStop.length) await clientsToStop.pop()!.heliaWithKuboRpcClientFunctions.stop();
+        while (startedRouters.length) {
+            try {
+                await startedRouters.pop()!.destroy();
+            } catch {
+                // already destroyed (e.g. a "dead" router we closed on purpose)
+            }
+        }
+    });
+
+    type RouterKind = "good" | "slow" | "empty" | "dead";
+
+    // Build one synthetic router of the given kind and return its URL. "good" serves the provider for
+    // queryCid (optionally after goodDelayMs); "slow" accepts then stalls; "empty" answers instantly
+    // with no providers; "dead" is a closed port that refuses connections (ECONNREFUSED).
+    const startRouter = async (kind: RouterKind, goodDelayMs: number): Promise<string> => {
+        if (kind === "dead") {
+            // Bind to grab a free port, then close it so connections to that port are refused.
+            const router = new MockHttpRouter();
+            await router.start();
+            const url = router.url;
+            await router.destroy();
+            return url;
+        }
+        const router =
+            kind === "slow"
+                ? new MockHttpRouter({ providerGetDelayMs: SLOW_ROUTER_STALL_MS })
+                : kind === "good"
+                  ? new MockHttpRouter({ providerGetDelayMs: goodDelayMs })
+                  : new MockHttpRouter();
+        await router.start();
+        startedRouters.push(router);
+        if (kind === "good") router.addProviderForTesting(queryCid.toString(), { ID: providerPeerIdStr, Addrs: ["/ip4/1.2.3.4/tcp/4001"] });
+        return router.url;
+    };
+
+    const createHeliaWithRouters = async (httpRoutersOptions: string[]): Promise<Libp2pJsClient> => {
+        const client = (await createLibp2pJsClientOrUseExistingOne({
+            key: `content-router-fault-tolerance-${keyCounter++}`,
+            httpRoutersOptions,
+            libp2pOptions: {},
+            heliaOptions: {}
+        })) as Libp2pJsClient;
+        clientsToStop.push(client);
+        return client;
+    };
+
+    // Run a single findProviders lookup, returning the first provider's peer-id, the ms until it
+    // arrived, and any thrown error. Breaks after the first provider (matching warmup semantics, which
+    // dials peers as they arrive) and aborts so in-flight requests to slow/dead routers are cancelled.
+    const lookupFirstProvider = async (
+        client: Libp2pJsClient
+    ): Promise<{ found: string[]; firstMs: number | null; threw: Error | null }> => {
+        const ac = new AbortController();
+        const timer = setTimeout(() => ac.abort(), FAST_LOOKUP_MAX_MS + SLOW_ROUTER_STALL_MS);
+        const start = Date.now();
+        const found: string[] = [];
+        let firstMs: number | null = null;
+        let threw: Error | null = null;
+        try {
+            for await (const peer of client._helia.libp2p.contentRouting.findProviders(queryCid, { signal: ac.signal })) {
+                if (firstMs === null) firstMs = Date.now() - start;
+                found.push(peer.id.toString());
+                break;
+            }
+        } catch (e) {
+            threw = e as Error;
+        } finally {
+            clearTimeout(timer);
+            ac.abort();
+        }
+        return { found, firstMs, threw };
+    };
+
+    const runScenario = async (kinds: RouterKind[], goodDelayMs = 0) => {
+        const urls = await Promise.all(kinds.map((kind) => startRouter(kind, goodDelayMs)));
+        const client = await createHeliaWithRouters(urls);
+        return lookupFirstProvider(client);
+    };
+
+    // The core regression: a healthy router plus one connection-refused router. The good router is
+    // given a small head start so the dead router's ECONNREFUSED is observed first — before the fix
+    // that refusal rejected the merged stream and the lookup threw before ever yielding the provider.
+    it("a connection-refused router does not abort a lookup that another router can satisfy", async () => {
+        const { found, threw } = await runScenario(["good", "dead"], 300);
+        expect(threw, threw ? `lookup threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
+        expect(found).to.deep.equal([providerPeerIdStr]);
+    });
+
+    // Every combination of unhealthy routers alongside one good router must still yield the provider
+    // without throwing. (goodDelayMs 0: post-fix the dead router is swallowed regardless of timing.)
+    const goodPlusBadCombos: { name: string; kinds: RouterKind[] }[] = [
+        { name: "good only", kinds: ["good"] },
+        { name: "good + dead", kinds: ["good", "dead"] },
+        { name: "good + slow", kinds: ["good", "slow"] },
+        { name: "good + empty", kinds: ["good", "empty"] },
+        { name: "dead + good (dead first)", kinds: ["dead", "good"] },
+        { name: "good + dead + slow + empty", kinds: ["good", "dead", "slow", "empty"] }
+    ];
+    for (const { name, kinds } of goodPlusBadCombos)
+        it(`yields the provider quickly for: ${name}`, async () => {
+            const { found, firstMs, threw } = await runScenario(kinds);
+            expect(threw, threw ? `lookup threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
+            expect(found).to.deep.equal([providerPeerIdStr]);
+            // Slow/dead/empty routers must not delay the result that the good router can serve.
+            expect(firstMs).to.be.a("number");
+            expect(firstMs!).to.be.lessThan(FAST_LOOKUP_MAX_MS);
+        });
+
+    // Explicit "speed is unaffected" guard: adding a slow, a dead and an empty router alongside the
+    // good one must not meaningfully slow down the lookup versus the good router alone.
+    it("unhealthy routers do not slow the lookup down vs a healthy router alone", async () => {
+        const baseline = await runScenario(["good"]);
+        expect(baseline.found).to.deep.equal([providerPeerIdStr]);
+        expect(baseline.firstMs).to.be.a("number");
+
+        const laden = await runScenario(["good", "slow", "dead", "empty"]);
+        expect(laden.threw, laden.threw ? `lookup threw: ${laden.threw.name}` : undefined).to.equal(null);
+        expect(laden.found).to.deep.equal([providerPeerIdStr]);
+        expect(laden.firstMs).to.be.a("number");
+        // The laden lookup is fast in absolute terms and within a generous delta of the baseline,
+        // i.e. it did NOT wait on the 30s slow router.
+        expect(laden.firstMs!).to.be.lessThan(FAST_LOOKUP_MAX_MS);
+        expect(laden.firstMs!).to.be.lessThan(baseline.firstMs! + 2000);
+    });
+
+    // When NO router can satisfy the lookup, an unreachable router must still degrade gracefully to
+    // "found nothing" rather than throwing — the harmless empty case.
+    it("a lookup with only unreachable/empty routers ends with no providers and no error", async () => {
+        const { found, threw } = await runScenario(["dead", "empty"]);
+        expect(threw, threw ? `lookup threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
+        expect(found).to.deep.equal([]);
+    });
+});

--- a/test/node/helia/content-router-fault-tolerance.unit.test.ts
+++ b/test/node/helia/content-router-fault-tolerance.unit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { createLibp2pJsClientOrUseExistingOne } from "../../../dist/node/helia/helia-for-pkc.js";
 import { MockHttpRouter } from "../../../dist/node/runtime/node/test/mock-http-router.js";
 import { pubsubTopicToDhtKeyCid } from "../../../dist/node/util.js";
@@ -61,11 +61,24 @@ describeSkipIfRpc("Content router fault tolerance (issue #171)", () => {
         }
     });
 
-    type RouterKind = "good" | "slow" | "empty" | "dead";
+    // Healthy and every unhealthy shape a real HTTP router can take. "dead"/"slow"/"empty" are the
+    // original #171 modes; "error5xx"/"error429"/"malformed"/"reset"/"blackhole" cover the common
+    // real-world outages (5xx under load, rate-limiting, a fronting proxy returning garbage, a
+    // connection reset mid-stream, and a true black hole that accepts then never replies).
+    type RouterKind = "good" | "slow" | "empty" | "dead" | "error5xx" | "error429" | "malformed" | "reset" | "blackhole";
 
     // Build one synthetic router of the given kind and return its URL. "good" serves the provider for
     // queryCid (optionally after goodDelayMs); "slow" accepts then stalls; "empty" answers instantly
-    // with no providers; "dead" is a closed port that refuses connections (ECONNREFUSED).
+    // with no providers; "dead" is a closed port that refuses connections (ECONNREFUSED); the rest
+    // misbehave per their fault mode (see MockHttpRouterFaultMode). Only "good" serves a provider.
+    const faultModeForKind: Partial<Record<RouterKind, ConstructorParameters<typeof MockHttpRouter>[0]>> = {
+        slow: { providerGetDelayMs: SLOW_ROUTER_STALL_MS },
+        error5xx: { faultMode: "errorStatus", errorStatusCode: 503 },
+        error429: { faultMode: "errorStatus", errorStatusCode: 429 },
+        malformed: { faultMode: "malformed" },
+        reset: { faultMode: "resetMidResponse" },
+        blackhole: { faultMode: "blackHole" }
+    };
     const startRouter = async (kind: RouterKind, goodDelayMs: number): Promise<string> => {
         if (kind === "dead") {
             // Bind to grab a free port, then close it so connections to that port are refused.
@@ -76,11 +89,7 @@ describeSkipIfRpc("Content router fault tolerance (issue #171)", () => {
             return url;
         }
         const router =
-            kind === "slow"
-                ? new MockHttpRouter({ providerGetDelayMs: SLOW_ROUTER_STALL_MS })
-                : kind === "good"
-                  ? new MockHttpRouter({ providerGetDelayMs: goodDelayMs })
-                  : new MockHttpRouter();
+            kind === "good" ? new MockHttpRouter({ providerGetDelayMs: goodDelayMs }) : new MockHttpRouter(faultModeForKind[kind]);
         await router.start();
         startedRouters.push(router);
         if (kind === "good") router.addProviderForTesting(queryCid.toString(), { ID: providerPeerIdStr, Addrs: ["/ip4/1.2.3.4/tcp/4001"] });
@@ -142,6 +151,17 @@ describeSkipIfRpc("Content router fault tolerance (issue #171)", () => {
         return router.url;
     };
 
+    // Like startServingRouter but returns the router INSTANCE (registered for cleanup) so a test can
+    // inspect its recorded/aborted request counts. Optionally seeds a provider for queryCid.
+    const startInspectableRouter = async (opts: ConstructorParameters<typeof MockHttpRouter>[0] & { servesProvider?: boolean } = {}) => {
+        const { servesProvider, ...routerOpts } = opts;
+        const router = new MockHttpRouter(routerOpts);
+        await router.start();
+        startedRouters.push(router);
+        if (servesProvider) router.addProviderForTesting(queryCid.toString(), { ID: providerPeerIdStr, Addrs: ["/ip4/1.2.3.4/tcp/4001"] });
+        return router;
+    };
+
     // Collect up to `want` providers, stopping as soon as we have them (or on the safety deadline).
     // Returns how long the collection took so a test can prove it did not block on a slow router.
     const collectProviders = async (
@@ -184,7 +204,18 @@ describeSkipIfRpc("Content router fault tolerance (issue #171)", () => {
         { name: "good + slow", kinds: ["good", "slow"] },
         { name: "good + empty", kinds: ["good", "empty"] },
         { name: "dead + good (dead first)", kinds: ["dead", "good"] },
-        { name: "good + dead + slow + empty", kinds: ["good", "dead", "slow", "empty"] }
+        { name: "good + dead + slow + empty", kinds: ["good", "dead", "slow", "empty"] },
+        // Real-world outage shapes: each bad router must be swallowed per-router, never thrown out of
+        // the merged stream, and must not delay the provider the good router can serve.
+        { name: "good + 5xx", kinds: ["good", "error5xx"] },
+        { name: "good + 429", kinds: ["good", "error429"] },
+        { name: "good + malformed body", kinds: ["good", "malformed"] },
+        { name: "good + connection reset mid-response", kinds: ["good", "reset"] },
+        { name: "5xx first + good", kinds: ["error5xx", "good"] },
+        {
+            name: "every failure mode + good",
+            kinds: ["good", "dead", "slow", "empty", "error5xx", "error429", "malformed", "reset", "blackhole"]
+        }
     ];
     for (const { name, kinds } of goodPlusBadCombos)
         it(`yields the provider quickly for: ${name}`, async () => {
@@ -255,5 +286,137 @@ describeSkipIfRpc("Content router fault tolerance (issue #171)", () => {
         expect(found).to.not.include(slowProviderPeerIdStr);
         // Both immediate providers were collected long before the slow router's 10s response.
         expect(elapsedMs).to.be.lessThan(2_000);
+    });
+
+    // No good router at all: every failure mode must degrade to "found nothing" rather than throwing.
+    // (The black hole is excluded here — with no router able to end the merged stream it can only end
+    // on abort/timeout, which is exercised by its own bounded test below.)
+    const allBadNoGoodModes: RouterKind[] = ["dead", "empty", "error5xx", "error429", "malformed", "reset"];
+    for (const mode of allBadNoGoodModes)
+        it(`degrades to no-providers-no-error when the only router is: ${mode}`, async () => {
+            const { found, threw, firstMs } = await runScenario([mode]);
+            expect(threw, threw ? `lookup threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
+            expect(found).to.deep.equal([]);
+            // Even the "no providers" outcome must be fast — a bad router must not stall the lookup.
+            expect(firstMs).to.equal(null);
+        });
+
+    // Aborting a lookup (subscriber found / maxPeers reached / caller signal) must actually CANCEL the
+    // in-flight HTTP request to a slow router rather than leak the socket. Across many warmups a leak
+    // here exhausts file descriptors and silently slows the whole node. The good router answers after a
+    // short head start; we break on the first provider, which aborts — and the slow router must observe
+    // its in-flight GET being cancelled.
+    it("aborting after the first provider cancels the in-flight request to a slow router", async () => {
+        const slow = await startInspectableRouter({ providerGetDelayMs: SLOW_ROUTER_STALL_MS });
+        const goodUrl = await startServingRouter({ delayMs: 200, providerId: providerPeerIdStr });
+        const client = await createHeliaWithRouters([slow.url, goodUrl]);
+
+        const { found, threw } = await lookupFirstProvider(client);
+        expect(threw, threw ? `lookup threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
+        expect(found).to.deep.equal([providerPeerIdStr]);
+        // The slow router received the GET and then saw the client disconnect when we aborted — i.e.
+        // the request was cancelled, not left dangling for its full 30s stall.
+        await vi.waitFor(() => expect(slow.abortedProviderGetCount).to.be.greaterThan(0), { timeout: 3_000 });
+    });
+
+    // Repeated lookups against a mixed-health fleet must stay fast and bounded: no per-lookup leak, no
+    // runaway retries against the good router, and every in-flight slow request cancelled. This is the
+    // sequential-warmup load a real node sees (one lookup per community/topic).
+    it("stays fast and leak-free across many sequential lookups against a mixed fleet", async () => {
+        const REPS = 20;
+        const slow = await startInspectableRouter({ providerGetDelayMs: SLOW_ROUTER_STALL_MS });
+        const good = await startInspectableRouter({ servesProvider: true });
+        const deadUrl = await startRouter("dead", 0);
+        const emptyUrl = await startRouter("empty", 0);
+        const client = await createHeliaWithRouters([slow.url, good.url, deadUrl, emptyUrl]);
+
+        for (let i = 0; i < REPS; i++) {
+            const { found, firstMs, threw } = await lookupFirstProvider(client);
+            expect(threw, threw ? `rep ${i} threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
+            expect(found, `rep ${i}`).to.deep.equal([providerPeerIdStr]);
+            expect(firstMs!, `rep ${i} firstMs`).to.be.lessThan(FAST_LOOKUP_MAX_MS);
+        }
+        // Exactly one GET per lookup to the good router — no retry storm amplifying load.
+        const goodGets = good.requests.filter((r) => r.method === "GET").length;
+        expect(goodGets).to.equal(REPS);
+        // Every slow request was cancelled when its lookup ended — none leaked across the 20 reps.
+        await vi.waitFor(() => expect(slow.abortedProviderGetCount).to.equal(REPS), { timeout: 5_000 });
+    });
+
+    // Scaling guard: the per-router wrap + it-merge fan-out must add negligible fixed cost, so shipping
+    // many routers is not inherently slower than shipping a few. One good router buried behind eight
+    // empty ones must resolve about as fast as the good router alone.
+    it("a good router buried behind many empty routers is not slowed down", async () => {
+        const baseline = await runScenario(["good"]);
+        expect(baseline.found).to.deep.equal([providerPeerIdStr]);
+        expect(baseline.firstMs).to.be.a("number");
+
+        const manyEmpty: RouterKind[] = ["good", "empty", "empty", "empty", "empty", "empty", "empty", "empty", "empty"];
+        const laden = await runScenario(manyEmpty);
+        expect(laden.threw, laden.threw ? `lookup threw: ${laden.threw.name}` : undefined).to.equal(null);
+        expect(laden.found).to.deep.equal([providerPeerIdStr]);
+        expect(laden.firstMs!).to.be.lessThan(FAST_LOOKUP_MAX_MS);
+        expect(laden.firstMs!).to.be.lessThan(baseline.firstMs! + 2000);
+    });
+
+    // A lookup whose signal is already aborted must return immediately with nothing and without
+    // throwing a non-abort error — the wrap swallows the abort per-router. Guards against an
+    // already-cancelled warmup wasting time or surfacing a spurious failure.
+    it("an already-aborted lookup ends immediately with no providers and no error", async () => {
+        const goodUrl = await startServingRouter({ delayMs: 0, providerId: providerPeerIdStr });
+        const client = await createHeliaWithRouters([goodUrl]);
+
+        const ac = new AbortController();
+        ac.abort();
+        const start = Date.now();
+        const found: string[] = [];
+        let threw: Error | null = null;
+        try {
+            for await (const peer of client._helia.libp2p.contentRouting.findProviders(queryCid, { signal: ac.signal })) {
+                found.push(peer.id.toString());
+                break;
+            }
+        } catch (e) {
+            threw = e as Error;
+        }
+        expect(threw, threw ? `lookup threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
+        expect(found).to.deep.equal([]);
+        expect(Date.now() - start).to.be.lessThan(1_000);
+    });
+
+    // Cross-router de-duplication: when the SAME provider is announced by several routers, libp2p's
+    // CompoundContentRouting yields it only ONCE across the merged stream. This is what keeps warmup
+    // from dialing one peer N times when it's announced to the whole fleet (the common case — every
+    // healthy router serves the same record). Pins the behaviour so a libp2p upgrade can't regress it
+    // into an N-fold dial amplification.
+    it("yields the same provider only once even when three routers announce it", async () => {
+        const urls = await Promise.all([
+            startServingRouter({ delayMs: 0, providerId: providerPeerIdStr }),
+            startServingRouter({ delayMs: 0, providerId: providerPeerIdStr }),
+            startServingRouter({ delayMs: 0, providerId: providerPeerIdStr })
+        ]);
+        const client = await createHeliaWithRouters(urls);
+
+        const { found, threw } = await collectProviders(client, { want: 10, maxMs: 2_000 });
+        expect(threw, threw ? `lookup threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
+        const occurrences = found.filter((id) => id === providerPeerIdStr).length;
+        expect(occurrences).to.equal(1);
+    });
+
+    // A true black hole (accepts the connection, never replies, never closes) must not hang a lookup
+    // another router can satisfy: the good router's provider arrives promptly and the black hole's
+    // dangling request is cancelled on abort rather than gating the result. This is the dangerous mode
+    // ECONNREFUSED/404 don't reproduce — those end instantly, a black hole would otherwise wait forever.
+    it("a black-hole router does not stall a lookup another router can satisfy", async () => {
+        const blackhole = await startInspectableRouter({ faultMode: "blackHole" });
+        const goodUrl = await startServingRouter({ delayMs: 0, providerId: providerPeerIdStr });
+        // Black hole listed FIRST so any "wait for the first router" bug would surface as a hang.
+        const client = await createHeliaWithRouters([blackhole.url, goodUrl]);
+
+        const { found, firstMs, threw } = await lookupFirstProvider(client);
+        expect(threw, threw ? `lookup threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
+        expect(found).to.deep.equal([providerPeerIdStr]);
+        expect(firstMs!).to.be.lessThan(FAST_LOOKUP_MAX_MS);
+        await vi.waitFor(() => expect(blackhole.abortedProviderGetCount).to.be.greaterThan(0), { timeout: 3_000 });
     });
 });

--- a/test/node/helia/content-router-fault-tolerance.unit.test.ts
+++ b/test/node/helia/content-router-fault-tolerance.unit.test.ts
@@ -31,13 +31,22 @@ describeSkipIfRpc("Content router fault tolerance (issue #171)", () => {
 
     const queryCid: CID = pubsubTopicToDhtKeyCid("content-router-fault-tolerance-test-topic");
     let providerPeerIdStr: string;
+    // Distinct provider ids so timing tests can prove WHICH router's provider arrived first.
+    let secondProviderPeerIdStr: string;
+    let slowProviderPeerIdStr: string;
 
     const startedRouters: MockHttpRouter[] = [];
     const clientsToStop: Libp2pJsClient[] = [];
     let keyCounter = 0;
 
+    const newPeerIdStr = async () => peerIdFromPrivateKey(await generateKeyPair("Ed25519")).toString();
+
     beforeAll(async () => {
-        providerPeerIdStr = peerIdFromPrivateKey(await generateKeyPair("Ed25519")).toString();
+        [providerPeerIdStr, secondProviderPeerIdStr, slowProviderPeerIdStr] = await Promise.all([
+            newPeerIdStr(),
+            newPeerIdStr(),
+            newPeerIdStr()
+        ]);
     });
 
     afterEach(async () => {
@@ -122,6 +131,42 @@ describeSkipIfRpc("Content router fault tolerance (issue #171)", () => {
         return lookupFirstProvider(client);
     };
 
+    // Start a router that serves `providerId` for queryCid after `delayMs` (0 = immediate). Unlike the
+    // fixed "good"/"slow" kinds above, this lets a timing test seed a DISTINCT provider behind a chosen
+    // delay so it can assert which router's provider arrived.
+    const startServingRouter = async (opts: { delayMs?: number; providerId: string }): Promise<string> => {
+        const router = new MockHttpRouter({ providerGetDelayMs: opts.delayMs ?? 0 });
+        await router.start();
+        startedRouters.push(router);
+        router.addProviderForTesting(queryCid.toString(), { ID: opts.providerId, Addrs: ["/ip4/1.2.3.4/tcp/4001"] });
+        return router.url;
+    };
+
+    // Collect up to `want` providers, stopping as soon as we have them (or on the safety deadline).
+    // Returns how long the collection took so a test can prove it did not block on a slow router.
+    const collectProviders = async (
+        client: Libp2pJsClient,
+        opts: { want: number; maxMs: number }
+    ): Promise<{ found: string[]; elapsedMs: number; threw: Error | null }> => {
+        const ac = new AbortController();
+        const timer = setTimeout(() => ac.abort(), opts.maxMs);
+        const start = Date.now();
+        const found: string[] = [];
+        let threw: Error | null = null;
+        try {
+            for await (const peer of client._helia.libp2p.contentRouting.findProviders(queryCid, { signal: ac.signal })) {
+                found.push(peer.id.toString());
+                if (found.length >= opts.want) break;
+            }
+        } catch (e) {
+            threw = e as Error;
+        } finally {
+            clearTimeout(timer);
+            ac.abort();
+        }
+        return { found, elapsedMs: Date.now() - start, threw };
+    };
+
     // The core regression: a healthy router plus one connection-refused router. The good router is
     // given a small head start so the dead router's ECONNREFUSED is observed first — before the fix
     // that refusal rejected the merged stream and the lookup threw before ever yielding the provider.
@@ -174,5 +219,41 @@ describeSkipIfRpc("Content router fault tolerance (issue #171)", () => {
         const { found, threw } = await runScenario(["dead", "empty"]);
         expect(threw, threw ? `lookup threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
         expect(found).to.deep.equal([]);
+    });
+
+    // Core browser requirement: a router that responds with providers immediately must surface them
+    // right away even when another configured router takes 10s to respond. The merged stream yields
+    // providers as each router produces them, so the immediate provider arrives in well under 10s — we
+    // do NOT block on the slow router. Both routers serve a (distinct) provider so we can assert the
+    // FIRST one returned is the immediate router's, not the slow router's.
+    it("an immediate router's provider arrives without waiting for a 10s-slow router", async () => {
+        const slowUrl = await startServingRouter({ delayMs: 10_000, providerId: slowProviderPeerIdStr });
+        const immediateUrl = await startServingRouter({ delayMs: 0, providerId: providerPeerIdStr });
+        // Slow router listed FIRST to rule out any ordering luck.
+        const client = await createHeliaWithRouters([slowUrl, immediateUrl]);
+
+        const { found, firstMs, threw } = await lookupFirstProvider(client);
+        expect(threw, threw ? `lookup threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
+        expect(found).to.deep.equal([providerPeerIdStr]);
+        expect(firstMs).to.be.a("number");
+        // Nowhere near the slow router's 10s response time.
+        expect(firstMs!).to.be.lessThan(2_000);
+    });
+
+    // All immediately-available providers (from multiple fast routers) must be collected without
+    // blocking on a 10s-slow router. We ask for the two immediate providers and assert we get both
+    // quickly; the slow router's provider does not gate them.
+    it("collects all immediately-available providers without blocking on a 10s-slow router", async () => {
+        const immediate1 = await startServingRouter({ delayMs: 0, providerId: providerPeerIdStr });
+        const immediate2 = await startServingRouter({ delayMs: 0, providerId: secondProviderPeerIdStr });
+        const slow = await startServingRouter({ delayMs: 10_000, providerId: slowProviderPeerIdStr });
+        const client = await createHeliaWithRouters([slow, immediate1, immediate2]);
+
+        const { found, elapsedMs, threw } = await collectProviders(client, { want: 2, maxMs: 8_000 });
+        expect(threw, threw ? `lookup threw: ${threw.name}: ${threw.message}` : undefined).to.equal(null);
+        expect(found).to.have.members([providerPeerIdStr, secondProviderPeerIdStr]);
+        expect(found).to.not.include(slowProviderPeerIdStr);
+        // Both immediate providers were collected long before the slow router's 10s response.
+        expect(elapsedMs).to.be.lessThan(2_000);
     });
 });

--- a/test/node/helia/content-router-fault-tolerance.unit.test.ts
+++ b/test/node/helia/content-router-fault-tolerance.unit.test.ts
@@ -51,7 +51,15 @@ describeSkipIfRpc("Content router fault tolerance (issue #171)", () => {
 
     afterEach(async () => {
         // countOfUsesOfInstance starts at 1, so a single stop() tears each helia instance down.
-        while (clientsToStop.length) await clientsToStop.pop()!.heliaWithKuboRpcClientFunctions.stop();
+        // Isolate each stop() so a failing client shutdown still lets every router get destroyed below.
+        let stopError: unknown;
+        while (clientsToStop.length) {
+            try {
+                await clientsToStop.pop()!.heliaWithKuboRpcClientFunctions.stop();
+            } catch (e) {
+                stopError ??= e;
+            }
+        }
         while (startedRouters.length) {
             try {
                 await startedRouters.pop()!.destroy();
@@ -59,6 +67,7 @@ describeSkipIfRpc("Content router fault tolerance (issue #171)", () => {
                 // already destroyed (e.g. a "dead" router we closed on purpose)
             }
         }
+        if (stopError) throw stopError;
     });
 
     // Healthy and every unhealthy shape a real HTTP router can take. "dead"/"slow"/"empty" are the

--- a/test/node/helia/warmup-connect-to-pubsub-peers.unit.test.ts
+++ b/test/node/helia/warmup-connect-to-pubsub-peers.unit.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createLibp2pJsClientOrUseExistingOne } from "../../../dist/node/helia/helia-for-pkc.js";
+import { connectToPubsubPeers } from "../../../dist/node/helia/util.js";
+import { MockHttpRouter } from "../../../dist/node/runtime/node/test/mock-http-router.js";
+import { pubsubTopicToDhtKeyCid } from "../../../dist/node/util.js";
+import Logger from "../../../dist/node/logger.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { generateKeyPair } from "@libp2p/crypto/keys";
+import { peerIdFromPrivateKey } from "@libp2p/peer-id";
+import type { Libp2pJsClient } from "../../../dist/node/helia/libp2pjsClient.js";
+
+// Warmup-level coverage for src/helia/util.ts connectToPubsubPeers — the production consumer of the
+// content-routing layer that the findProviders fault-tolerance suite (content-router-fault-tolerance.unit.test.ts)
+// does NOT exercise. connectToPubsubPeers is what IPNS-over-pubsub warmup actually runs: it
+// findProviders(topicCid), dials each provider in parallel, and resolves the moment a remote peer's
+// gossipsub subscription-change for the topic is observed — OR, failing that, blocks up to the
+// hardcoded 10s TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS floor before giving up.
+//
+// The router-mix benchmark (.temp/router-mix-benchmark.mjs) showed the content-routing layer itself is
+// already fast and order-independent (~250ms to first dialable provider regardless of router order or
+// count, post-#171). So the remaining client-side speed lever is THIS layer: a community whose only
+// reachable record is undialable (e.g. a router announcing tcp/quic-only, or the dialable peer being
+// down) makes warmup eat the full 10s floor, while a community with one dialable+up subscriber returns
+// in well under a second. These tests pin both ends: a dialable subscriber is found fast and is NOT
+// slowed by black-hole / undialable noise, and the 10s floor is the bound (and the only knob) for the
+// no-dialable-peer case.
+//
+// Heavier than the findProviders suite: it needs a STARTED node-under-test plus a real second gossipsub
+// node that listens on /ws and subscribes to the topic, so the dial actually produces a
+// subscription-change. Client-side libp2p only and config-independent, so it runs once under non-RPC.
+describeSkipIfRpc("connectToPubsubPeers warmup (issue #171 follow-up)", () => {
+    // Mirrors TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS in src/helia/util.ts (not exported). Warmup blocks up to
+    // this long when it never observes a topic subscriber.
+    const TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS = 10_000;
+    // A successful warmup (dialable subscriber found) must finish far below the floor. Generous enough
+    // for CI jitter on a dial + identify + gossipsub subscription exchange between two local nodes,
+    // while still proving we did NOT wait the 10s floor.
+    const FAST_WARMUP_MAX_MS = 7_000;
+
+    const log = Logger("pkc-js:test:warmup");
+    const clientsToStop: Libp2pJsClient[] = [];
+    const startedRouters: MockHttpRouter[] = [];
+    let keyCounter = 0;
+
+    const newPeerIdStr = async () => peerIdFromPrivateKey(await generateKeyPair("Ed25519")).toString();
+
+    afterEach(async () => {
+        // countOfUsesOfInstance starts at 1, so a single stop() tears each helia instance down.
+        while (clientsToStop.length) await clientsToStop.pop()!.heliaWithKuboRpcClientFunctions.stop();
+        while (startedRouters.length) {
+            try {
+                await startedRouters.pop()!.destroy();
+            } catch {
+                // already destroyed
+            }
+        }
+    });
+
+    // Build a libp2p-js helia node. `listen` makes it bind a WebSocket listener (so it can be dialed and
+    // serve as the subscriber); the node-under-test stays listen-less (the production default). The dummy
+    // router keeps creation from throwing and is never expected to serve anything.
+    const createNode = async (opts: { listen?: boolean; routers?: string[] } = {}): Promise<Libp2pJsClient> => {
+        const client = (await createLibp2pJsClientOrUseExistingOne({
+            key: `warmup-${keyCounter++}`,
+            httpRoutersOptions: opts.routers ?? ["http://localhost:1"],
+            libp2pOptions: opts.listen ? { addresses: { listen: ["/ip4/127.0.0.1/tcp/0/ws"] } } : {},
+            heliaOptions: {}
+        })) as Libp2pJsClient;
+        clientsToStop.push(client);
+        return client;
+    };
+
+    // Stand up a real gossipsub node that subscribes to `topic` and listens on /ws, then return the
+    // provider record (peerId + dialable ws multiaddrs) that a router should serve for it. We subscribe
+    // via the GossipSub PROTOTYPE method, bypassing the instance-level subscribe monkey-patch that
+    // helia-for-pkc installs (it would kick off this helper node's OWN findProviders/10s-wait warmup
+    // against its dummy router and leak a timer past test teardown).
+    const startSubscriberNode = async (topic: string): Promise<{ ID: string; Addrs: string[] }> => {
+        const sub = await createNode({ listen: true });
+        const pubsub = sub._helia.libp2p.services.pubsub;
+        Object.getPrototypeOf(pubsub).subscribe.call(pubsub, topic);
+        const wsAddrs = sub._helia.libp2p
+            .getMultiaddrs()
+            .map((m) => m.toString())
+            .filter((a) => a.includes("/ws"))
+            // Strip the /p2p/<id> suffix so the record looks like a real delegated-routing record (ID + bare Addrs).
+            .map((a) => a.replace(/\/p2p\/[^/]+$/, ""));
+        expect(wsAddrs.length, "subscriber must expose at least one ws multiaddr").to.be.greaterThan(0);
+        return { ID: sub._helia.libp2p.peerId.toString(), Addrs: wsAddrs };
+    };
+
+    const startRouterServing = async (cid: string, provider: { ID: string; Addrs: string[] }): Promise<string> => {
+        const router = new MockHttpRouter();
+        await router.start();
+        startedRouters.push(router);
+        router.addProviderForTesting(cid, provider);
+        return router.url;
+    };
+
+    const startBlackHoleRouter = async (): Promise<string> => {
+        const router = new MockHttpRouter({ faultMode: "blackHole" });
+        await router.start();
+        startedRouters.push(router);
+        return router.url;
+    };
+
+    const topicFor = (suffix: string) => `warmup-test-topic-${suffix}-${keyCounter}`;
+
+    // The happy path: one router serving a dialable, subscribed peer. Warmup must dial it, observe the
+    // gossipsub subscription-change, and return in well under the 10s floor with the peer connected.
+    it("returns well under the 10s floor when a dialable subscriber is found", async () => {
+        const topic = topicFor("fast");
+        const cid = pubsubTopicToDhtKeyCid(topic).toString();
+        const subscriber = await startSubscriberNode(topic);
+        const routerUrl = await startRouterServing(cid, subscriber);
+        const node = await createNode({ routers: [routerUrl] });
+
+        const start = Date.now();
+        const connections = await connectToPubsubPeers({ helia: node._helia, pubsubTopic: topic, maxPeers: 4, log });
+        const elapsed = Date.now() - start;
+
+        expect(elapsed, `warmup took ${elapsed}ms, expected well under the ${TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS}ms floor`).to.be.lessThan(
+            FAST_WARMUP_MAX_MS
+        );
+        expect(connections.length, "should have connected to the dialable subscriber").to.be.greaterThan(0);
+        expect(node._helia.libp2p.services.pubsub.getSubscribers(topic).map((p) => p.toString())).to.include(subscriber.ID);
+    });
+
+    // The core fault-tolerance-for-speed claim at the warmup layer: a black-hole router (accepts then
+    // never replies) and a router serving only an UNDIALABLE record (a peer at a closed port) must not
+    // drag warmup toward the 10s floor when ONE router also serves a dialable, subscribed peer. The
+    // black hole's findProviders request is cancelled on subscription-change; the undialable dial fails
+    // fast; the dialable subscriber still resolves warmup quickly.
+    it("a black-hole + undialable-only fleet does not push warmup toward the floor when one dialable subscriber exists", async () => {
+        const topic = topicFor("noise");
+        const cid = pubsubTopicToDhtKeyCid(topic).toString();
+        const subscriber = await startSubscriberNode(topic);
+        const deadPeerId = await newPeerIdStr();
+
+        const blackHoleUrl = await startBlackHoleRouter();
+        const undialableUrl = await startRouterServing(cid, { ID: deadPeerId, Addrs: ["/ip4/127.0.0.1/tcp/1/ws"] }); // port 1 refuses
+        const goodUrl = await startRouterServing(cid, subscriber);
+        // Black hole + undialable listed FIRST so any "wait for earlier routers/providers" bug surfaces.
+        const node = await createNode({ routers: [blackHoleUrl, undialableUrl, goodUrl] });
+
+        const start = Date.now();
+        const connections = await connectToPubsubPeers({ helia: node._helia, pubsubTopic: topic, maxPeers: 4, log });
+        const elapsed = Date.now() - start;
+
+        expect(
+            elapsed,
+            `warmup took ${elapsed}ms despite noise, expected well under the ${TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS}ms floor`
+        ).to.be.lessThan(FAST_WARMUP_MAX_MS);
+        const connectedPeers = connections.map((c) => c.remotePeer.toString());
+        expect(connectedPeers, "should have connected to the dialable subscriber, not the dead peer").to.include(subscriber.ID);
+        expect(connectedPeers).to.not.include(deadPeerId);
+    });
+
+    // The floor itself, and the size of the win from a dialable peer. When the only record is undialable
+    // (peer at a closed port) and no subscriber ever appears, warmup is bounded by — and pays in full —
+    // the ~10s TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS, then throws ERR_FAILED_TO_DIAL_ANY_PEERS_PROVIDING_CID.
+    // Adding a single dialable subscriber collapses that to well under a second. This is the lever: the
+    // floor is what a stuck warmup costs, and it is the only client-side knob for the no-dialable case.
+    it("is bounded by the ~10s floor when no provider is dialable, and a dialable subscriber beats it by a wide margin", async () => {
+        // Leg 1: undialable-only record, no subscriber → pays the floor and throws.
+        const floorTopic = topicFor("floor");
+        const floorCid = pubsubTopicToDhtKeyCid(floorTopic).toString();
+        const deadPeerId = await newPeerIdStr();
+        const undialableUrl = await startRouterServing(floorCid, { ID: deadPeerId, Addrs: ["/ip4/127.0.0.1/tcp/1/ws"] });
+        const floorNode = await createNode({ routers: [undialableUrl] });
+
+        const floorStart = Date.now();
+        let floorThrew: Error | null = null;
+        try {
+            await connectToPubsubPeers({ helia: floorNode._helia, pubsubTopic: floorTopic, maxPeers: 4, log });
+        } catch (e) {
+            floorThrew = e as Error;
+        }
+        const floorElapsed = Date.now() - floorStart;
+
+        expect(floorThrew, "warmup with no dialable peer should throw after the floor").to.not.equal(null);
+        expect((floorThrew as Error & { code?: string }).code ?? floorThrew!.message).to.contain(
+            "ERR_FAILED_TO_DIAL_ANY_PEERS_PROVIDING_CID"
+        );
+        // Pays roughly the full floor: at least ~9s (allowing scheduler slack below the 10s nominal),
+        // and not wildly beyond it (no extra stall stacked on top).
+        expect(floorElapsed, `floor leg took ${floorElapsed}ms`).to.be.greaterThan(TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS - 1_500);
+        expect(floorElapsed, `floor leg took ${floorElapsed}ms`).to.be.lessThan(TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS + 4_000);
+
+        // Leg 2: same shape but with a dialable subscriber added → returns far below the floor.
+        const fastTopic = topicFor("floor-fast");
+        const fastCid = pubsubTopicToDhtKeyCid(fastTopic).toString();
+        const subscriber = await startSubscriberNode(fastTopic);
+        const goodUrl = await startRouterServing(fastCid, subscriber);
+        const fastNode = await createNode({ routers: [goodUrl] });
+
+        const fastStart = Date.now();
+        const connections = await connectToPubsubPeers({ helia: fastNode._helia, pubsubTopic: fastTopic, maxPeers: 4, log });
+        const fastElapsed = Date.now() - fastStart;
+
+        expect(connections.length).to.be.greaterThan(0);
+        expect(fastElapsed, `fast leg took ${fastElapsed}ms`).to.be.lessThan(FAST_WARMUP_MAX_MS);
+        // The dialable peer beat the floor by a wide margin — this is the speed delta the floor governs.
+        expect(fastElapsed).to.be.lessThan(floorElapsed - 3_000);
+    });
+
+    // The floor must also BOUND a router whose findProviders iterator never ends — a true black hole
+    // (accepts the GET, never responds, never closes). Such a router never yields and never ends its
+    // it-merge source, so the for-await over findProviders only terminates if something aborts it. The
+    // subscriber-wait timeout (the floor) is that something: on timeout, warmup must abort findProviders
+    // and give up, not pull the black hole's iterator forever. Regression guard — before the fix the
+    // floor-timeout path did NOT abort findProvidersAbort, so this hung well past the floor.
+    it("does not hang past the floor when the only router is a black hole and no subscriber appears", async () => {
+        const topic = topicFor("blackhole-floor");
+        const blackHoleUrl = await startBlackHoleRouter();
+        const node = await createNode({ routers: [blackHoleUrl] });
+
+        // Watchdog > floor (10s) + generous teardown. Hitting it means warmup hung on the black hole.
+        const HANG_WATCHDOG_MS = 20_000;
+        const ac = new AbortController();
+        let hung = false;
+        const start = Date.now();
+        const outcome = await Promise.race([
+            connectToPubsubPeers({ helia: node._helia, pubsubTopic: topic, maxPeers: 4, log, options: { signal: ac.signal } })
+                .then(() => "returned" as const)
+                .catch((e: Error) => e),
+            new Promise<"hung">((resolve) =>
+                setTimeout(() => {
+                    hung = true;
+                    resolve("hung");
+                }, HANG_WATCHDOG_MS)
+            )
+        ]);
+        const elapsed = Date.now() - start;
+        // Unblock any still-pending lookup (matters on the pre-fix hang) so afterEach teardown completes.
+        ac.abort();
+
+        expect(hung, `warmup did not terminate within ${HANG_WATCHDOG_MS}ms — the black hole hung the findProviders loop`).to.equal(false);
+        expect(elapsed, `warmup took ${elapsed}ms`).to.be.lessThan(TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS + 4_000);
+        // With no dialable peer it gives up at the floor the same way the undialable case does.
+        const outcomeErr = outcome as Error & { code?: string };
+        expect(outcomeErr?.code ?? outcomeErr?.message ?? "").to.contain("ERR_FAILED_TO_DIAL_ANY_PEERS_PROVIDING_CID");
+    });
+});

--- a/test/node/helia/warmup-connect-to-pubsub-peers.unit.test.ts
+++ b/test/node/helia/warmup-connect-to-pubsub-peers.unit.test.ts
@@ -219,19 +219,21 @@ describeSkipIfRpc("connectToPubsubPeers warmup (issue #171 follow-up)", () => {
         const HANG_WATCHDOG_MS = 20_000;
         const ac = new AbortController();
         let hung = false;
+        let watchdog: ReturnType<typeof setTimeout> | undefined;
         const start = Date.now();
         const outcome = await Promise.race([
             connectToPubsubPeers({ helia: node._helia, pubsubTopic: topic, maxPeers: 4, log, options: { signal: ac.signal } })
                 .then(() => "returned" as const)
                 .catch((e: Error) => e),
-            new Promise<"hung">((resolve) =>
-                setTimeout(() => {
+            new Promise<"hung">((resolve) => {
+                watchdog = setTimeout(() => {
                     hung = true;
                     resolve("hung");
-                }, HANG_WATCHDOG_MS)
-            )
+                }, HANG_WATCHDOG_MS);
+            })
         ]);
         const elapsed = Date.now() - start;
+        if (watchdog) clearTimeout(watchdog);
         // Unblock any still-pending lookup (matters on the pre-fix hang) so afterEach teardown completes.
         ac.abort();
 


### PR DESCRIPTION
Fixes #171.

## Problem

A single unreachable (connection-refused) HTTP router aborted the node's **entire** content-routing provider lookup. IPNS-over-pubsub warmup calls `helia.libp2p.contentRouting.findProviders(cid)`, which libp2p implements with `it-merge` over every configured router. The moment one router's iterator throws (e.g. `ECONNREFUSED` from a host that's up but whose service is down), the merged stream rejects — so `connectToPubsubPeers` re-threw, warmup failed, and every `community.update()` rejected instantly with `ERR_RESOLVED_IPNS_P2P_TO_UNDEFINED`, even when healthy routers were returning providers.

Per the issue's benchmark, a *slow* or *empty* router was correctly tolerated; only a *dead* (refused) router was fatal — proving the regression is specific to the iterator-level throw, not "an extra unhealthy router" in general.

## Fix

Wrap each router's `findProviders` in `getDelegatedRoutingFields` (`src/helia/helia-for-pkc.ts`) so its errors end **its** iterator instead of poisoning the merge. A dead/erroring router now degrades to the harmless "no providers" case (the underlying client already swallows `NotFoundError`; this additionally covers connection/transport errors and aborts). This is the issue's suggested option 1, applied at the source, so it also protects bitswap provider lookups that share the same merged iterator.

## Tests

`test/node/helia/content-router-fault-tolerance.unit.test.ts` drives `contentRouting.findProviders` directly against synthetic routers:

- **Regression:** good + connection-refused router → yields the provider, no throw. (Confirmed red against the unfixed build: `TypeError: fetch failed … ECONNREFUSED`.)
- **All combinations** of good/slow/empty/dead → as long as one router has the provider, the lookup yields it and is **not** slowed down by the unhealthy routers (asserts time-to-first-provider stays well under the 30s slow-router stall, and within a small delta of the good-only baseline).
- **All-bad** (dead + empty) → degrades gracefully to "no providers", no throw.

`MockHttpRouter` gains a configurable provider-GET delay (to emulate a slow/hanging router) and a direct provider-seeding helper. Existing `httprouter.test.ts` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content routing reliability so a single bad or slow router no longer blocks provider lookup.
  * Provider searches now fail gracefully with “no providers” instead of throwing when routers misbehave.
  * Warmup/connect flows now stop waiting on unresponsive provider sources and finish within a bounded time.
  * Reduced the chance of hangs and resource buildup when lookups are aborted or a router never responds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->