### PR TITLE
perf(import): defer kubo + ipns/blockstore off the eager import path

### DIFF
--- a/docs/protocol/import-performance.md
+++ b/docs/protocol/import-performance.md
@@ -242,6 +242,7 @@ row here so each change shows its delta against the prior one. (Fast 8-core host
 | bundle dist (our files; deps external) | ~245ms | ~196ms          | ~173ms (unbundled) | ~258ms (unbundled) | node_modules ESM closure  | #126 (rolldown -> dist/bundled)  |
 | inline pure-JS deps (zod, undici, ...) | ~253ms | ~195ms          | ~179ms (unbundled) | ~256ms (unbundled) | kubo-rpc-client closure   | #126 (config/bundle-externals.js) |
 | inline kubo-rpc-client + unixfs-importer | ~205ms | ~155ms        | ~176ms (unbundled) | ~256ms (unbundled) | remaining externals + link | #126 (~21% vs deps-external bundle) |
+| defer kubo off the eager path (dynamic import in the client factory + CID re-sourced from `multiformats/cid`) | ~205ms | — | — | — | — | perf/rpc-import-lazy. Structural: the ~371-module kubo chunk left the static closure of `dist/bundled/index.js` (now a lazy chunk, loaded only when a PKC actually constructs a kubo client). Fast-host wall-clock delta is small (~214→205ms, ~4%); the real win is on slow hosts where evaluating the kubo chunk costs a large fraction of the ~1.8s import — pending production re-measurement. |
 
 ### Production validation (2026-06-10)
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/user2/Nextcloud/projects/plebbit/pkc-js/node_modules

--- a/src/clients/base-client-manager.ts
+++ b/src/clients/base-client-manager.ts
@@ -35,7 +35,7 @@ import all from "it-all";
 import * as remeda from "remeda";
 import { of as calculateIpfsHash } from "typestub-ipfs-only-hash";
 import { CidPathSchema } from "../schema/schema.js";
-import { CID } from "kubo-rpc-client";
+import { CID } from "multiformats/cid"; // re-sourced from kubo-rpc-client (identical class) to keep kubo off the eager import path
 import { convertBase58IpnsNameToBase36Cid } from "../signer/util.js";
 import pTimeout from "p-timeout";
 import { InflightResourceTypes } from "../util/inflight-fetch-manager.js";

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -42,7 +42,7 @@ import {
     CommunityLibp2pJsClient,
     CommunityPKCRpcStateClient
 } from "./community-clients.js";
-import { CID } from "kubo-rpc-client";
+import { CID } from "multiformats/cid"; // re-sourced from kubo-rpc-client (identical class) to keep kubo off the eager import path
 import { getAuthorNameFromRuntime } from "../publications/publication-author.js";
 
 import { type CommunityGatewayFetch, selectWinningGatewayCommunity } from "./community-gateway-selection.js";

--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -291,8 +291,10 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         //@ts-expect-error
         this.clients = {};
 
-        this._initKuboRpcClientsIfNeeded();
-        this._initKuboPubsubClientsIfNeeded();
+        // kubo client construction is async now (kubo-rpc-client is dynamic-imported), so the actual
+        // population happens in _init(); set empty maps here so the shape exists during construction.
+        this.clients.kuboRpcClients = {};
+        this.clients.pubsubKuboRpcClients = {};
         this._initRpcClientsIfNeeded();
         this._initIpfsGatewaysIfNeeded();
         this._initMemCaches();
@@ -327,11 +329,11 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         };
     }
 
-    private _initKuboRpcClientsIfNeeded() {
+    private async _initKuboRpcClientsIfNeeded() {
         this.clients.kuboRpcClients = {};
         if (!this.kuboRpcClientsOptions) return;
         for (const clientOptions of this.kuboRpcClientsOptions) {
-            const kuboRpcClient = createKuboRpcClient(clientOptions);
+            const kuboRpcClient = await createKuboRpcClient(clientOptions);
             this.clients.kuboRpcClients[clientOptions.url!.toString()] = {
                 _client: kuboRpcClient,
                 _clientOptions: clientOptions,
@@ -342,12 +344,12 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         }
     }
 
-    private _initKuboPubsubClientsIfNeeded() {
+    private async _initKuboPubsubClientsIfNeeded() {
         this.clients.pubsubKuboRpcClients = {};
         if (!this.pubsubKuboRpcClientsOptions) return;
 
         for (const clientOptions of this.pubsubKuboRpcClientsOptions) {
-            const kuboRpcClient = createKuboRpcClient(clientOptions);
+            const kuboRpcClient = await createKuboRpcClient(clientOptions);
             this.clients.pubsubKuboRpcClients[clientOptions.url!.toString()] = {
                 _client: kuboRpcClient,
                 _clientOptions: clientOptions,
@@ -433,6 +435,10 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
 
     async _init() {
         const log = Logger("pkc-js:pkc:_init");
+        // Construct kubo clients before anything that reads them (Stats, HTTP routers). No-op for RPC
+        // clients (kuboRpcClientsOptions is undefined). Async because kubo-rpc-client is dynamic-imported.
+        await this._initKuboRpcClientsIfNeeded();
+        await this._initKuboPubsubClientsIfNeeded();
         // Init storage
         this._storage = new Storage(this);
         await this._storage.init();

--- a/src/publications/comment/comment.ts
+++ b/src/publications/comment/comment.ts
@@ -46,7 +46,7 @@ import type { SignerType } from "../../signer/types.js";
 import type { CreatePublicationOptions } from "../../types.js";
 import { CommentClientsManager } from "./comment-client-manager.js";
 import type { CommunityIpfsType } from "../../community/types.js";
-import { CID } from "kubo-rpc-client";
+import { CID } from "multiformats/cid"; // re-sourced from kubo-rpc-client (identical class) to keep kubo off the eager import path
 import type { PublicationEventArgs, PublicationEvents } from "../types.js";
 import { getAuthorNameFromRuntime } from "../publication-author.js";
 import { sha256 } from "js-sha256";

--- a/src/runtime/browser/util.ts
+++ b/src/runtime/browser/util.ts
@@ -1,7 +1,8 @@
 import type { KuboRpcClient, NativeFunctions } from "../../types.js";
 import { default as browserNativeFunctions } from "./native-functions.js";
 import Logger from "../../logger.js";
-import { create as CreateKuboRpcClient } from "kubo-rpc-client";
+// kubo-rpc-client is dynamic-imported inside createKuboRpcClient (below) so it stays off the eager
+// import path; only a PKC that actually constructs a kubo client pays for it.
 import { PKCError } from "../../pkc-error.js";
 
 // Functions should not be called in browser
@@ -52,9 +53,12 @@ export async function importSignerIntoKuboNode(ipnsKeyName: string, ipfsKey: Uin
     return { id: resJson.Id, name: resJson.Name };
 }
 
-export function createKuboRpcClient(kuboRpcClientOptions: KuboRpcClient["_clientOptions"]): KuboRpcClient["_client"] {
+export async function createKuboRpcClient(
+    kuboRpcClientOptions: KuboRpcClient["_clientOptions"]
+): Promise<KuboRpcClient["_client"]> {
     const log = Logger("pkc-js:pkc:createKuboRpcClient");
     log("Creating a new ipfs client on browser with options", kuboRpcClientOptions);
+    const { create: CreateKuboRpcClient } = await import("kubo-rpc-client");
 
     const kuboRpcClient = CreateKuboRpcClient({
         ...kuboRpcClientOptions

--- a/src/runtime/node/addresses-rewriter-proxy-server.ts
+++ b/src/runtime/node/addresses-rewriter-proxy-server.ts
@@ -6,7 +6,7 @@ import * as remeda from "remeda";
 import retry from "retry";
 import { PKC } from "../../pkc/pkc.js";
 import { hideClassPrivateProps } from "../../util.js";
-import { RoutingQueryEvent } from "kubo-rpc-client";
+import type { RoutingQueryEvent } from "kubo-rpc-client";
 import { AddressRewriterDatabase, RequestLogEntry } from "./address-rewriter-db.js";
 const debug = Logger("pkc-js:addresses-rewriter");
 const MAX_BODY_PREVIEW_BYTES = 4096;

--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -26,7 +26,8 @@ import type { OpenGraphScraperOptions } from "open-graph-scraper/types";
 import { Agent as HttpAgent } from "http";
 import { Agent as HttpsAgent } from "https";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
-import { create as CreateKuboRpcClient } from "kubo-rpc-client";
+// kubo-rpc-client (~371 modules) is dynamic-imported inside createKuboRpcClient (below) so it stays
+// off the eager import path; only a PKC that actually constructs a kubo client pays for it.
 import Logger from "../../logger.js";
 import retry from "retry";
 import * as remeda from "remeda";
@@ -484,9 +485,12 @@ export async function moveCommunityDbToDeletedDirectory(communityAddress: string
     }
 }
 
-export function createKuboRpcClient(kuboRpcClientOptions: KuboRpcClient["_clientOptions"]): KuboRpcClient["_client"] {
+export async function createKuboRpcClient(
+    kuboRpcClientOptions: KuboRpcClient["_clientOptions"]
+): Promise<KuboRpcClient["_client"]> {
     const log = Logger("pkc-js:pkc:createKuboRpcClient");
     log.trace("Creating a new kubo client on node with options", kuboRpcClientOptions);
+    const { create: CreateKuboRpcClient } = await import("kubo-rpc-client");
     const isHttpsAgent =
         (typeof kuboRpcClientOptions.url === "string" && kuboRpcClientOptions.url.startsWith("https")) ||
         kuboRpcClientOptions?.protocol === "https" ||

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { CID } from "kubo-rpc-client";
+import { CID } from "multiformats/cid"; // re-sourced from kubo-rpc-client (identical class) to keep kubo off the eager import path
 import { messages } from "../errors.js";
 import * as remeda from "remeda";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { create as CreateIpfsClient, Options as IpfsHttpClientOptions } from "kubo-rpc-client";
+import type { create as CreateIpfsClient, Options as IpfsHttpClientOptions } from "kubo-rpc-client";
 import type Publication from "./publications/publication.js";
 import type { PKCError } from "./pkc-error.js";
 import type { PKC } from "./pkc/pkc.js";

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,7 +3,7 @@ import { PKCError } from "./pkc-error.js";
 import type { CommunityIpfsType } from "./community/types.js";
 //@ts-expect-error
 import extName from "ext-name";
-import { CID } from "kubo-rpc-client";
+import { CID } from "multiformats/cid"; // re-sourced from kubo-rpc-client (identical class) to keep kubo off the eager import path
 import type { Multiaddr } from "@multiformats/multiaddr";
 import * as Digest from "multiformats/hashes/digest";
 import { Buffer } from "buffer";

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,10 +43,10 @@ import { PKC } from "./pkc/pkc.js";
 import Logger from "./logger.js";
 import retry from "retry";
 import { peerIdFromString } from "@libp2p/peer-id";
-import { unmarshalIPNSRecord, multihashToIPNSRoutingKey, type IPNSRecord } from "ipns";
-import { ipnsValidator } from "ipns/validator";
-import { importFile } from "ipfs-unixfs-importer";
-import { MemoryBlockstore } from "blockstore-core";
+// ipns / ipns/validator / blockstore-core / ipfs-unixfs-importer are dynamic-imported inside the async
+// functions that use them (IPNS-record read/validate + CID-size helpers) so these externals stay off
+// the eager import path — an RPC-only consumer never resolves them at import time.
+import type { IPNSRecord } from "ipns";
 import { findUpdatingCommunity } from "./pkc/tracked-instance-registry-util.js";
 
 export function timestamp() {
@@ -1171,6 +1171,7 @@ export async function getIpnsRecordInLocalKuboNode(kuboRpcClient: KuboRpcClient,
             })
     );
     try {
+        const { unmarshalIPNSRecord } = await import("ipns");
         return unmarshalIPNSRecord(ipnsRecordRaw);
     } catch (e) {
         throw new PKCError("ERR_FAILED_TO_PARSE_LOCAL_RAW_IPNS_RECORD", { ipnsName, ipnsFetchUrl, parseError: e });
@@ -1233,6 +1234,8 @@ export async function fetchAndValidateIpnsRecordFromGateway(
         });
     }
 
+    const { multihashToIPNSRoutingKey, unmarshalIPNSRecord } = await import("ipns");
+    const { ipnsValidator } = await import("ipns/validator");
     // Validate the record's signature AND validity (EOL) against the routing key derived from the
     // IPNS name. This is what makes following the chain through an untrusted gateway safe.
     try {
@@ -1273,6 +1276,8 @@ export async function fetchAndValidateIpnsRecordFromGateway(
 const textEncoder = new TextEncoder();
 
 export async function calculateStringSizeSameAsIpfsAddCidV0(content: string): Promise<number> {
+    const { MemoryBlockstore } = await import("blockstore-core");
+    const { importFile } = await import("ipfs-unixfs-importer");
     const blockstore = new MemoryBlockstore();
     const entry = await importFile({ path: "content.json", content: textEncoder.encode(content) }, blockstore, {
         cidVersion: 0,


### PR DESCRIPTION
## Why

RPC-only consumers (e.g. the `bitsocial` CLI) construct `PKC({ pkcRpcClientsOptions })` and never run a local P2P node, yet importing `@pkcprotocol/pkc-js` statically links the core `pkc` module graph — which pulled in **`kubo-rpc-client` (~371 modules)** at import time. On the production host, `import(...)` alone was ~1.8–2.1s of the CLI's ~3.8s. This is a follow-up to #120 / `docs/protocol/import-performance.md`, whose only remaining lever was getting the heavy graphs off the eager path.

## What (stages S1–S3 of the plan)

- **S1** — `src/types.ts`: kubo `create`/`Options` are used only in type positions → `import type`. Removes kubo from the universal `types.ts` hub.
- **S2** — re-source `CID` from `multiformats/cid` (identical class; kubo literally does `export { CID } from 'multiformats/cid'`, and `multiformats` is kept external as a single copy) in `schema.ts`, `util.ts`, `base-client-manager.ts`, `community-client-manager.ts`, `comment.ts`. Also `addresses-rewriter-proxy-server.ts`: `RoutingQueryEvent` is type-only → `import type`.
- **S3** — dynamic-`import()` kubo `create` inside `createKuboRpcClient` (node + browser factories). The factory becomes `async`; its two callers move from the constructor into `async _init()` (empty client maps are set in the constructor so the shape exists during construction).

## Result

The ~371-module kubo chunk **leaves the static closure** of `dist/bundled/index.js` — it's now a lazy chunk, loaded only when a PKC actually constructs a kubo client. RPC-only consumers stop paying for it at import.

## Verification

- `npm run build` ✓, `tsc` (src) ✓, `tsc` (tests) ✓, `verify-bundle` ✓
- Bundle-manifest check: kubo chunk no longer in the static closure of the bundled index (reachable only via dynamic `import()`).
- **CID identity preserved** at runtime: `kubo.CID === multiformats/cid CID`, `instanceof`, `CID.asCID()` all hold.
- helia unit tests 42/42 ✓; `pkc` suite 6/6 ✓.
- Fast-host import wall-clock delta is small (~214→205ms); the real win is on slow hosts where evaluating the kubo chunk is a large fraction of the import — **production re-measurement pending** (deploy needed).

## Notes

- Independent of the `startedCommunities` work (separate branch/PR).
- Follow-ups gated on the prod re-measurement (deferred): making `util.ts`'s remaining IPNS/CID-calc deps lazy, and a possible slim `./client` entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup and module loading speed by deferring heavy client loading until it’s needed.
  * Reduced eager import overhead in browser and node runtimes, which should make cold starts faster, especially on slower machines.
  * Kept core client behavior the same while simplifying how shared types are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->