### PR TITLE
perf(import): slim ./client entry for RPC-only consumers

### DIFF
--- a/config/build-node-bundle.js
+++ b/config/build-node-bundle.js
@@ -58,6 +58,8 @@ const bundle = await rolldown({
     input: {
         index: "dist/node/index.js",
         "index-with-compile-cache": "dist/node/index-with-compile-cache.js",
+        client: "dist/node/client.js",
+        "client-with-compile-cache": "dist/node/client-with-compile-cache.js",
         challenges: "dist/node/challenges.js",
         "rpc/src/index": "dist/node/rpc/src/index.js"
     },

--- a/config/verify-bundle.js
+++ b/config/verify-bundle.js
@@ -74,6 +74,38 @@ for (const lazyInput of lazyInputs) {
     }
 }
 
+// --- 1a. The slim ./client entry must NOT statically pull the local-node / signer / community graph.
+// This is the whole point of the entry (issue #120, Lever B): an RPC-only consumer that never
+// materializes a community must pay only the transport floor. These subgraphs are dynamic-imported
+// behind the async createCommunity / create* boundaries in pkc.ts + pkc-with-rpc-client.ts, so a
+// refactor that makes any of them a static import again should fail the build here.
+const clientClosure = staticClosure("client.js");
+const clientLazyInputs = [
+    "dist/node/helia/helia-for-pkc.js",
+    "dist/node/runtime/node/community/local-community.js",
+    "dist/node/signer/util.js", // -> @libp2p/peer-id, @noble/curves (the ~380ms blocker)
+    "dist/node/signer/signatures.js",
+    "dist/node/pages/pages.js",
+    "dist/node/publications/comment/comment.js", // -> typestub-ipfs-only-hash
+    "dist/node/publications/vote/vote.js",
+    "dist/node/publications/comment-edit/comment-edit.js",
+    "dist/node/publications/comment-moderation/comment-moderation.js",
+    "dist/node/publications/community-edit/community-edit.js",
+    "dist/node/community/remote-community.js",
+    "dist/node/community/community-client-manager.js"
+];
+for (const lazyInput of clientLazyInputs) {
+    const fileName = outputContainingInput(lazyInput);
+    if (!fileName) {
+        problems.push(`${lazyInput} is in no bundled output - was it renamed? Update verify-bundle.js.`);
+    } else if (clientClosure.has(fileName)) {
+        problems.push(
+            `${lazyInput} (in ${fileName}) is in the STATIC import closure of dist/bundled/client.js - ` +
+                `the slim RPC-only client entry (issue #120, Lever B) would over-import the local-node runtime.`
+        );
+    }
+}
+
 // --- 1b. External allowlist: only declared externals may stay bare ---------------------------
 
 for (const [fileName, out] of Object.entries(outputs)) {
@@ -105,9 +137,24 @@ if (!bootstrap.includes('import("./index.js")')) {
     );
 }
 
+const clientBootstrap = fs.readFileSync(path.join(bundledDir, "client-with-compile-cache.js"), "utf8");
+if (!clientBootstrap.includes('import("./client.js")')) {
+    problems.push(
+        'dist/bundled/client-with-compile-cache.js lost its dynamic import("./client.js") boundary - ' +
+            "the compile cache would no longer cover the client graph."
+    );
+}
+
 // --- 3 + 4. Export parity and require(esm), in fresh child processes -------------------------
 
-const entries = ["index.js", "index-with-compile-cache.js", "challenges.js", "rpc/src/index.js"];
+const entries = [
+    "index.js",
+    "index-with-compile-cache.js",
+    "client.js",
+    "client-with-compile-cache.js",
+    "challenges.js",
+    "rpc/src/index.js"
+];
 
 function exportKeysInChildProcess(fileAbsPath) {
     const script = `const m = await import(${JSON.stringify(url.pathToFileURL(fileAbsPath).href)}); console.log(JSON.stringify(Object.keys(m).sort()));`;
@@ -127,7 +174,7 @@ for (const entry of entries) {
     }
 }
 
-for (const requireEntry of ["index.js", "rpc/src/index.js"]) {
+for (const requireEntry of ["index.js", "client.js", "rpc/src/index.js"]) {
     const fileAbsPath = path.join(bundledDir, requireEntry);
     const script = `const { createRequire } = require("node:module"); createRequire(process.cwd() + "/")(${JSON.stringify(fileAbsPath)}); console.log("ok");`;
     try {

--- a/docs/protocol/import-performance.md
+++ b/docs/protocol/import-performance.md
@@ -151,9 +151,41 @@ were consolidated into it).
     pays a one-time ~30ms cache-population cost. Cache dir is Node's default
     (`os.tmpdir()/node-compile-cache`), overridable with `NODE_COMPILE_CACHE`; opt out with
     `NODE_DISABLE_COMPILE_CACHE=1`.
--   [ ] **Thin client entry point** — e.g. a `./client` export that pulls a minimal graph so RPC-only
-        consumers never resolve/link the local-node modules at all. Likely unnecessary now that the
-        heavy leaves are lazy; revisit only if the residual is still too high on slow hardware.
+-   [x] **Thin client entry point** (`./client`) — a slim RPC-only export for consumers that only talk
+        to a remote daemon over RPC (e.g. the bitsocial CLI) and never start a local node. It constructs
+        `PKCWithRpcClient` directly and throws if `pkcRpcClientsOptions` is absent. The win came less from
+        the entry file itself and more from pushing the heavy subgraphs behind dynamic `import()`s on the
+        `create*`/`createCommunity`/publish/gateway paths so a bare RPC import never resolves/links them:
+
+    -   **signer/pages/community/publication subtree** — all `create*` factories in
+        [`src/pkc/pkc.ts`](../../src/pkc/pkc.ts) and the `Rpc*Community` classes in
+        [`src/pkc/pkc-with-rpc-client.ts`](../../src/pkc/pkc-with-rpc-client.ts) now dynamic-import
+        through one barrel, [`src/pkc/lazy-runtime.ts`](../../src/pkc/lazy-runtime.ts). Funnelling every
+        heavy import through a single dynamic entry keeps the whole subtree (comment →
+        `typestub-ipfs-only-hash`, `signer/util` → `@libp2p/peer-id`, pages, the community classes) in
+        one lazy chunk that no entry references statically — otherwise rolldown hoists a module shared by
+        two lazy chunks into the shared static chunk and defeats the laziness.
+    -   **kubo-rpc-client** (~371 modules incl. `@libp2p/peer-id`) — `create` is dynamic-imported inside
+        `createKuboRpcClient`, and kubo client construction moved from the `PKC` constructor to the async
+        `_init()`. RPC-only clients never build a kubo client, so they never import the graph.
+    -   **undici** (~112 modules) — the global-fetch body-timeout patch left `polyfill.ts` (which forced
+        undici into every import graph) and is now applied lazily on the first kubo/gateway fetch.
+    -   **open-graph-scraper + probe-image-size** (~230 modules of HTML/image parsing) and
+        **ipfs-unixfs-importer + blockstore-core** (~40) — dynamic-imported at their publish-path use
+        sites in `runtime/node/util.ts` and `util.ts`.
+    -   Small relocations so ubiquitously-imported `util.ts`/`runtime/node/util.ts` stop pulling
+        `@libp2p/peer-id`/`typestub`: `ipnsNameToIpnsOverPubsubTopic` moved to
+        [`src/ipns-pubsub-topic.ts`](../../src/ipns-pubsub-topic.ts); `CID` re-sourced from
+        `multiformats/cid` (identity-safe, cf. PR #177); `MAX_FILE_SIZE_BYTES_FOR_COMMENT_UPDATE` moved
+        to `constants.ts`.
+
+    Result: the `./client` static closure went from **952 → 309 modules** with **zero** heavy static
+    externals (no `@libp2p/peer-id`, `typestub-ipfs-only-hash`, `kubo-rpc-client`, or `undici`).
+    `config/verify-bundle.js` asserts this closure stays clean. Because most of the deferrals live in
+    shared code (`pkc.ts`, `util.ts`, `runtime/node/util.ts`), the `.` entry benefits too. The residual
+    309 modules are dominated by `remeda` (164 — a namespace import rolldown will not tree-shake) plus
+    the core zod/cborg/PKC-shell graph; getting materially below this needs a remeda replacement or a
+    deeper split of the `PKC` base class (follow-ups).
 -   [x] **Bundle the published `dist` (our files; deps external)** (done in #126) — a rolldown step
         ([`config/build-node-bundle.js`](../../config/build-node-bundle.js)) collapses the compiled
         `dist/node/*.js` graph into a few ESM chunks under `dist/bundled/`, and the package.json
@@ -242,6 +274,11 @@ row here so each change shows its delta against the prior one. (Fast 8-core host
 | bundle dist (our files; deps external) | ~245ms | ~196ms          | ~173ms (unbundled) | ~258ms (unbundled) | node_modules ESM closure  | #126 (rolldown -> dist/bundled)  |
 | inline pure-JS deps (zod, undici, ...) | ~253ms | ~195ms          | ~179ms (unbundled) | ~256ms (unbundled) | kubo-rpc-client closure   | #126 (config/bundle-externals.js) |
 | inline kubo-rpc-client + unixfs-importer | ~205ms | ~155ms        | ~176ms (unbundled) | ~256ms (unbundled) | remaining externals + link | #126 (~21% vs deps-external bundle) |
+| `./client` slim entry + defer kubo/undici/signer/thumbnail | index ~119ms cold / ~99ms warm; **client ~113ms cold / ~97ms warm** | — | — | — | `remeda` (164 mods) + zod/cborg/PKC shell | #120 (client closure 952 → 309 modules) |
+
+On this fast host the absolute deltas are tiny (the residual graph link dominates and both entries
+now defer the same heavy leaves); the change matters on slow hardware, where per-module ESM link cost
+is ~10× higher — see the production numbers below.
 
 ### Production validation (2026-06-10)
 
@@ -295,3 +332,29 @@ multiformats identity layer — plus link/exec of the bundle itself), ~1.2s the 
 uncached graph (bitsocial-cli compile-cache issue), ~2s RPC work (daemon-side; next lever
 would be batching the per-community `createCommunity` round trips or including `started` in
 the communities subscription).
+
+### Production validation — `./client` slim entry (2026-07-05)
+
+Deployed this branch's `dist/` + `package.json` into the CLI's pkc-js install (slow host, Node
+v22.22.2) and timed a fresh-process import of the bundled bootstrap entries (6–7 runs, drop the
+cold first run, median):
+
+| Entry (bundled `*-with-compile-cache.js`) | before (deployed `.` baseline) | after (this branch) |
+| ----------------------------------------- | ------------------------------ | ------------------- |
+| `.` (index)                               | ~1968ms                        | **~1360ms**         |
+| `./client`                                | n/a (new)                      | **~1220ms** (~38% vs the `.` baseline) |
+
+`bitsocial community list -q` (steady state, the CLI still imports the `.` entry until the CLI is
+switched to `./client`): **~3.34s → ~2.6s** (~22%). The `./client` import is ~140ms below the new
+`.` import — that gap is `@libp2p/peer-id`, which the `.` entry still pulls statically through the
+challenges subsystem but `./client` never touches.
+
+Neither entry is sub-second on this host: after removing `@libp2p/peer-id`, kubo-rpc-client, undici,
+typestub and the thumbnail graph from the `./client` static closure (952 → 309 modules), the residual
+is `remeda` (164 tiny per-function modules that a `import * as remeda` namespace import prevents
+rolldown from tree-shaking) plus the core zod/cborg/PKC-shell graph. Reaching sub-second would need a
+remeda replacement (or a working tree-shake of it) and/or splitting the `PKC` base class so the RPC
+client links even fewer of the schema/client-manager modules — larger, separate efforts.
+
+Prod restored to the prior deployed `dist/` + `package.json` after measuring (`community list`
+verified to still print the full started-column table).

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -3,6 +3,8 @@
     "entry": [
         // package.json "exports" point at dist/, knip auto-detects the other src entries
         "src/index-with-compile-cache.ts",
+        // slim RPC-only ./client entry + its compile-cache bootstrap (issue #120)
+        "src/client-with-compile-cache.ts",
         // standalone bootstrap for running the RPC server directly
         "src/rpc/start.js",
         // the browser build is a post-build text replacement of /runtime/node/ -> /runtime/browser/

--- a/package.json
+++ b/package.json
@@ -54,6 +54,12 @@
             "import": "./dist/bundled/index-with-compile-cache.js",
             "require": "./dist/bundled/index.js"
         },
+        "./client": {
+            "types": "./dist/node/client.d.ts",
+            "browser": "./dist/browser/client.js",
+            "import": "./dist/bundled/client-with-compile-cache.js",
+            "require": "./dist/bundled/client.js"
+        },
         "./challenges": {
             "types": "./dist/node/challenges.d.ts",
             "browser": null,

--- a/scripts/bench-import-time.js
+++ b/scripts/bench-import-time.js
@@ -46,6 +46,10 @@ const targets = [
     { label: "challenges subsystem", file: "runtime/node/community/challenges/index.js" },
     { label: "pkc core class", file: "pkc/pkc.js" },
     { label: "pkc-with-rpc-client (extends PKC)", file: "pkc/pkc-with-rpc-client.js" },
+    // The slim RPC-only entry (issue #120, Lever B): should land near the rpc-client floor, NOT near
+    // pkc-with-rpc-client, because the signer/pages/community subgraphs are dynamic-imported behind
+    // the async createCommunity / create* boundaries and never loaded on a bare import.
+    { label: "client.js (slim RPC-only entry)", file: "client.js" },
     { label: "index.js (public entry)", file: "index.js" },
     // cache disabled in cold runs (NODE_DISABLE_COMPILE_CACHE=1), so this row isolates the
     // bootstrap wrapper's own overhead vs index.js — it should be ~0
@@ -112,6 +116,8 @@ console.log(`| --- | --- | --- | --- |`);
 const bundledTargets = [
     { label: "index.js (public entry)", file: "index.js" },
     { label: "index-with-compile-cache.js (npm import entry, cache disabled)", file: "index-with-compile-cache.js" },
+    { label: "client.js (slim RPC-only entry)", file: "client.js" },
+    { label: "client-with-compile-cache.js (npm import entry, cache disabled)", file: "client-with-compile-cache.js" },
     { label: "challenges.js", file: "challenges.js" },
     { label: "rpc/src/index.js (RPC server)", file: "rpc/src/index.js" }
 ];

--- a/scripts/smoke-pack-install.js
+++ b/scripts/smoke-pack-install.js
@@ -75,14 +75,26 @@ if (!resolvedEntry.includes("dist/bundled/")) {
 }
 
 // 3. Import every public subpath, ESM and CJS.
-for (const subpath of ["@pkcprotocol/pkc-js", "@pkcprotocol/pkc-js/challenges", "@pkcprotocol/pkc-js/rpc"]) {
+for (const subpath of ["@pkcprotocol/pkc-js", "@pkcprotocol/pkc-js/client", "@pkcprotocol/pkc-js/challenges", "@pkcprotocol/pkc-js/rpc"]) {
     run(`esm import ${subpath}`, process.execPath, ["--input-type=module", "-e", `await import(${JSON.stringify(subpath)});`], {
         cwd: consumerDir
     });
 }
-for (const subpath of ["@pkcprotocol/pkc-js", "@pkcprotocol/pkc-js/rpc"]) {
+for (const subpath of ["@pkcprotocol/pkc-js", "@pkcprotocol/pkc-js/client", "@pkcprotocol/pkc-js/rpc"]) {
     run(`cjs require ${subpath}`, process.execPath, ["-e", `require(${JSON.stringify(subpath)});`], { cwd: consumerDir });
 }
+// The slim ./client entry must reject when constructed without an RPC client (it has no local node).
+run(
+    "client entry rejects without pkcRpcClientsOptions",
+    process.execPath,
+    [
+        "--input-type=module",
+        "-e",
+        `import PKC from "@pkcprotocol/pkc-js/client";
+         await PKC({}).then(() => { console.error("expected client PKC() to reject"); process.exit(1); }, () => {});`
+    ],
+    { cwd: consumerDir }
+);
 
 // 4. Real work: createCommunity() through the installed bundle. This crosses the lazy
 // local-community chunk boundary and opens a better-sqlite3 database on disk.
@@ -158,7 +170,12 @@ for (const dep of inlinedDeps) {
 }
 console.log(`hid ${hidden.length} inlined dependencies from the consumer's node_modules`);
 try {
-    for (const subpath of ["@pkcprotocol/pkc-js", "@pkcprotocol/pkc-js/challenges", "@pkcprotocol/pkc-js/rpc"]) {
+    for (const subpath of [
+        "@pkcprotocol/pkc-js",
+        "@pkcprotocol/pkc-js/client",
+        "@pkcprotocol/pkc-js/challenges",
+        "@pkcprotocol/pkc-js/rpc"
+    ]) {
         run(
             `esm import ${subpath} (inlined deps hidden)`,
             process.execPath,

--- a/src/client-with-compile-cache.ts
+++ b/src/client-with-compile-cache.ts
@@ -1,0 +1,21 @@
+// Thin bootstrap for the `"./client"` -> `import` condition, mirroring index-with-compile-cache.ts.
+// It enables Node's on-disk V8 compile cache and ONLY THEN dynamic-imports the real slim entry, so
+// the whole (small) client graph compiles with the cache active and later runs reuse the cached
+// bytecode. See index-with-compile-cache.ts for why the separate-file + dynamic-import dance is
+// required (the cache only covers modules compiled after the call, and Node compiles the entire
+// static graph before any module body runs).
+import { enableNodeCompileCache } from "./runtime/node/compile-cache.js";
+
+enableNodeCompileCache();
+
+const client = await import("./client.js");
+
+export default client.default;
+export const setNativeFunctions = client.setNativeFunctions;
+export const nativeFunctions = client.nativeFunctions;
+export const getShortCid = client.getShortCid;
+export const getShortAddress = client.getShortAddress;
+
+// Keep the type-only surface identical to client.ts.
+export type { NameResolverInterface } from "./schema.js";
+export type { NameResolver } from "./types.js";

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,62 @@
+// Slim RPC-only entry (`"./client"` export). Issue #120 / Lever B: consumers that ONLY talk to a
+// remote daemon over RPC (e.g. the bitsocial CLI) never start a local P2P node, yet importing the
+// full "." entry drags in the signer (-> @libp2p/peer-id), the pages/comment graph
+// (-> typestub-ipfs-only-hash) and the community subtree — hundreds of ms on slow hosts for code the
+// RPC path never runs.
+//
+// This entry constructs PKCWithRpcClient directly and imports only the RPC transport graph. The heavy
+// subgraphs (community classes, publications, signer, pages) are dynamic-imported behind the async
+// createCommunity / create* / publish boundaries in pkc.ts + pkc-with-rpc-client.ts, so a fresh
+// `import("@pkcprotocol/pkc-js/client")` — and read-only commands like `community list` that never
+// materialize a community — pay only the transport floor. config/verify-bundle.js asserts those
+// subgraphs are NOT in this entry's static closure.
+//
+// It is a strict subset of the "." entry: same PKC factory shape, but it throws if the caller did not
+// pass pkcRpcClientsOptions (there is no local node here to fall back to).
+import "./zod-error-map.js";
+import polyfill from "./runtime/node/polyfill.js";
+polyfill();
+import { PKCWithRpcClient } from "./pkc/pkc-with-rpc-client.js";
+import type { InputPKCOptions } from "./types.js";
+import type { PKC as PKCClass } from "./pkc/pkc.js";
+import { setNativeFunctions as utilSetNativeFunctions } from "./runtime/node/util.js";
+import nodeNativeFunctions from "./runtime/node/native-functions.js";
+import browserNativeFunctions from "./runtime/browser/native-functions.js";
+import { shortifyAddress, shortifyCid } from "./util.js";
+import type { AuthorNameRpcParam, CidRpcParam } from "./clients/rpc-client/types.js";
+import { parseRpcAuthorNameParam, parseRpcCidParam } from "./clients/rpc-client/rpc-schema-util.js";
+
+const PKC = async function PKC(pkcOptions: InputPKCOptions = {}): Promise<PKCClass> {
+    if (!pkcOptions.pkcRpcClientsOptions?.length)
+        throw new Error(
+            '@pkcprotocol/pkc-js/client is an RPC-only entry: pass pkcRpcClientsOptions (e.g. ["ws://localhost:9138"]). ' +
+                'For a local IPFS/libp2p or gateway node, import the default "@pkcprotocol/pkc-js" entry instead.'
+        );
+    const pkc = new PKCWithRpcClient(pkcOptions);
+    await pkc._init();
+    return pkc;
+};
+
+const getShortAddressValue = (params: AuthorNameRpcParam) => {
+    const parsed = parseRpcAuthorNameParam(params);
+    return shortifyAddress(parsed.name);
+};
+const getShortCidValue = (params: CidRpcParam) => {
+    const parsed = parseRpcCidParam(params);
+    return shortifyCid(parsed.cid);
+};
+
+PKC.setNativeFunctions = utilSetNativeFunctions;
+PKC.nativeFunctions = { node: nodeNativeFunctions, browser: browserNativeFunctions };
+PKC.getShortCid = getShortCidValue;
+PKC.getShortAddress = getShortAddressValue;
+export default PKC;
+export const setNativeFunctions = PKC.setNativeFunctions;
+export const nativeFunctions = PKC.nativeFunctions;
+export const getShortCid = PKC.getShortCid;
+export const getShortAddress = PKC.getShortAddress;
+
+// Public type surface — keep identical to the "." entry so `@pkcprotocol/pkc-js/client` is a drop-in
+// for RPC-only consumers.
+export type { NameResolverInterface } from "./schema.js";
+export type { NameResolver } from "./types.js";

--- a/src/clients/base-client-manager.ts
+++ b/src/clients/base-client-manager.ts
@@ -13,8 +13,10 @@ import {
     throwIfAbortSignalAborted
 } from "../util.js";
 import { sha256 } from "js-sha256";
-import { getPKCAddressFromPublicKey } from "../signer/util.js";
-import { nativeFunctions } from "../runtime/node/util.js";
+// getPKCAddressFromPublicKey, convertBase58IpnsNameToBase36Cid (from ../signer/util.js -> @libp2p/peer-id)
+// and `of` (typestub-ipfs-only-hash) are dynamic-imported at their gateway/verification use sites below,
+// so this base manager — loaded during every PKC construction — no longer statically pulls them (#120).
+import { nativeFunctions, applyGlobalFetchBodyTimeoutPatch } from "../runtime/node/util.js";
 import pLimit from "p-limit";
 import pRetry, { AbortError as PRetryAbortError } from "p-retry";
 import {
@@ -33,10 +35,8 @@ import { concat as uint8ArrayConcat } from "uint8arrays/concat";
 import { toString as uint8ArrayToString } from "uint8arrays/to-string";
 import all from "it-all";
 import * as remeda from "remeda";
-import { of as calculateIpfsHash } from "typestub-ipfs-only-hash";
 import { CidPathSchema } from "../schema/schema.js";
-import { CID } from "kubo-rpc-client";
-import { convertBase58IpnsNameToBase36Cid } from "../signer/util.js";
+import { CID } from "multiformats/cid"; // identity-safe; avoids pulling the kubo-rpc-client graph (#120)
 import pTimeout from "p-timeout";
 import { InflightResourceTypes } from "../util/inflight-fetch-manager.js";
 import { NameResolutionCache } from "./name-resolution-cache.js";
@@ -84,19 +84,27 @@ export type OptionsToLoadFromGateway = {
     log: Logger;
 };
 
-const createUrlFromPathResolution = (gateway: string, opts: OptionsToLoadFromGateway): string => {
-    const root = opts.recordIpfsType === "ipfs" ? CID.parse(opts.root).toV1().toString() : convertBase58IpnsNameToBase36Cid(opts.root);
+// async so convertBase58IpnsNameToBase36Cid (-> signer/util -> @libp2p/peer-id) can be dynamic-imported
+// only on the gateway-fetch path; keeps peer-id out of this module's static graph (issue #120). The
+// sole caller (_fetchWithGateway) is already async.
+const createUrlFromPathResolution = async (gateway: string, opts: OptionsToLoadFromGateway): Promise<string> => {
+    let root: string;
+    if (opts.recordIpfsType === "ipfs") root = CID.parse(opts.root).toV1().toString();
+    else {
+        const { convertBase58IpnsNameToBase36Cid } = await import("../signer/util.js");
+        root = convertBase58IpnsNameToBase36Cid(opts.root);
+    }
     return `${gateway}/${opts.recordIpfsType}/${root}${opts.path ? "/" + opts.path : ""}`;
 };
 
-const createUrlFromSubdomainResolution = (gateway: string, opts: OptionsToLoadFromGateway): string => {
+const createUrlFromSubdomainResolution = async (gateway: string, opts: OptionsToLoadFromGateway): Promise<string> => {
     const gatewayUrl = new URL(gateway);
-    const root =
-        opts.recordIpfsType === "ipfs"
-            ? CID.parse(opts.root).toV1().toString()
-            : opts.recordIpfsType === "ipns"
-              ? convertBase58IpnsNameToBase36Cid(opts.root)
-              : opts.root;
+    let root: string;
+    if (opts.recordIpfsType === "ipfs") root = CID.parse(opts.root).toV1().toString();
+    else if (opts.recordIpfsType === "ipns") {
+        const { convertBase58IpnsNameToBase36Cid } = await import("../signer/util.js");
+        root = convertBase58IpnsNameToBase36Cid(opts.root);
+    } else root = opts.root;
 
     return `${gatewayUrl.protocol}//${root}.${opts.recordIpfsType}.${gatewayUrl.host}${opts.path ? "/" + opts.path : ""}`;
 };
@@ -462,9 +470,13 @@ export class BaseClientsManager {
     ): Promise<{ res: Response; resText: string | undefined } | { error: PKCError }> {
         const log = Logger("pkc-js:pkc:fetchWithGateway");
 
+        // Apply the global-fetch body-timeout workaround before the first gateway fetch (it used to run
+        // eagerly in polyfill.ts, which forced undici into every import graph). No-op after the first call.
+        await applyGlobalFetchBodyTimeoutPatch();
+
         const url = GATEWAYS_THAT_SUPPORT_SUBDOMAIN_RESOLUTION[gateway]
-            ? createUrlFromSubdomainResolution(gateway, loadOpts)
-            : createUrlFromPathResolution(gateway, loadOpts);
+            ? await createUrlFromSubdomainResolution(gateway, loadOpts)
+            : await createUrlFromPathResolution(gateway, loadOpts);
 
         this.preFetchGateway(gateway, loadOpts);
         const timeBefore = Date.now();
@@ -733,6 +745,7 @@ export class BaseClientsManager {
                 throw new PKCError("ERR_FAILED_TO_FETCH_IPFS_CID_VIA_IPFS_P2P", { cid: cidV0, loadOpts });
             }
             if (data.byteLength === loadOpts.maxFileSizeBytes) {
+                const { of: calculateIpfsHash } = await import("typestub-ipfs-only-hash"); // deferred (#120)
                 const calculatedCid: string = await calculateIpfsHash(fileContent);
                 if (calculatedCid !== cidV0)
                     throw new PKCError("ERR_OVER_DOWNLOAD_LIMIT", {
@@ -817,6 +830,7 @@ export class BaseClientsManager {
         cid: string,
         loadOpts: Pick<OptionsToLoadFromGateway, "maxFileSizeBytes">
     ) {
+        const { of: calculateIpfsHash } = await import("typestub-ipfs-only-hash"); // deferred (#120)
         const calculatedCid: string = await calculateIpfsHash(gatewayResponseBody);
         if (gatewayResponseBody.length === loadOpts.maxFileSizeBytes && calculatedCid !== cid)
             throw new PKCError("ERR_OVER_DOWNLOAD_LIMIT", { cid, loadOpts, gatewayResponseBody });
@@ -996,6 +1010,7 @@ export class BaseClientsManager {
                     // undefined so the next pass retries. Failing-shut here would risk permanently rejecting an author after a brief outage.
                     return false;
                 }
+                const { getPKCAddressFromPublicKey } = await import("../signer/util.js"); // deferred (#120)
                 const signerAddress = await getPKCAddressFromPublicKey(entry.signaturePublicKey);
                 verificationCache.set(entry.cacheKey, resolved === signerAddress);
                 return true; // newly set

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -15,13 +15,13 @@ import * as remeda from "remeda";
 import type { CommunityIpfsType } from "./types.js";
 import { getCommunityNameFromWire } from "./community-wire.js";
 import { getPKCAddressFromPublicKeySync } from "../signer/util.js";
+import { ipnsNameToIpnsOverPubsubTopic } from "../ipns-pubsub-topic.js";
 import Logger from "../logger.js";
 
 import {
     areEquivalentCommunityAddresses,
     fetchAndValidateIpnsRecordFromGateway,
     hideClassPrivateProps,
-    ipnsNameToIpnsOverPubsubTopic,
     isAbortError,
     isIpfsPath,
     isIpnsPath,

--- a/src/community/remote-community.ts
+++ b/src/community/remote-community.ts
@@ -2,14 +2,14 @@ import {
     createAbortError,
     doesDomainAddressHaveCapitalLetter,
     hideClassPrivateProps,
-    ipnsNameToIpnsOverPubsubTopic,
     isIpns,
     isStringDomain,
     pubsubTopicToDhtKey,
     shortifyAddress,
     timestamp
 } from "../util.js";
-import { PKC } from "../pkc/pkc.js";
+import type { PKC } from "../pkc/pkc.js";
+import { ipnsNameToIpnsOverPubsubTopic } from "../ipns-pubsub-topic.js";
 
 import Logger from "../logger.js";
 

--- a/src/community/rpc-local-community.ts
+++ b/src/community/rpc-local-community.ts
@@ -16,7 +16,7 @@ import { RpcRemoteCommunity } from "./rpc-remote-community.js";
 import { z } from "zod";
 import { messages } from "../errors.js";
 import * as remeda from "remeda";
-import { PKC } from "../pkc/pkc.js";
+import type { PKC } from "../pkc/pkc.js";
 import { PKCError } from "../pkc-error.js";
 
 import { CommunityEditOptionsSchema } from "./schema.js";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,4 +6,10 @@ export enum STORAGE_KEYS {
     EXPORTS // CommunityExportRecord[] — backups of this community produced by community.export(); persisted so they survive process restart
 }
 
+// Max byte size of a CommentUpdate file. Lives here (a dependency-free constants module) rather than
+// in comment-client-manager.ts so that importers which only need the number — e.g. runtime/node/util.ts
+// — don't drag in the comment-client-manager graph (-> signer/signatures, signer/util -> @libp2p/peer-id).
+// See issue #120 (slim ./client import).
+export const MAX_FILE_SIZE_BYTES_FOR_COMMENT_UPDATE = 1024 * 1024;
+
 // Configs for LRU storage

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -24,7 +24,7 @@ import { PKCError } from "../pkc-error.js";
 import { Libp2pJsClient } from "./libp2pjsClient.js";
 import { connectToPubsubPeers, getHeliaDebugContext } from "./util.js";
 import { createDefaultDialTransportGater } from "./dial-transport-filter.js";
-import { ipnsNameToIpnsOverPubsubTopic } from "../util.js";
+import { ipnsNameToIpnsOverPubsubTopic } from "../ipns-pubsub-topic.js";
 
 const log = Logger("pkc-js:libp2p-js");
 

--- a/src/ipns-pubsub-topic.ts
+++ b/src/ipns-pubsub-topic.ts
@@ -1,0 +1,18 @@
+import { peerIdFromString } from "@libp2p/peer-id";
+import { toString as uint8ArrayToString } from "uint8arrays/to-string";
+
+// Relocated out of util.ts (issue #120, slim ./client import). util.ts is imported by nearly every
+// module — including the static graph of the RPC-only ./client entry — and this was its only
+// @libp2p/peer-id use (~380ms to import). Only community/helia code paths call it, and those are all
+// loaded lazily, so keeping the peer-id dependency here means a bare RPC import never pays for it.
+export function ipnsNameToIpnsOverPubsubTopic(ipnsName: string) {
+    // for ipns over pubsub, the topic is '/record/' + Base64Url(Uint8Array('/ipns/') + Uint8Array('12D...'))
+    // https://github.com/ipfs/helia/blob/1561e4a106074b94e421a77b0b8776b065e48bc5/packages/ipns/src/routing/pubsub.ts#L169
+    const ipnsNamespaceBytes = new TextEncoder().encode("/ipns/");
+    const ipnsNameBytes = peerIdFromString(ipnsName).toMultihash().bytes; // accepts base58 (12D...) and base36 (k51...)
+    const ipnsNameBytesWithNamespace = new Uint8Array(ipnsNamespaceBytes.length + ipnsNameBytes.length);
+    ipnsNameBytesWithNamespace.set(ipnsNamespaceBytes, 0);
+    ipnsNameBytesWithNamespace.set(ipnsNameBytes, ipnsNamespaceBytes.length);
+    const pubsubTopic = "/record/" + uint8ArrayToString(ipnsNameBytesWithNamespace, "base64url");
+    return pubsubTopic;
+}

--- a/src/pkc/lazy-runtime.ts
+++ b/src/pkc/lazy-runtime.ts
@@ -1,0 +1,28 @@
+// Single lazy barrel for the "heavy" runtime that RPC-only consumers never touch on a bare import
+// (issue #120, Lever B). pkc.ts and pkc-with-rpc-client.ts dynamic-import EVERYTHING heavy through
+// this one module instead of importing publications/comment/signer/community modules from many
+// separate `await import()` sites.
+//
+// Why one barrel and not many direct dynamic imports: rolldown's automatic code-splitting hoists a
+// module shared by two *different* lazy chunks (e.g. pages/pages.js, reached from both the comment
+// chunk and the remote-community chunk) into their nearest common chunk — which turns out to be the
+// shared static chunk that also holds src/util.js, so it ends up in every entry's static closure and
+// defeats the laziness. Funnelling all the heavy imports through this single dynamic entry point
+// means the whole subtree (comment -> typestub-ipfs-only-hash, signer/util -> @libp2p/peer-id, pages,
+// the community classes) is reachable through exactly one dynamic import, so rolldown keeps it in one
+// lazy chunk that no entry references statically. config/verify-bundle.js asserts this holds.
+//
+// It costs nothing extra at runtime: the first create*/createCommunity call loads the chunk once, and
+// materializing a community needs the whole subtree anyway.
+export { Comment } from "../publications/comment/comment.js";
+export { default as Vote } from "../publications/vote/vote.js";
+export { CommentEdit } from "../publications/comment-edit/comment-edit.js";
+export { CommentModeration } from "../publications/comment-moderation/comment-moderation.js";
+export { default as CommunityEdit } from "../publications/community-edit/community-edit.js";
+export { RemoteCommunity } from "../community/remote-community.js";
+export { RpcRemoteCommunity } from "../community/rpc-remote-community.js";
+export { RpcLocalCommunity } from "../community/rpc-local-community.js";
+export { createSigner } from "../signer/index.js";
+export { verifyCommentIpfs, verifyCommentUpdate } from "../signer/signatures.js";
+export { cleanWireAuthor, normalizeCreatePublicationAuthor } from "../publications/publication-author.js";
+export { extractCommunityRuntimeFieldsFromParsedPages } from "../pages/util.js";

--- a/src/pkc/pkc-with-rpc-client.ts
+++ b/src/pkc/pkc-with-rpc-client.ts
@@ -3,15 +3,19 @@ import { PKC } from "./pkc.js";
 import type { InputPKCOptions, GetCommunityArgs } from "../types.js";
 import { parseCreateRpcCommunityFunctionArgumentSchemaWithPKCErrorIfItFails } from "../schema/schema-util.js";
 import { CreateRpcCommunityFunctionArgumentSchema } from "../community/schema.js";
-import { RpcLocalCommunity } from "../community/rpc-local-community.js";
-import { RpcRemoteCommunity } from "../community/rpc-remote-community.js";
+// The RPC community classes pull the RemoteCommunity subtree (pages -> comment ->
+// typestub-ipfs-only-hash, signer/util -> @libp2p/peer-id). They are only needed once a community is
+// materialized, so they are dynamic-imported inside createCommunity (below) and kept type-only here.
+// This keeps them out of the ./client static closure (issue #120).
+import type { RpcLocalCommunity } from "../community/rpc-local-community.js";
+import type { RpcRemoteCommunity } from "../community/rpc-remote-community.js";
 import type { RpcLocalCommunityJson, RpcLocalCommunityUpdateResultType, RpcRemoteCommunityJson } from "../community/types.js";
 import { z } from "zod";
 import { PKCError } from "../pkc-error.js";
 import type { AuthorNameRpcParam, CidRpcParam } from "../clients/rpc-client/types.js";
 import { parseRpcAuthorNameParam, parseRpcCidParam, parseRpcFetchCidParam } from "../clients/rpc-client/rpc-schema-util.js";
 import { listStartedCommunities } from "./tracked-instance-registry-util.js";
-import { CommentJson } from "../publications/comment/types.js";
+import type { CommentJson } from "../publications/comment/types.js";
 
 // This is a helper class for separating RPC-client logic from main PKC
 // Not meant to be used with end users
@@ -84,6 +88,10 @@ export class PKCWithRpcClient extends PKC {
         options: z.infer<typeof CreateRpcCommunityFunctionArgumentSchema> | RpcRemoteCommunityJson | RpcLocalCommunityJson = {}
     ): Promise<RpcLocalCommunity | RpcRemoteCommunity> {
         const log = Logger("pkc-js:pkc-with-rpc-client:createCommunity");
+
+        // Load the community classes on demand — this is the boundary that keeps the RemoteCommunity
+        // subtree (pages, signer, community-client-manager) out of the ./client static closure (#120).
+        const { RpcLocalCommunity, RpcRemoteCommunity } = await import("./lazy-runtime.js");
 
         // No need to parse if it's a jsonified instance
         const parsedRpcOptions =

--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -21,7 +21,7 @@ import type {
     CreatePublicationOptions,
     GetCommunityArgs
 } from "../types.js";
-import { Comment } from "../publications/comment/comment.js";
+import type { Comment } from "../publications/comment/comment.js";
 import {
     waitForUpdateInCommunityInstanceWithErrorAndTimeout,
     areEquivalentCommunityAddresses,
@@ -33,12 +33,10 @@ import {
     timestamp,
     resolveWhenPredicateIsTrue
 } from "../util.js";
-import Vote from "../publications/vote/vote.js";
-import { createSigner, verifyCommentPubsubMessage } from "../signer/index.js";
-import { CommentEdit } from "../publications/comment-edit/comment-edit.js";
+import type Vote from "../publications/vote/vote.js";
+import type { CommentEdit } from "../publications/comment-edit/comment-edit.js";
 import Logger from "../logger.js";
 import env from "../version.js";
-import { verifyCommentEdit, verifyCommentIpfs, verifyCommentUpdate, verifyCommunityEdit } from "../signer/signatures.js";
 import Stats from "../stats.js";
 import Storage from "../runtime/node/storage.js";
 import { PKCClientsManager } from "./pkc-client-manager.js";
@@ -56,14 +54,18 @@ import type {
     RpcRemoteCommunityJson
 } from "../community/types.js";
 import LRUStorage from "../runtime/node/lru-storage.js";
-import { RemoteCommunity } from "../community/remote-community.js";
-import { RpcRemoteCommunity } from "../community/rpc-remote-community.js";
-import { RpcLocalCommunity } from "../community/rpc-local-community.js";
+// The community classes and their subtree (pages -> comment -> typestub-ipfs-only-hash, signer/util
+// -> @libp2p/peer-id, community-client-manager) are the bulk of the RPC-only import cost (issue #120).
+// They are only needed once a community is actually materialized, so they are dynamic-imported at the
+// `new RemoteCommunity(this)` / `new Rpc*Community(this)` sites (all inside async create paths) and
+// kept type-only here (erased at build time). This keeps them out of the ./client static closure.
+import type { RemoteCommunity } from "../community/remote-community.js";
+import type { RpcRemoteCommunity } from "../community/rpc-remote-community.js";
+import type { RpcLocalCommunity } from "../community/rpc-local-community.js";
 // LocalCommunity pulls in the db-handler -> better-sqlite3 graph (issue #120). It is only
 // instantiated when a local community is created (_createLocalCommunity), so the class and its
 // helper functions are loaded dynamically there; here we keep only the type (erased at build time).
 import type { LocalCommunity } from "../runtime/node/community/local-community.js";
-import { extractCommunityRuntimeFieldsFromParsedPages } from "../pages/util.js";
 import pTimeout, { TimeoutError } from "p-timeout";
 import * as remeda from "remeda";
 import { z } from "zod";
@@ -111,7 +113,7 @@ import {
     parseCommunityEditPubsubMessagePublicationSchemaWithPKCErrorIfItFails,
     parseVotePubsubMessagePublicationSchemaWithPKCErrorIfItFails
 } from "../schema/schema-util.js";
-import { CommentModeration } from "../publications/comment-moderation/comment-moderation.js";
+import type { CommentModeration } from "../publications/comment-moderation/comment-moderation.js";
 import type {
     CommentModerationOptionsToSign,
     CommentModerationPubsubMessagePublication,
@@ -119,7 +121,7 @@ import type {
     CreateCommentModerationOptions
 } from "../publications/comment-moderation/types.js";
 import { setupKuboAddressesRewriterAndHttpRouters } from "../runtime/node/setup-kubo-address-rewriter-and-http-router.js";
-import CommunityEdit from "../publications/community-edit/community-edit.js";
+import type CommunityEdit from "../publications/community-edit/community-edit.js";
 import type {
     CreateCommunityEditPublicationOptions,
     CommunityEditJson,
@@ -136,7 +138,6 @@ import type { PageTypeJson } from "../pages/types.js";
 import type { Libp2pJsClient } from "../helia/libp2pjsClient.js";
 import type { AuthorNameRpcParam, CidRpcParam, RpcFetchCidResult } from "../clients/rpc-client/types.js";
 import { parseRpcAuthorNameParam, parseRpcCidParam } from "../clients/rpc-client/rpc-schema-util.js";
-import { cleanWireAuthor, normalizeCreatePublicationAuthor } from "../publications/publication-author.js";
 import { IndexedTrackedInstanceRegistry, TrackedInstanceRegistry } from "./tracked-instance-registry.js";
 import {
     findUpdatingCommunity,
@@ -291,8 +292,11 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         //@ts-expect-error
         this.clients = {};
 
-        this._initKuboRpcClientsIfNeeded();
-        this._initKuboPubsubClientsIfNeeded();
+        // kubo client creation is deferred to _init() (async) so the kubo-rpc-client graph
+        // (-> @libp2p/peer-id, ~371 modules) is only imported when a kubo client is actually built.
+        // RPC-only clients never build one, so the slim ./client entry never loads kubo. See #120.
+        this.clients.kuboRpcClients = {};
+        this.clients.pubsubKuboRpcClients = {};
         this._initRpcClientsIfNeeded();
         this._initIpfsGatewaysIfNeeded();
         this._initMemCaches();
@@ -327,11 +331,11 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         };
     }
 
-    private _initKuboRpcClientsIfNeeded() {
+    private async _initKuboRpcClientsIfNeeded() {
         this.clients.kuboRpcClients = {};
         if (!this.kuboRpcClientsOptions) return;
         for (const clientOptions of this.kuboRpcClientsOptions) {
-            const kuboRpcClient = createKuboRpcClient(clientOptions);
+            const kuboRpcClient = await createKuboRpcClient(clientOptions);
             this.clients.kuboRpcClients[clientOptions.url!.toString()] = {
                 _client: kuboRpcClient,
                 _clientOptions: clientOptions,
@@ -342,12 +346,12 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         }
     }
 
-    private _initKuboPubsubClientsIfNeeded() {
+    private async _initKuboPubsubClientsIfNeeded() {
         this.clients.pubsubKuboRpcClients = {};
         if (!this.pubsubKuboRpcClientsOptions) return;
 
         for (const clientOptions of this.pubsubKuboRpcClientsOptions) {
-            const kuboRpcClient = createKuboRpcClient(clientOptions);
+            const kuboRpcClient = await createKuboRpcClient(clientOptions);
             this.clients.pubsubKuboRpcClients[clientOptions.url!.toString()] = {
                 _client: kuboRpcClient,
                 _clientOptions: clientOptions,
@@ -433,6 +437,11 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
 
     async _init() {
         const log = Logger("pkc-js:pkc:_init");
+        // Build kubo clients here (not in the constructor) so the kubo-rpc-client import stays lazy
+        // for RPC-only consumers (#120). Must run before Stats / PKCClientsManager / http-router setup,
+        // which read this.clients.kubo*RpcClients.
+        await this._initKuboRpcClientsIfNeeded();
+        await this._initKuboPubsubClientsIfNeeded();
         // Init storage
         this._storage = new Storage(this);
         await this._storage.init();
@@ -511,6 +520,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     ): Promise<CommentOptionsToSign | VoteOptionsToSign | CommentEditOptionsToSign | CommunityEditPublicationOptionsToSign> {
         const finalOptions = remeda.clone(pubOptions);
         if (!finalOptions.signer) throw Error("User did not provide a signer to create a local publication");
+        const { cleanWireAuthor, normalizeCreatePublicationAuthor } = await import("./lazy-runtime.js");
         const normalizedAuthor = normalizeCreatePublicationAuthor(finalOptions.author);
         let cleanedAuthor = cleanWireAuthor(normalizedAuthor);
         // Strip empty objects from author — empty {} should not be signed
@@ -541,6 +551,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     }
 
     private async _createCommentInstanceFromAnotherCommentInstance(options: Comment | CommentWithinRepliesPostsPageJson | CommentJson) {
+        const { Comment } = await import("./lazy-runtime.js");
         const commentInstance = new Comment(this);
 
         if (options.cid) commentInstance.setCid(options.cid);
@@ -602,6 +613,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
             | CommentIpfsWithCidDefined
     ): Promise<Comment> {
         const log = Logger("pkc-js:pkc:createComment");
+        const { Comment } = await import("./lazy-runtime.js");
 
         if ("clients" in options || "raw" in options || "original" in options || options instanceof Comment)
             return this._createCommentInstanceFromAnotherCommentInstance(
@@ -684,6 +696,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         options: CreateRemoteCommunityOptions | CommunityIpfsType | RemoteCommunityJson | RpcRemoteCommunityJson
     ) {
         await community.initRemoteCommunityPropsNoMerge(options);
+        const { extractCommunityRuntimeFieldsFromParsedPages } = await import("./lazy-runtime.js");
         const preservedRuntimeFields = extractCommunityRuntimeFieldsFromParsedPages({
             postsPages: community.posts.pages,
             modQueuePages: community.modQueue.pages
@@ -749,6 +762,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         const log = Logger("pkc-js:pkc:createRemoteCommunity");
 
         log.trace("Received community options to create a remote community instance:", options);
+        const { RemoteCommunity } = await import("./lazy-runtime.js");
         const community = new RemoteCommunity(this);
         await this._setCommunityIpfsOnInstanceIfPossible(community, options);
 
@@ -876,6 +890,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     }
 
     async _createVoteInstanceFromJsonfiedVote(jsonfied: VoteJson) {
+        const { Vote } = await import("./lazy-runtime.js");
         const voteInstance = new Vote(this);
         const unsignedOpts = (jsonfied.raw as { unsignedPublicationOptions?: CreatePublicationOptions }).unsignedPublicationOptions;
         if (jsonfied.raw.pubsubMessageToPublish)
@@ -901,6 +916,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     async createVote(options: CreateVoteOptions | VotePubsubMessagePublication | VoteJson): Promise<Vote> {
         const log = Logger("pkc-js:pkc:createVote");
         if ("clients" in options) return this._createVoteInstanceFromJsonfiedVote(options);
+        const { Vote } = await import("./lazy-runtime.js");
         const voteInstance = new Vote(this);
 
         if ("signature" in options) {
@@ -919,6 +935,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     }
 
     async _createCommentEditInstanceFromJsonfiedCommentEdit(jsonfied: CommentEditTypeJson) {
+        const { CommentEdit } = await import("./lazy-runtime.js");
         const editInstance = new CommentEdit(this);
         const unsignedOpts = (jsonfied.raw as { unsignedPublicationOptions?: CreatePublicationOptions }).unsignedPublicationOptions;
         if (jsonfied.raw.pubsubMessageToPublish)
@@ -946,6 +963,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     ): Promise<CommentEdit> {
         const log = Logger("pkc-js:pkc:createCommentEdit");
         if ("clients" in options) return this._createCommentEditInstanceFromJsonfiedCommentEdit(options);
+        const { CommentEdit } = await import("./lazy-runtime.js");
         const editInstance = new CommentEdit(this);
 
         if ("signature" in options) {
@@ -964,6 +982,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     }
 
     async _createCommentModerationInstanceFromJsonfiedCommentModeration(jsonfied: CommentModerationTypeJson) {
+        const { CommentModeration } = await import("./lazy-runtime.js");
         const modInstance = new CommentModeration(this);
         const unsignedOpts = (jsonfied.raw as { unsignedPublicationOptions?: CreatePublicationOptions }).unsignedPublicationOptions;
         if (jsonfied.raw.pubsubMessageToPublish)
@@ -991,6 +1010,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     ): Promise<CommentModeration> {
         const log = Logger("pkc-js:pkc:createCommentEdit");
         if ("clients" in options) return this._createCommentModerationInstanceFromJsonfiedCommentModeration(options);
+        const { CommentModeration } = await import("./lazy-runtime.js");
         const modInstance = new CommentModeration(this);
 
         if ("signature" in options) {
@@ -1011,6 +1031,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     }
 
     async _createCommunityEditInstanceFromJsonfiedCommunityEdit(jsonfied: CommunityEditJson) {
+        const { CommunityEdit } = await import("./lazy-runtime.js");
         const communityEditInstance = new CommunityEdit(this);
         const unsignedOpts = (jsonfied.raw as { unsignedPublicationOptions?: CreatePublicationOptions }).unsignedPublicationOptions;
         if (jsonfied.raw.pubsubMessageToPublish)
@@ -1038,6 +1059,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     ): Promise<CommunityEdit> {
         const log = Logger("pkc-js:pkc:createCommunityEdit");
         if ("clients" in options) return this._createCommunityEditInstanceFromJsonfiedCommunityEdit(options);
+        const { CommunityEdit } = await import("./lazy-runtime.js");
         const communityEditInstance = new CommunityEdit(this);
 
         if ("signature" in options) {
@@ -1057,7 +1079,8 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         return communityEditInstance;
     }
 
-    createSigner(createSignerOptions?: CreateSignerOptions) {
+    async createSigner(createSignerOptions?: CreateSignerOptions) {
+        const { createSigner } = await import("./lazy-runtime.js");
         return createSigner(createSignerOptions);
     }
 
@@ -1105,6 +1128,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         if (!commentUpdate) throw new PKCError("ERR_COMMENT_MISSING_UPDATE", { comment, commentUpdate });
         if (!postCid) throw new PKCError("ERR_COMMENT_MISSING_POST_CID", { comment, postCid }); // postCid should always be defined if you have CommentIpfs
 
+        const { verifyCommentIpfs, verifyCommentUpdate } = await import("./lazy-runtime.js");
         const commentIpfsVerificationOpts = {
             comment: commentIpfs,
             resolveAuthorNames: this.resolveAuthorNames,

--- a/src/publications/comment/comment-client-manager.ts
+++ b/src/publications/comment/comment-client-manager.ts
@@ -13,6 +13,7 @@ import {
 import { FailedToFetchCommentUpdateFromGatewaysError, PKCError } from "../../pkc-error.js";
 import { verifyCommentIpfs, verifyCommentUpdate } from "../../signer/signatures.js";
 import { getPKCAddressFromPublicKeySync } from "../../signer/util.js";
+import { MAX_FILE_SIZE_BYTES_FOR_COMMENT_UPDATE } from "../../constants.js";
 import Logger from "../../logger.js";
 import { getPostUpdateTimestampRange, hideClassPrivateProps, isAbortError, resolveWhenPredicateIsTrue } from "../../util.js";
 import { PublicationClientsManager } from "../publication-client-manager.js";
@@ -43,7 +44,10 @@ type NewCommentUpdate =
     | { commentUpdate: CommentUpdateType; commentUpdateIpfsPath: NonNullable<Comment["_commentUpdateIpfsPath"]> }
     | undefined;
 
-export const MAX_FILE_SIZE_BYTES_FOR_COMMENT_UPDATE = 1024 * 1024;
+// Re-exported so existing importers keep working; the number now lives in constants.js (a
+// dependency-free module) so runtime/node/util.ts can import it without dragging this heavy module in.
+// See issue #120.
+export { MAX_FILE_SIZE_BYTES_FOR_COMMENT_UPDATE };
 export class CommentClientsManager extends PublicationClientsManager {
     override clients!: {
         ipfsGateways: { [ipfsGatewayUrl: string]: CommentIpfsGatewayClient };

--- a/src/runtime/node/addresses-rewriter-proxy-server.ts
+++ b/src/runtime/node/addresses-rewriter-proxy-server.ts
@@ -6,7 +6,7 @@ import * as remeda from "remeda";
 import retry from "retry";
 import { PKC } from "../../pkc/pkc.js";
 import { hideClassPrivateProps } from "../../util.js";
-import { RoutingQueryEvent } from "kubo-rpc-client";
+import type { RoutingQueryEvent } from "kubo-rpc-client";
 import { AddressRewriterDatabase, RequestLogEntry } from "./address-rewriter-db.js";
 const debug = Logger("pkc-js:addresses-rewriter");
 const MAX_BODY_PREVIEW_BYTES = 4096;

--- a/src/runtime/node/community/local-community/db-state.ts
+++ b/src/runtime/node/community/local-community/db-state.ts
@@ -1,7 +1,8 @@
 import Logger from "../../../../logger.js";
 import * as remeda from "remeda";
 import { v4 as uuidV4 } from "uuid";
-import { ipnsNameToIpnsOverPubsubTopic, pubsubTopicToDhtKey, timestamp } from "../../../../util.js";
+import { pubsubTopicToDhtKey, timestamp } from "../../../../util.js";
+import { ipnsNameToIpnsOverPubsubTopic } from "../../../../ipns-pubsub-topic.js";
 import { PKCError } from "../../../../pkc-error.js";
 import env from "../../../../version.js";
 import { STORAGE_KEYS } from "../../../../constants.js";

--- a/src/runtime/node/polyfill.ts
+++ b/src/runtime/node/polyfill.ts
@@ -1,24 +1,14 @@
-// import this file at the very top of index.ts to polyfill
-// stuff for browsers
-
-// nothing to polyfill in node
-import { setGlobalDispatcher, Agent, WebSocket } from "undici";
-import Logger from "../../logger.js";
+// import this file at the very top of index.ts to polyfill stuff for browsers.
 
 // Add Promise.withResolvers polyfill for Node.js < 22
 import "@enhances/with-resolvers";
 
-if (Number(process.versions.node.split(".")[0]) >= 18) {
-    // We're on node 18+, we need to change the timeout of the body globally
-    // Should be removed at some point once kubo-rpc-client fixes their problem with node 18+
-    const log = Logger("pkc-js:polyfill");
-    log("Patching up the global body timeout");
-    setGlobalDispatcher(new Agent({ bodyTimeout: Number.MAX_SAFE_INTEGER }));
-}
-
-if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === "undefined") {
-    Reflect.set(globalThis as object, "WebSocket", WebSocket);
-}
+// The undici global-dispatcher body-timeout patch (a workaround for kubo-rpc-client's HTTP body
+// timeout, see applyKuboGlobalFetchBodyTimeoutPatch in runtime/node/util.ts) used to live here and
+// forced every consumer — including the slim RPC-only ./client entry — to statically import undici's
+// ~112-module graph. It is now applied lazily next to the kubo client, since it only matters for
+// kubo's HTTP fetch. Node >= 22 (our `engines` floor) also ships a global WebSocket, so undici's
+// WebSocket fallback is no longer needed. See issue #120.
 
 // must export a function and call it or this file isn't read
 export default () => {};

--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -14,19 +14,22 @@ import { default as nodeNativeFunctions } from "./native-functions.js";
 import type { KuboRpcClient, NativeFunctions } from "../../types.js";
 import path from "path";
 import assert from "assert";
-import scraper from "open-graph-scraper";
 import { HttpProxyAgent, HttpsProxyAgent } from "hpagent";
 import { PKCError } from "../../pkc-error.js";
-import probe from "probe-image-size";
-import { PKC } from "../../pkc/pkc.js";
-import { STORAGE_KEYS } from "../../constants.js";
-import { RemoteCommunity } from "../../community/remote-community.js";
+import type { PKC } from "../../pkc/pkc.js";
+import { STORAGE_KEYS, MAX_FILE_SIZE_BYTES_FOR_COMMENT_UPDATE } from "../../constants.js";
+// Type-only: RemoteCommunity is used solely as a parameter type here. A value import would pull the
+// community subtree (pages -> typestub-ipfs-only-hash, signer/util -> @libp2p/peer-id) into every
+// consumer of this node-util hub — including the slim ./client entry (issue #120).
+import type { RemoteCommunity } from "../../community/remote-community.js";
 import os from "os";
 import type { OpenGraphScraperOptions } from "open-graph-scraper/types";
 import { Agent as HttpAgent } from "http";
 import { Agent as HttpsAgent } from "https";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
-import { create as CreateKuboRpcClient } from "kubo-rpc-client";
+// `create` (the kubo-rpc-client factory, ~371 modules incl. @libp2p/peer-id) is dynamic-imported
+// inside createKuboRpcClient() below so importing this node-util hub — and therefore the slim ./client
+// entry — never statically pulls the kubo graph. RPC-only clients never create a kubo client. See #120.
 import Logger from "../../logger.js";
 import retry from "retry";
 import * as remeda from "remeda";
@@ -44,7 +47,6 @@ import { DbHandler } from "./community/db-handler.js";
 import Database from "better-sqlite3";
 import { CommentIpfsSchema, CommentUpdateSchema } from "../../publications/comment/schema.js";
 import type { PageIpfs } from "../../pages/types.js";
-import { MAX_FILE_SIZE_BYTES_FOR_COMMENT_UPDATE } from "../../publications/comment/comment-client-manager.js";
 
 export const getDefaultDataPath = () => path.join(process.cwd(), ".pkc");
 
@@ -82,6 +84,9 @@ async function _getThumbnailUrlOfLink(url: string, agent?: { https: any; http: a
 
     if (agent) options["agent"] = agent;
 
+    // open-graph-scraper drags a ~200-module HTML-parsing graph (parse5/cheerio/iconv-lite/...) that is
+    // only needed to scrape a link thumbnail on the publish path; dynamic-import it (#120).
+    const { default: scraper } = await import("open-graph-scraper");
     const res = await scraper(options);
 
     if (res.error) {
@@ -158,6 +163,7 @@ export async function getThumbnailPropsOfLink(
 }
 
 async function fetchDimensionsOfImage(imageUrl: string, agent?: any): Promise<{ width: number; height: number } | undefined> {
+    const { default: probe } = await import("probe-image-size");
     const result = await probe(imageUrl, { agent });
     if (typeof result?.width === "number") return { width: result.width, height: result.height };
 }
@@ -484,7 +490,25 @@ export async function moveCommunityDbToDeletedDirectory(communityAddress: string
     }
 }
 
-export function createKuboRpcClient(kuboRpcClientOptions: KuboRpcClient["_clientOptions"]): KuboRpcClient["_client"] {
+// Patch Node's global fetch dispatcher to disable the body timeout — a workaround for kubo-rpc-client
+// (and long gateway body reads) hanging on node 18+, to be removed once kubo fixes it upstream. This
+// used to run at polyfill import time and forced every consumer to statically import undici's
+// ~112-module graph. It is now applied lazily and once, at the first place Node's global fetch is
+// actually used (a kubo client is built, or a gateway fetch is issued), so RPC-only consumers — which
+// do neither — never import undici. See issue #120.
+let _globalFetchBodyTimeoutPatched = false;
+export async function applyGlobalFetchBodyTimeoutPatch(): Promise<void> {
+    if (_globalFetchBodyTimeoutPatched) return;
+    _globalFetchBodyTimeoutPatched = true;
+    if (Number(process.versions.node.split(".")[0]) >= 18) {
+        const { setGlobalDispatcher, Agent } = await import("undici");
+        setGlobalDispatcher(new Agent({ bodyTimeout: Number.MAX_SAFE_INTEGER }));
+    }
+}
+
+export async function createKuboRpcClient(kuboRpcClientOptions: KuboRpcClient["_clientOptions"]): Promise<KuboRpcClient["_client"]> {
+    await applyGlobalFetchBodyTimeoutPatch();
+    const { create: CreateKuboRpcClient } = await import("kubo-rpc-client");
     const log = Logger("pkc-js:pkc:createKuboRpcClient");
     log.trace("Creating a new kubo client on node with options", kuboRpcClientOptions);
     const isHttpsAgent =

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { CID } from "kubo-rpc-client";
+import { CID } from "multiformats/cid"; // identity-safe; avoids pulling the kubo-rpc-client graph (#120)
 import { messages } from "../errors.js";
 import * as remeda from "remeda";
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,7 +3,7 @@ import { PKCError } from "./pkc-error.js";
 import type { CommunityIpfsType } from "./community/types.js";
 //@ts-expect-error
 import extName from "ext-name";
-import { CID } from "kubo-rpc-client";
+import { CID } from "multiformats/cid"; // was kubo-rpc-client; identity-safe (kubo re-exports multiformats CID) and keeps the kubo graph off util.ts (#120, cf. PR #177)
 import type { Multiaddr } from "@multiformats/multiaddr";
 import * as Digest from "multiformats/hashes/digest";
 import { Buffer } from "buffer";
@@ -33,20 +33,22 @@ import type {
 } from "./pubsub-messages/types.js";
 import { DecryptedChallengeRequestPublicationSchema } from "./pubsub-messages/schema.js";
 import EventEmitter from "events";
-import { RemoteCommunity } from "./community/remote-community.js";
+// Type-only: RemoteCommunity is only a parameter type here; a value import would pull the community
+// subtree (-> typestub-ipfs-only-hash, @libp2p/peer-id) into util.ts, which is imported almost
+// everywhere. See issue #120.
+import type { RemoteCommunity } from "./community/remote-community.js";
 import pTimeout from "p-timeout";
-import { of as calculateIpfsCidV0Lib } from "typestub-ipfs-only-hash";
+// typestub-ipfs-only-hash (CID hashing) and @libp2p/peer-id are dynamic-imported at their use sites
+// below so util.ts — imported by nearly every module, including the slim ./client static graph — no
+// longer statically pulls them (issue #120).
 import { toString as uint8ArrayToString } from "uint8arrays/to-string";
 import { sha256 } from "js-sha256";
 import { base32 } from "multiformats/bases/base32";
-import { PKC } from "./pkc/pkc.js";
+import type { PKC } from "./pkc/pkc.js";
 import Logger from "./logger.js";
 import retry from "retry";
-import { peerIdFromString } from "@libp2p/peer-id";
 import { unmarshalIPNSRecord, multihashToIPNSRoutingKey, type IPNSRecord } from "ipns";
 import { ipnsValidator } from "ipns/validator";
-import { importFile } from "ipfs-unixfs-importer";
-import { MemoryBlockstore } from "blockstore-core";
 import { findUpdatingCommunity } from "./pkc/tracked-instance-registry-util.js";
 
 export function timestamp() {
@@ -675,7 +677,8 @@ export async function waitForUpdateInCommunityInstanceWithErrorAndTimeout(commun
     }
 }
 
-export function calculateIpfsCidV0(content: string) {
+export async function calculateIpfsCidV0(content: string) {
+    const { of: calculateIpfsCidV0Lib } = await import("typestub-ipfs-only-hash");
     return calculateIpfsCidV0Lib(content);
 }
 
@@ -688,17 +691,8 @@ export function binaryKeyToPubsubTopic(key: Uint8Array) {
     return `/record/${b64url}`;
 }
 
-export function ipnsNameToIpnsOverPubsubTopic(ipnsName: string) {
-    // for ipns over pubsub, the topic is '/record/' + Base64Url(Uint8Array('/ipns/') + Uint8Array('12D...'))
-    // https://github.com/ipfs/helia/blob/1561e4a106074b94e421a77b0b8776b065e48bc5/packages/ipns/src/routing/pubsub.ts#L169
-    const ipnsNamespaceBytes = new TextEncoder().encode("/ipns/");
-    const ipnsNameBytes = peerIdFromString(ipnsName).toMultihash().bytes; // accepts base58 (12D...) and base36 (k51...)
-    const ipnsNameBytesWithNamespace = new Uint8Array(ipnsNamespaceBytes.length + ipnsNameBytes.length);
-    ipnsNameBytesWithNamespace.set(ipnsNamespaceBytes, 0);
-    ipnsNameBytesWithNamespace.set(ipnsNameBytes, ipnsNamespaceBytes.length);
-    const pubsubTopic = "/record/" + uint8ArrayToString(ipnsNameBytesWithNamespace, "base64url");
-    return pubsubTopic;
-}
+// ipnsNameToIpnsOverPubsubTopic moved to ./ipns-pubsub-topic.js so util.ts no longer statically
+// imports @libp2p/peer-id (issue #120). Import it from there.
 
 export const pubsubTopicToDhtKey = (pubsubTopic: string): string => {
     return pubsubTopicToDhtKeyCid(pubsubTopic).toString(base32);
@@ -1236,6 +1230,7 @@ export async function fetchAndValidateIpnsRecordFromGateway(
     // Validate the record's signature AND validity (EOL) against the routing key derived from the
     // IPNS name. This is what makes following the chain through an untrusted gateway safe.
     try {
+        const { peerIdFromString } = await import("@libp2p/peer-id"); // deferred: keep peer-id off util.ts's static graph (#120)
         const routingKey = multihashToIPNSRoutingKey(peerIdFromString(ipnsName).toMultihash());
         await ipnsValidator(routingKey, ipnsRecordRaw);
     } catch (e) {
@@ -1273,6 +1268,9 @@ export async function fetchAndValidateIpnsRecordFromGateway(
 const textEncoder = new TextEncoder();
 
 export async function calculateStringSizeSameAsIpfsAddCidV0(content: string): Promise<number> {
+    // ipfs-unixfs-importer (+ blockstore-core) is a ~40-module graph only needed to size a comment;
+    // dynamic-imported so it stays off util.ts's static graph and the slim ./client entry (#120).
+    const [{ importFile }, { MemoryBlockstore }] = await Promise.all([import("ipfs-unixfs-importer"), import("blockstore-core")]);
     const blockstore = new MemoryBlockstore();
     const entry = await importFile({ path: "content.json", content: textEncoder.encode(content) }, blockstore, {
         cidVersion: 0,

--- a/test/node-and-browser/community/delegated-ipns.test.ts
+++ b/test/node-and-browser/community/delegated-ipns.test.ts
@@ -9,7 +9,8 @@ import {
     resolveWhenConditionIsTrue
 } from "../../../dist/node/test/test-util.js";
 import { getPKCAddressFromPublicKeySync, convertBase58IpnsNameToBase36Cid } from "../../../dist/node/signer/util.js";
-import { ipnsNameToIpnsOverPubsubTopic, fetchAndValidateIpnsRecordFromGateway } from "../../../dist/node/util.js";
+import { fetchAndValidateIpnsRecordFromGateway } from "../../../dist/node/util.js";
+import { ipnsNameToIpnsOverPubsubTopic } from "../../../dist/node/ipns-pubsub-topic.js";
 import { generateKeyPair } from "@libp2p/crypto/keys";
 import { createIPNSRecord, marshalIPNSRecord } from "ipns";
 

--- a/test/node-and-browser/community/ipns/ipns.fields.community.test.ts
+++ b/test/node-and-browser/community/ipns/ipns.fields.community.test.ts
@@ -6,7 +6,8 @@ import {
 } from "../../../../dist/node/test/test-util.js";
 import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
 import signers from "../../../fixtures/signers.js";
-import { ipnsNameToIpnsOverPubsubTopic, pubsubTopicToDhtKey } from "../../../../dist/node/util.js";
+import { pubsubTopicToDhtKey } from "../../../../dist/node/util.js";
+import { ipnsNameToIpnsOverPubsubTopic } from "../../../../dist/node/ipns-pubsub-topic.js";
 import { createSigner } from "../../../../dist/node/signer/index.js";
 
 import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";

--- a/test/node-and-browser/helia/helia.test.ts
+++ b/test/node-and-browser/helia/helia.test.ts
@@ -12,7 +12,7 @@ import { describe, it, beforeAll, afterAll, expect, vi } from "vitest";
 import type { PKC } from "../../../dist/node/pkc/pkc.js";
 import type { Comment } from "../../../dist/node/publications/comment/comment.js";
 import type { IpfsHttpClientPubsubMessage } from "../../../dist/node/types.js";
-import { ipnsNameToIpnsOverPubsubTopic } from "../../../dist/node/util.js";
+import { ipnsNameToIpnsOverPubsubTopic } from "../../../dist/node/ipns-pubsub-topic.js";
 import { importer } from "ipfs-unixfs-importer";
 
 async function firstFromAsyncIterable<T>(iterable: AsyncIterable<T>): Promise<T> {


### PR DESCRIPTION
Closes #178. Follow-up to the import-performance work in #120.

## What

Adds a slim `./client` export for consumers that only talk to a remote daemon over RPC (the bitsocial
CLI) and never start a local node. It builds `PKCWithRpcClient` directly and throws if
`pkcRpcClientsOptions` is absent.

The real win is pushing the heavy subgraphs behind dynamic `import()` on the
`create*`/`createCommunity`/publish/gateway paths a bare RPC import never hits:

- signer + pages + community-class + publication subtree, funnelled through one lazy barrel
  (`src/pkc/lazy-runtime.ts`) so rolldown keeps it in a single lazy chunk instead of hoisting a
  shared module into the static chunk
- `kubo-rpc-client` `create` — kubo client construction moved from the `PKC` constructor to async
  `_init()`
- `undici` — global-fetch body-timeout patch applied lazily on the first kubo/gateway fetch
- `open-graph-scraper` + `probe-image-size` + `ipfs-unixfs-importer` + `blockstore-core`
- relocate `ipnsNameToIpnsOverPubsubTopic` (new `src/ipns-pubsub-topic.ts`), re-source `CID` from
  `multiformats/cid` (identity-safe, cf. #177), move `MAX_FILE_SIZE_BYTES_FOR_COMMENT_UPDATE` to
  `constants.ts` — so the ubiquitous `util.ts` / `runtime/node/util.ts` stop statically pulling
  `@libp2p/peer-id` / `typestub-ipfs-only-hash`

`config/verify-bundle.js` gains a `./client`-closure assertion; `scripts/smoke-pack-install.js`
exercises the new entry; `scripts/bench-import-time.js` gets a `client` layer.

## Results (prod, slow host, Node v22.22.2)

- `./client` static closure: **952 -> 309 modules**, zero heavy static externals
- import: `.` ~1968ms baseline -> **`./client` ~1220ms** (~38%); `.` also improves to ~1360ms since
  most deferrals are in shared code
- `bitsocial community list -q` **~3.34s -> ~2.6s**

Not sub-second on the slow host — the residual 309 modules are dominated by `remeda` (164 tiny
per-function modules that a `import * as remeda` namespace import stops rolldown from tree-shaking)
plus the core zod/cborg/PKC-shell graph. Getting below this needs a remeda replacement / working
tree-shake, or a deeper split of the `PKC` base class (separate follow-ups; noted in the doc).

## Tests

- `npm run build` (tsc + browser-imports + bundle + verify-bundle) green; `tsc -p test/tsconfig.json`
  green
- `scripts/smoke-pack-install.js` green (adds `./client` esm/cjs/reject checks)
- pkc suite (local-kubo-rpc) 6 passed; RPC `createcommunity` suite 16 passed; A/B'd the two
  worktree-environmental community failures against master (fail identically on master)

## Follow-up

Separate bitsocial-cli PR switches `BaseCommand._connectToPkcRpc()` to
`@pkcprotocol/pkc-js/client`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `client` entry for RPC-only use, with support for both import and require.
  * Added compile-cache-enabled client loading for faster repeated startup.

* **Bug Fixes**
  * Reduced unnecessary loading of heavy modules during client initialization.
  * Improved runtime checks so client imports fail clearly when required RPC options are missing.
  * Tightened packaging and verification to keep bundled exports aligned across entry points.

* **Documentation**
  * Updated import-performance notes with new benchmark results and production validation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->