### PR TITLE
feat(rpc): createCommunity include:["started"] fast path for community-list started lookups

### DIFF
--- a/src/clients/rpc-client/pkc-rpc-client.ts
+++ b/src/clients/rpc-client/pkc-rpc-client.ts
@@ -5,7 +5,7 @@ import { PKCError } from "../../pkc-error.js";
 import EventEmitter from "events";
 import pTimeout from "p-timeout";
 import { hideClassPrivateProps, replaceXWithY, resolveWhenPredicateIsTrue } from "../../util.js";
-import type { CreateNewLocalCommunityUserOptions } from "../../community/types.js";
+import type { CreateNewLocalCommunityUserOptions, CommunityIncludeFields } from "../../community/types.js";
 import type { CommentChallengeRequestToEncryptType } from "../../publications/comment/types.js";
 import type { VoteChallengeRequestToEncryptType } from "../../publications/vote/types.js";
 import type { CommentEditChallengeRequestToEncryptType } from "../../publications/comment-edit/types.js";
@@ -37,6 +37,7 @@ import type {
     RpcSubscriptionIdResult,
     RpcSuccessResult,
     RpcFetchCidResult,
+    RpcCommunityStartedResult,
     ExportCommunityRpcParam,
     CancelExportRpcParam,
     RpcExportCommunityResult,
@@ -53,6 +54,7 @@ import {
     parseRpcCommunityPageParam,
     parseRpcResolveAuthorNameResult,
     parseRpcFetchCidResult,
+    parseRpcCommunityStartedResult,
     parseRpcSuccessResult,
     parseRpcSubscriptionIdResult,
     parseRpcExportCommunityParam,
@@ -359,7 +361,22 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
 
     async createCommunity(
         createCommunityOptions: CreateNewLocalCommunityUserOptions
-    ): Promise<RpcInternalCommunityRecordBeforeFirstUpdateType> {
+    ): Promise<RpcInternalCommunityRecordBeforeFirstUpdateType>;
+    async createCommunity(
+        createCommunityOptions: CommunityIdentifierRpcParam & { include: CommunityIncludeFields }
+    ): Promise<RpcCommunityStartedResult>;
+    async createCommunity(
+        createCommunityOptions: CreateNewLocalCommunityUserOptions | (CommunityIdentifierRpcParam & { include: CommunityIncludeFields })
+    ): Promise<RpcInternalCommunityRecordBeforeFirstUpdateType | RpcCommunityStartedResult> {
+        // Fast path: started-only (or other cheap-field) fetch of an EXISTING community — the server
+        // returns { address, started } from its in-memory registry without instantiating anything.
+        if (
+            "include" in createCommunityOptions &&
+            Array.isArray(createCommunityOptions.include) &&
+            createCommunityOptions.include.length > 0
+        ) {
+            return parseRpcCommunityStartedResult(await this._webSocketClient.call("createCommunity", [createCommunityOptions]));
+        }
         // This is gonna create a new local community. Not an instance of an existing community
         const communityProps = <RpcInternalCommunityRecordBeforeFirstUpdateType>(
             await this._webSocketClient.call("createCommunity", [createCommunityOptions])

--- a/src/clients/rpc-client/rpc-schema-util.ts
+++ b/src/clients/rpc-client/rpc-schema-util.ts
@@ -10,6 +10,7 @@ import {
     RpcUnsubscribeParamSchema,
     RpcResolveAuthorNameResultSchema,
     RpcFetchCidResultSchema,
+    RpcCommunityStartedResultSchema,
     RpcSuccessResultSchema,
     RpcSubscriptionIdResultSchema,
     RpcExportCommunityParamSchema,
@@ -34,6 +35,7 @@ export const parseRpcUnsubscribeParam = (params: unknown) => RpcUnsubscribeParam
 // Result parsers — all use .loose() so newer servers can send extra fields
 export const parseRpcResolveAuthorNameResult = (result: unknown) => RpcResolveAuthorNameResultSchema.loose().parse(result);
 export const parseRpcFetchCidResult = (result: unknown) => RpcFetchCidResultSchema.loose().parse(result);
+export const parseRpcCommunityStartedResult = (result: unknown) => RpcCommunityStartedResultSchema.loose().parse(result);
 export const parseRpcSuccessResult = (result: unknown) => RpcSuccessResultSchema.loose().parse(result);
 export const parseRpcSubscriptionIdResult = (result: unknown) => RpcSubscriptionIdResultSchema.loose().parse(result);
 

--- a/src/clients/rpc-client/schema.ts
+++ b/src/clients/rpc-client/schema.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 import { CommentIpfsSchema, CommentUpdateSchema } from "../../publications/comment/schema.js";
 import { AuthorAddressSchema, ChallengeAnswersSchema, CidStringSchema } from "../../schema/schema.js";
-import { CommunityEditOptionsSchema, CommunityExportRecordsSchema, ExportCommunityModLogsOptionsSchema } from "../../community/schema.js";
+import {
+    CommunityEditOptionsSchema,
+    CommunityExportRecordsSchema,
+    CommunityIncludeFieldsSchema,
+    ExportCommunityModLogsOptionsSchema
+} from "../../community/schema.js";
 import { CommentModerationsTableRowSchema } from "../../publications/comment-moderation/schema.js";
 import { NameResolveCacheOptionsSchema } from "../../schema.js";
 import type { EncodedDecryptedChallengeVerificationMessageType } from "../../pubsub-messages/types.js";
@@ -30,7 +35,8 @@ export const RpcCidParamSchema = z
 export const RpcCommunityIdentifierParamSchema = z
     .object({
         name: z.string().min(1).optional(),
-        publicKey: z.string().min(1).optional()
+        publicKey: z.string().min(1).optional(),
+        include: CommunityIncludeFieldsSchema.optional() // request only cheap fields (fast started-only fetch)
     })
     .refine((args) => args.name || args.publicKey, "At least one of name or publicKey must be provided");
 export const RpcFetchCidParamSchema = z.object({ cid: CidStringSchema });
@@ -62,6 +68,7 @@ export const RpcUnsubscribeParamSchema = z.object({ subscriptionId: Subscription
 export const RpcStateChangeEventResultSchema = z.object({ state: z.string() });
 export const RpcCommunitiesChangeEventResultSchema = z.object({ communities: z.array(z.string()) });
 export const RpcFetchCidResultSchema = z.object({ content: z.string() });
+export const RpcCommunityStartedResultSchema = z.object({ address: z.string(), started: z.boolean() }); // createCommunity({ include: ["started"] }) fast-path result
 export const RpcResolveAuthorNameResultSchema = z.object({ resolvedAuthorName: z.string().nullable() });
 export const RpcSuccessResultSchema = z.object({ success: z.literal(true) });
 export const RpcSubscriptionIdResultSchema = z.object({ subscriptionId: SubscriptionIdSchema }); // parsed with .loose() in rpc-schema-util.ts

--- a/src/clients/rpc-client/types.ts
+++ b/src/clients/rpc-client/types.ts
@@ -10,6 +10,7 @@ import {
     RpcPublishChallengeAnswersParamSchema,
     RpcResolveAuthorNameResultSchema,
     RpcFetchCidResultSchema,
+    RpcCommunityStartedResultSchema,
     RpcSuccessResultSchema,
     RpcSubscriptionIdResultSchema,
     RpcExportCommunityParamSchema,
@@ -38,6 +39,7 @@ export type ExportCommunityModLogsRpcParam = z.infer<typeof RpcExportCommunityMo
 // Result types (shared between RPC client and server)
 export type RpcResolveAuthorNameResult = z.infer<typeof RpcResolveAuthorNameResultSchema>;
 export type RpcFetchCidResult = z.infer<typeof RpcFetchCidResultSchema>;
+export type RpcCommunityStartedResult = z.infer<typeof RpcCommunityStartedResultSchema>;
 export type RpcSuccessResult = z.infer<typeof RpcSuccessResultSchema>;
 export type RpcSubscriptionIdResult = z.infer<typeof RpcSubscriptionIdResultSchema>;
 export type RpcExportCommunityResult = z.infer<typeof RpcExportCommunityResultSchema>;

--- a/src/community/schema.ts
+++ b/src/community/schema.ts
@@ -255,12 +255,17 @@ export const RpcRemoteCommunityUpdateEventResultSchema = z.object({
 });
 // At least one of address, name, or publicKey must be provided to identify the community
 
+// Cheap, in-memory community fields a caller can request without a full update/DB load.
+// Extensible: append new field names here as they become cheaply available on the daemon.
+export const CommunityIncludeFieldsSchema = z.array(z.enum(["started"]));
+
 export const CreateRemoteCommunityOptionsSchema = CommunityIpfsSchema.partial()
     .extend({
         address: CommunityAddressSchema.optional(), // instance-only, computed as name || publicKey if not provided
         publicKey: z.string().min(1).optional(), // B58 IPNS name (e.g. 12D3KooW...)
         posts: CommunityIpfsSchema.shape.posts.or(PostsPagesIpfsSchema.pick({ pageCids: true })),
-        updateCid: CidStringSchema.optional()
+        updateCid: CidStringSchema.optional(),
+        include: CommunityIncludeFieldsSchema.optional() // request only these cheap fields (fast started-only fetch)
     })
     .strict()
     .refine((opts) => opts.address || opts.name || opts.publicKey, "At least one of address, name, or publicKey must be provided");

--- a/src/community/types.ts
+++ b/src/community/types.ts
@@ -10,6 +10,7 @@ import {
     CreateNewLocalCommunityParsedOptionsSchema,
     CreateNewLocalCommunityUserOptionsSchema,
     CreateRemoteCommunityOptionsSchema,
+    CommunityIncludeFieldsSchema,
     GetChallengeArgsSchema,
     CommunityChallengeSchema,
     CommunityChallengeSettingSchema,
@@ -86,6 +87,7 @@ export interface CommunitySignature extends JsonSignature {
 }
 
 export type CreateRemoteCommunityOptions = z.infer<typeof CreateRemoteCommunityOptionsSchema>;
+export type CommunityIncludeFields = z.infer<typeof CommunityIncludeFieldsSchema>;
 
 export type CreateNewLocalCommunityUserOptions = z.infer<typeof CreateNewLocalCommunityUserOptionsSchema>;
 

--- a/src/pkc/pkc-with-rpc-client.ts
+++ b/src/pkc/pkc-with-rpc-client.ts
@@ -5,7 +5,13 @@ import { parseCreateRpcCommunityFunctionArgumentSchemaWithPKCErrorIfItFails } fr
 import { CreateRpcCommunityFunctionArgumentSchema } from "../community/schema.js";
 import { RpcLocalCommunity } from "../community/rpc-local-community.js";
 import { RpcRemoteCommunity } from "../community/rpc-remote-community.js";
-import type { RpcLocalCommunityJson, RpcLocalCommunityUpdateResultType, RpcRemoteCommunityJson } from "../community/types.js";
+import type {
+    CommunityIncludeFields,
+    CreateNewLocalCommunityUserOptions,
+    RpcLocalCommunityJson,
+    RpcLocalCommunityUpdateResultType,
+    RpcRemoteCommunityJson
+} from "../community/types.js";
 import { z } from "zod";
 import { PKCError } from "../pkc-error.js";
 import type { AuthorNameRpcParam, CidRpcParam } from "../clients/rpc-client/types.js";
@@ -120,6 +126,27 @@ export class PKCWithRpcClient extends PKC {
                 await community._attachExportsSubscription();
                 return community;
             } else if (isCommunityRpcLocal) {
+                // Fast path: caller only wants cheap in-memory fields (currently just `started`).
+                // Skip the subscribe → update() → wait → stop() cycle and do a single request/response
+                // that reads `started` from the daemon's in-memory registry. See issue #175.
+                const include = (parsedRpcOptions as { include?: CommunityIncludeFields }).include;
+                if (include?.length && include.every((f) => f === "started")) {
+                    try {
+                        const community = new RpcLocalCommunity(this);
+                        community.setAddress(effectiveAddress!);
+                        const startedResult = await this._pkcRpcClient!.createCommunity({
+                            name: community.name,
+                            publicKey: community.publicKey,
+                            include
+                        });
+                        community.started = startedResult.started;
+                        return community; // read-only snapshot: never subscribed, nothing to clean up
+                    } catch (e) {
+                        // Version skew: an old daemon rejects `include` or returns the full record shape
+                        // (parse fails) — fall through to the full createCommunity path below.
+                        log.trace("include:[started] fast path unsupported, falling back to full createCommunity", e);
+                    }
+                }
                 // No jsonified data — do a fresh fetch
                 const community = new RpcLocalCommunity(this);
                 community.setAddress(effectiveAddress!);
@@ -148,8 +175,10 @@ export class PKCWithRpcClient extends PKC {
                 await this._setCommunityIpfsOnInstanceIfPossible(remoteCommunity, parsedRpcOptions);
                 return remoteCommunity;
             }
-            // We're creating a new local community
-            const communityPropsAfterCreation = await this._pkcRpcClient!.createCommunity(parsedRpcOptions);
+            // We're creating a new local community (control flow above excludes remote/identifier cases)
+            const communityPropsAfterCreation = await this._pkcRpcClient!.createCommunity(
+                parsedRpcOptions as CreateNewLocalCommunityUserOptions
+            );
             log(
                 `Created new local-RPC community (${communityPropsAfterCreation.localCommunity.address}) with props:`,
                 JSON.parse(JSON.stringify(communityPropsAfterCreation))

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -95,6 +95,7 @@ import type {
     RpcSubscriptionIdResult,
     RpcSuccessResult,
     RpcFetchCidResult,
+    RpcCommunityStartedResult,
     RpcResolveAuthorNameResult,
     RpcCommentPageResult,
     RpcCommunityPageResult,
@@ -625,7 +626,17 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
         return { page, runtimeFields };
     }
 
-    async createCommunity(params: any): Promise<RpcInternalCommunityRecordBeforeFirstUpdateType> {
+    async createCommunity(params: any): Promise<RpcInternalCommunityRecordBeforeFirstUpdateType | RpcCommunityStartedResult> {
+        // Fast path: a caller that only wants cheap in-memory fields (currently just `started`)
+        // passes `include`. We read the started flag from the in-memory registry — no DB load,
+        // no community instantiation, no subscription. See pkc-js issue #175 (alternative to #141).
+        const includeFields = params[0]?.include;
+        if (Array.isArray(includeFields) && includeFields.length > 0 && includeFields.every((f: unknown) => f === "started")) {
+            const parsedIdentifier = parseRpcCommunityIdentifierParam(params[0]);
+            const pkcInstance = await this._getPKCInstance();
+            const started = Boolean(findStartedCommunity(pkcInstance, parsedIdentifier));
+            return { address: parsedIdentifier.name ?? parsedIdentifier.publicKey!, started };
+        }
         const createCommunityOptions = parseCreateNewLocalCommunityUserOptionsSchemaWithPKCErrorIfItFails(params[0]);
         const pkc = await this._getPKCInstance();
         const community = <LocalCommunity>await pkc.createCommunity(createCommunityOptions);
@@ -1150,6 +1161,17 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
             });
 
         const pkc = await this._getPKCInstance();
+
+        // Fast path: a subscriber that only wants the cheap in-memory `started` flag passes `include`.
+        // Emit an immediate started-only "update" and skip creating/binding a real community — no DB
+        // load, no update wait. See pkc-js issue #175 (alternative to #141).
+        if (Array.isArray(parsedArgs.include) && parsedArgs.include.length > 0 && parsedArgs.include.every((f) => f === "started")) {
+            const started = Boolean(findStartedCommunity(pkc, parsedArgs));
+            sendEvent("update", { address: parsedArgs.name ?? parsedArgs.publicKey!, started });
+            this.subscriptionCleanups[connectionId][subscriptionId] = async () => {}; // nothing created — no-op cleanup
+            return;
+        }
+
         const startedCommunity = findStartedCommunity(pkc, parsedArgs);
         const isStartedCommunity = Boolean(startedCommunity);
         const community = startedCommunity || <LocalCommunity | RemoteCommunity>await pkc.createCommunity(parsedArgs);

--- a/src/rpc/test/node/rpc.listeners.test.ts
+++ b/src/rpc/test/node/rpc.listeners.test.ts
@@ -7,6 +7,7 @@ import { findStartedCommunity } from "../../../../dist/node/pkc/tracked-instance
 import { mockRpcServerForTests, mockRpcServerPKC } from "../../../../dist/node/test/test-util.js";
 import { describeSkipIfRpc } from "../../../../test/helpers/conditional-tests.js";
 import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { RpcInternalCommunityRecordBeforeFirstUpdateType } from "../../../../dist/node/community/types.js";
 
 const { PKCWsServer: createPKCWsServer, setPKCJs } = PKCWsServerModule;
 
@@ -85,7 +86,7 @@ describeSkipIfRpc("PKCWsServer listener lifecycle", function () {
         };
 
         try {
-            const created = await rpcServer.createCommunity([{}]);
+            const created = (await rpcServer.createCommunity([{}])) as RpcInternalCommunityRecordBeforeFirstUpdateType;
             expect(created.localCommunity.address).to.be.a("string");
             expect(trackedCalls).to.have.length(0, "createCommunity should not track event listeners");
         } finally {
@@ -111,7 +112,7 @@ describeSkipIfRpc("PKCWsServer listener lifecycle", function () {
         const connectionId = "start-stop-connection";
         setupConnectionContext(rpcServer, connectionId);
 
-        const createResponse = await rpcServer.createCommunity([{}]);
+        const createResponse = (await rpcServer.createCommunity([{}])) as RpcInternalCommunityRecordBeforeFirstUpdateType;
         const address = createResponse.localCommunity.address;
         expect(address).to.be.a("string");
 
@@ -166,7 +167,7 @@ describeSkipIfRpc("PKCWsServer listener lifecycle", function () {
         const connectionId = "delete-connection";
         setupConnectionContext(rpcServer, connectionId);
 
-        const createResponse = await rpcServer.createCommunity([{}]);
+        const createResponse = (await rpcServer.createCommunity([{}])) as RpcInternalCommunityRecordBeforeFirstUpdateType;
         const address = createResponse.localCommunity.address;
         expect(address).to.be.a("string");
 

--- a/test/node/community/include-started.community.test.ts
+++ b/test/node/community/include-started.community.test.ts
@@ -1,0 +1,60 @@
+import { mockPKC } from "../../../dist/node/test/test-util.js";
+import { describeIfRpc } from "../../helpers/conditional-tests.js";
+import { findUpdatingCommunity } from "../../../dist/node/pkc/tracked-instance-registry-util.js";
+import { beforeAll, afterAll, it, expect, vi } from "vitest";
+import type { PKC } from "../../../dist/node/pkc/pkc.js";
+import type { RpcLocalCommunity } from "../../../dist/node/community/rpc-local-community.js";
+import type PKCRpcClient from "../../../dist/node/clients/rpc-client/pkc-rpc-client.js";
+
+// The `include: ["started"]` fast path only exists on the RPC client path (pkc-with-rpc-client):
+// it reads `started` from the daemon's in-memory registry via a single createCommunity RPC call,
+// skipping the subscribe -> update() -> wait -> stop() cycle. In non-RPC mode `include` is ignored,
+// so these assertions are meaningful only under RPC. See issue #175.
+describeIfRpc(`createCommunity({ include: ["started"] }) fast path (RPC)`, () => {
+    let pkc: PKC;
+    beforeAll(async () => {
+        pkc = await mockPKC();
+    });
+    afterAll(async () => {
+        await pkc.destroy();
+    });
+
+    it(`returns started true/false without opening an update subscription (unlike the full path)`, async () => {
+        const community = (await pkc.createCommunity()) as RpcLocalCommunity;
+        await community.start();
+
+        const rpcClient = (pkc as unknown as { _pkcRpcClient: PKCRpcClient })._pkcRpcClient;
+        const updateSubscribeSpy = vi.spyOn(rpcClient, "communityUpdateSubscribe");
+
+        // Fast path while the community is running: single request/response, no subscription.
+        updateSubscribeSpy.mockClear();
+        const startedSnapshot = (await pkc.createCommunity({
+            address: community.address,
+            include: ["started"]
+        })) as RpcLocalCommunity;
+        expect(startedSnapshot.address).to.equal(community.address);
+        expect(startedSnapshot.started).to.equal(true);
+        expect(startedSnapshot.updatedAt).to.be.undefined; // read-only snapshot: never waited for an update
+        expect(updateSubscribeSpy).toHaveBeenCalledTimes(0); // did NOT open an update subscription
+        expect(findUpdatingCommunity(pkc, { publicKey: community.publicKey, name: community.name })).to.be.undefined;
+
+        // Contrast: the plain (full) path DOES open an update subscription.
+        updateSubscribeSpy.mockClear();
+        await pkc.createCommunity({ address: community.address });
+        expect(updateSubscribeSpy.mock.calls.length).to.be.greaterThan(0);
+
+        await community.stop();
+
+        // Fast path after stop reports started=false, still without a subscription.
+        updateSubscribeSpy.mockClear();
+        const stoppedSnapshot = (await pkc.createCommunity({
+            address: community.address,
+            include: ["started"]
+        })) as RpcLocalCommunity;
+        expect(stoppedSnapshot.started).to.equal(false);
+        expect(stoppedSnapshot.updatedAt).to.be.undefined;
+        expect(updateSubscribeSpy).toHaveBeenCalledTimes(0);
+
+        updateSubscribeSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
Closes #175. Alternative to #141.

## Problem

A thin RPC client that only needs each community's `started` flag (e.g. the CLI `community list`) previously instantiated every community via the full `subscribe -> update() -> wait-for-first-update -> stop()` cycle. That's O(N) blocking round-trips that also serialize each **full** community record. Measured ~10-20s for 17 communities.

The `started` flag needs **zero DB load** — the daemon already holds it in memory (`findStartedCommunity`).

## Change

Add an optional `include` field-selection arg to `createCommunity`:

- `createCommunity({ address, include: ["started"] })` takes a **fast path**: a single `createCommunity` RPC request/response where the server reads `started` from its in-memory registry and returns `{ address, started }` — no DB load, no instantiation, no subscription.
- Falls back to the full cycle against an **old daemon** (version skew) — the old handler rejects the unknown `include` key, which the client catches and retries the normal way.
- `include` is also honored on `communityUpdateSubscribe` (emits an immediate started-only update).
- `pkc.communities` is **unchanged** (stays `string[]`) — this is the key difference from #141, which changed its element type.

`started` is the only cheap in-memory field today; the `include` enum is extensible for future cheap fields.

## Tests

- `test/node/community/include-started.community.test.ts` (RPC-only): asserts `started` true/false across start/stop and that the fast path opens **no** update subscription (spies `communityUpdateSubscribe`), unlike the full path.
- Local benchmark (empty communities): fast path is consistently 2.2-3.5x faster with matching `started` results; the production win is expected larger since it also skips full-record serialization.

## Verification

- `npm run build` clean; `npx tsc --project test/tsconfig.json --noEmit` clean.
- New test passes; `started-communities` and the touched `rpc.listeners` server test pass (no regression).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a faster community creation option that can return the community’s started status immediately.
  * Community creation now supports requesting only lightweight status data instead of a full community snapshot.

* **Bug Fixes**
  * Improved community creation behavior to avoid unnecessary follow-up updates when only the started state is needed.
  * Existing full community creation flow remains available and unchanged for standard use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->