### PR TITLE
perf(import): tree-shake remeda (v2 + named imports)

### DIFF
--- a/docs/protocol/import-performance.md
+++ b/docs/protocol/import-performance.md
@@ -154,6 +154,32 @@ were consolidated into it).
 -   [ ] **Thin client entry point** — e.g. a `./client` export that pulls a minimal graph so RPC-only
         consumers never resolve/link the local-node modules at all. Likely unnecessary now that the
         heavy leaves are lazy; revisit only if the residual is still too high on slow hardware.
+-   [x] **Tree-shake `remeda` (upgrade to v2 + named imports)** — every module did
+        `import * as remeda from "remeda"`, and a namespace import cannot be tree-shaken, so all 164 of
+        remeda's per-function modules landed in every static closure (~53% of the slim `./client`
+        entry's 309 modules). remeda **v1 does not tree-shake even with named imports** — its
+        `export *` barrel plus the TS namespace-merge `.strict` IIFE pattern defeat rolldown (verified
+        with a throwaway rolldown build: named imports of a few functions still pulled all 164). remeda
+        **v2** tree-shakes cleanly, so this bumps to v2 and converts every `import * as remeda` site in
+        `src/` (49) and `test/` (31) to specific named imports (`remeda.pick` → `pick`).
+
+    Result: the `./client` static closure drops from **309 → 167 modules** (remeda 164 → 22) and the
+    `.` index closure from 164 → 32 remeda modules. Wall-clock is a **modest** improvement — remeda's
+    per-module link cost is tiny — so on the slow prod host (Node v22.22.2) the `./client` entry import
+    went ~1274ms → ~1218ms (~4-5%, medians of 6 warm runs) and the full `.` index entry moved only
+    within noise (~2049ms → ~2021ms). The value is the far smaller module graph (fewer files to
+    resolve/link, less memory), which is a prerequisite for pushing `./client` toward sub-second.
+
+    v2 API migration notes: the `.strict` variants were removed (strict is the default), so
+    `keys.strict`/`fromEntries.strict`/`sortBy.strict`/`groupBy.strict` drop `.strict` and
+    `isDefined.strict` (null+undefined) becomes `isNonNullish`; `maxBy(a,fn)`→`firstBy(a,[fn,"desc"])`,
+    `minBy(a,fn)`→`firstBy(a,fn)`, `flatten`/`flattenDeep`→`flat`; the `unique<T>`/`difference<T>` type
+    param is the container in v2 (dropped). Two behavior changes bit at runtime: `omit`/`pick` key
+    params are typed `const Keys extends readonly ...`, so `keysToOmitFromSignedPropertyNames` had to
+    become an `as const` tuple to keep removing keys from the derived zod `.pick()` schema types; and
+    **v2's `difference` is multiset** (removes each `other` element once) where v1's was set-based —
+    the `*ReservedFields` candidate lists (which concatenate multiple key sources) now wrap their first
+    argument in `unique()` so a duplicated-and-signed field is not wrongly retained as reserved.
 -   [x] **Bundle the published `dist` (our files; deps external)** (done in #126) — a rolldown step
         ([`config/build-node-bundle.js`](../../config/build-node-bundle.js)) collapses the compiled
         `dist/node/*.js` graph into a few ESM chunks under `dist/bundled/`, and the package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
                 "p-timeout": "7.0.1",
                 "probe-image-size": "7.2.3",
                 "quick-lru": "5.1.1",
-                "remeda": "^2.39.0",
+                "remeda": "2.39.0",
                 "retry": "0.13.1",
                 "rpc-websockets": "9.3.8",
                 "safe-stable-stringify": "2.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
                 "p-timeout": "7.0.1",
                 "probe-image-size": "7.2.3",
                 "quick-lru": "5.1.1",
-                "remeda": "1.57.0",
+                "remeda": "^2.39.0",
                 "retry": "0.13.1",
                 "rpc-websockets": "9.3.8",
                 "safe-stable-stringify": "2.4.3",
@@ -16942,10 +16942,16 @@
             }
         },
         "node_modules/remeda": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/remeda/-/remeda-1.57.0.tgz",
-            "integrity": "sha512-guUqXntj7WtPuT1DLmfNCeyMZ2pE5m4ffJnWkOsbVQSvPsGIhNcKeFV94LTxqggOWwaIubUd4FZKTlGIOg2wDw==",
-            "license": "MIT"
+            "version": "2.39.0",
+            "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.39.0.tgz",
+            "integrity": "sha512-3Ki8dU1o3OVu4dwIQ2Pj+yiuP7OnEbmWAGmJ3yDRqopily5jsj8NWzPvbS89H85d6UdONKEcUnrfuHY6jN9vyw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/remeda"
+            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "p-timeout": "7.0.1",
         "probe-image-size": "7.2.3",
         "quick-lru": "5.1.1",
-        "remeda": "1.57.0",
+        "remeda": "^2.39.0",
         "retry": "0.13.1",
         "rpc-websockets": "9.3.8",
         "safe-stable-stringify": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "p-timeout": "7.0.1",
         "probe-image-size": "7.2.3",
         "quick-lru": "5.1.1",
-        "remeda": "^2.39.0",
+        "remeda": "2.39.0",
         "retry": "0.13.1",
         "rpc-websockets": "9.3.8",
         "safe-stable-stringify": "2.4.3",

--- a/src/clients/base-client-manager.ts
+++ b/src/clients/base-client-manager.ts
@@ -32,7 +32,7 @@ import * as cborg from "cborg";
 import { concat as uint8ArrayConcat } from "uint8arrays/concat";
 import { toString as uint8ArrayToString } from "uint8arrays/to-string";
 import all from "it-all";
-import * as remeda from "remeda";
+import { keys } from "remeda";
 import { of as calculateIpfsHash } from "typestub-ipfs-only-hash";
 import { CidPathSchema } from "../schema/schema.js";
 import { CID } from "kubo-rpc-client";
@@ -111,8 +111,8 @@ export class BaseClientsManager {
 
     constructor(pkc: PKC) {
         this._pkc = pkc;
-        for (const provider of remeda.keys.strict(pkc.clients.pubsubKuboRpcClients)) this.pubsubProviderSubscriptions[provider] = [];
-        for (const provider of remeda.keys.strict(pkc.clients.libp2pJsClients)) this.pubsubProviderSubscriptions[provider] = [];
+        for (const provider of keys(pkc.clients.pubsubKuboRpcClients)) this.pubsubProviderSubscriptions[provider] = [];
+        for (const provider of keys(pkc.clients.libp2pJsClients)) this.pubsubProviderSubscriptions[provider] = [];
 
         hideClassPrivateProps(this);
     }
@@ -122,9 +122,9 @@ export class BaseClientsManager {
     }
 
     getDefaultPubsubKuboRpcClientOrHelia() {
-        const defaultPubsubProviderUrl = remeda.keys.strict(this._pkc.clients.pubsubKuboRpcClients)[0];
+        const defaultPubsubProviderUrl = keys(this._pkc.clients.pubsubKuboRpcClients)[0];
         if (defaultPubsubProviderUrl) return this._pkc.clients.pubsubKuboRpcClients[defaultPubsubProviderUrl];
-        const defaultLibp2pJsClient = remeda.keys.strict(this._pkc.clients.libp2pJsClients)[0];
+        const defaultLibp2pJsClient = keys(this._pkc.clients.libp2pJsClients)[0];
         if (defaultLibp2pJsClient) return this._pkc.clients.libp2pJsClients[defaultLibp2pJsClient];
         throw new PKCError("ERR_NO_DEFAULT_PUBSUB_PROVIDER", {
             pubsubKuboRpcClients: this._pkc.clients.pubsubKuboRpcClients,
@@ -133,9 +133,9 @@ export class BaseClientsManager {
     }
 
     getDefaultKuboRpcClientOrHelia(): PKC["clients"]["kuboRpcClients"][string] | PKC["clients"]["libp2pJsClients"][string] {
-        const defaultKuboRpcClient = remeda.keys.strict(this._pkc.clients.kuboRpcClients)[0];
+        const defaultKuboRpcClient = keys(this._pkc.clients.kuboRpcClients)[0];
         if (defaultKuboRpcClient) return this._pkc.clients.kuboRpcClients[defaultKuboRpcClient];
-        const defaultLibp2pJsClient = remeda.keys.strict(this._pkc.clients.libp2pJsClients)[0];
+        const defaultLibp2pJsClient = keys(this._pkc.clients.libp2pJsClients)[0];
         if (defaultLibp2pJsClient) return this._pkc.clients.libp2pJsClients[defaultLibp2pJsClient];
         throw new PKCError("ERR_NO_DEFAULT_IPFS_PROVIDER", {
             kuboRpcClients: this._pkc.clients.kuboRpcClients,
@@ -144,7 +144,7 @@ export class BaseClientsManager {
     }
 
     getDefaultKuboRpcClient() {
-        const defaultKuboRpcClient = remeda.keys.strict(this._pkc.clients.kuboRpcClients)[0];
+        const defaultKuboRpcClient = keys(this._pkc.clients.kuboRpcClients)[0];
         if (defaultKuboRpcClient) return this._pkc.clients.kuboRpcClients[defaultKuboRpcClient];
         throw new PKCError("ERR_NO_DEFAULT_KUBO_RPC_IPFS_PROVIDER", {
             kuboRpcClients: this._pkc.clients.kuboRpcClients,
@@ -153,7 +153,7 @@ export class BaseClientsManager {
     }
 
     getDefaultKuboPubsubClient() {
-        const defaultKuboPubsubClient = remeda.keys.strict(this._pkc.clients.pubsubKuboRpcClients)[0];
+        const defaultKuboPubsubClient = keys(this._pkc.clients.pubsubKuboRpcClients)[0];
         if (defaultKuboPubsubClient) return this._pkc.clients.pubsubKuboRpcClients[defaultKuboPubsubClient];
         throw new PKCError("ERR_NO_DEFAULT_KUBO_RPC_PUBSUB_PROVIDER", {
             pubsubKuboRpcClients: this._pkc.clients.pubsubKuboRpcClients
@@ -161,9 +161,9 @@ export class BaseClientsManager {
     }
 
     getIpfsClientWithKuboRpcClientFunctions() {
-        const defaultKuboRpcClient = remeda.keys.strict(this._pkc.clients.kuboRpcClients)[0];
+        const defaultKuboRpcClient = keys(this._pkc.clients.kuboRpcClients)[0];
         if (defaultKuboRpcClient) return this._pkc.clients.kuboRpcClients[defaultKuboRpcClient]._client;
-        const defaultLibp2pJsClient = remeda.keys.strict(this._pkc.clients.libp2pJsClients)[0];
+        const defaultLibp2pJsClient = keys(this._pkc.clients.libp2pJsClients)[0];
         if (defaultLibp2pJsClient) return this._pkc.clients.libp2pJsClients[defaultLibp2pJsClient].heliaWithKuboRpcClientFunctions;
         throw new PKCError("ERR_NO_DEFAULT_IPFS_PROVIDER", {
             kuboRpcClients: this._pkc.clients.kuboRpcClients,
@@ -261,7 +261,7 @@ export class BaseClientsManager {
     }
 
     async pubsubUnsubscribe(pubsubTopic: string, handler?: PubsubSubscriptionHandler) {
-        for (const pubsubProviderUrl of remeda.keys.strict(this._pkc.clients.pubsubKuboRpcClients)) {
+        for (const pubsubProviderUrl of keys(this._pkc.clients.pubsubKuboRpcClients)) {
             try {
                 await this.pubsubUnsubscribeOnProvider(pubsubTopic, pubsubProviderUrl, handler);
             } catch (e) {
@@ -517,8 +517,8 @@ export class BaseClientsManager {
 
         // Only sort if we have more than 3 gateways
         const gatewaysSorted =
-            remeda.keys.strict(this._pkc.clients.ipfsGateways).length <= concurrencyLimit
-                ? remeda.keys.strict(this._pkc.clients.ipfsGateways)
+            keys(this._pkc.clients.ipfsGateways).length <= concurrencyLimit
+                ? keys(this._pkc.clients.ipfsGateways)
                 : await this._pkc._stats.sortGatewaysAccordingToScore(loadOpts.recordIpfsType);
 
         const gatewayFetches: GenericGatewayFetch = {};

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -11,7 +11,7 @@ import { ResultOfFetchingCommunity } from "../types.js";
 import { NameResolverClient } from "../clients/name-resolver-client.js";
 import type { NameResolveCacheOptions } from "../schema.js";
 import { RemoteCommunity } from "./remote-community.js";
-import * as remeda from "remeda";
+import { keys, mapValues } from "remeda";
 import type { CommunityIpfsType } from "./types.js";
 import { getCommunityNameFromWire } from "./community-wire.js";
 import { getPKCAddressFromPublicKeySync } from "../signer/util.js";
@@ -72,12 +72,12 @@ export class CommunityClientsManager extends PKCClientsManager {
 
     protected override _initKuboRpcClients(): void {
         if (this._pkc.clients.kuboRpcClients)
-            for (const ipfsUrl of remeda.keys.strict(this._pkc.clients.kuboRpcClients))
+            for (const ipfsUrl of keys(this._pkc.clients.kuboRpcClients))
                 this.clients.kuboRpcClients = { ...this.clients.kuboRpcClients, [ipfsUrl]: new CommunityKuboRpcClient("stopped") };
     }
 
     protected override _initPubsubKuboRpcClients(): void {
-        for (const pubsubUrl of remeda.keys.strict(this._pkc.clients.pubsubKuboRpcClients))
+        for (const pubsubUrl of keys(this._pkc.clients.pubsubKuboRpcClients))
             this.clients.pubsubKuboRpcClients = {
                 ...this.clients.pubsubKuboRpcClients,
                 [pubsubUrl]: new CommunityKuboPubsubClient("stopped")
@@ -86,7 +86,7 @@ export class CommunityClientsManager extends PKCClientsManager {
 
     protected override _initLibp2pJsClients(): void {
         if (this._pkc.clients.libp2pJsClients)
-            for (const libp2pJsClientUrl of remeda.keys.strict(this._pkc.clients.libp2pJsClients))
+            for (const libp2pJsClientUrl of keys(this._pkc.clients.libp2pJsClients))
                 this.clients.libp2pJsClients = {
                     ...this.clients.libp2pJsClients,
                     [libp2pJsClientUrl]: new CommunityLibp2pJsClient("stopped")
@@ -94,7 +94,7 @@ export class CommunityClientsManager extends PKCClientsManager {
     }
 
     protected _initPKCRpcClients() {
-        for (const rpcUrl of remeda.keys.strict(this._pkc.clients.pkcRpcClients))
+        for (const rpcUrl of keys(this._pkc.clients.pkcRpcClients))
             this.clients.pkcRpcClients = {
                 ...this.clients.pkcRpcClients,
                 [rpcUrl]: new CommunityPKCRpcStateClient("stopped")
@@ -602,8 +602,8 @@ export class CommunityClientsManager extends PKCClientsManager {
 
         // Only sort if we have more than 3 gateways
         const gatewaysSorted =
-            remeda.keys.strict(this._pkc.clients.ipfsGateways).length <= concurrencyLimit
-                ? remeda.keys.strict(this._pkc.clients.ipfsGateways)
+            keys(this._pkc.clients.ipfsGateways).length <= concurrencyLimit
+                ? keys(this._pkc.clients.ipfsGateways)
                 : await this._pkc._stats.sortGatewaysAccordingToScore("ipns");
 
         // need to handle
@@ -819,9 +819,7 @@ export class CommunityClientsManager extends PKCClientsManager {
                     gatewayPromise
                         .then(async (res) => {
                             if ("error" in res) Object.values(gatewayFetches)[i].error = res.error;
-                            const gatewaysWithError = remeda.keys
-                                .strict(gatewayFetches)
-                                .filter((gatewayUrl) => gatewayFetches[gatewayUrl].error);
+                            const gatewaysWithError = keys(gatewayFetches).filter((gatewayUrl) => gatewayFetches[gatewayUrl].error);
                             if (gatewaysWithError.length === gatewaysSorted.length)
                                 // All gateways failed
                                 reject("All gateways failed to fetch community record " + ipnsName);
@@ -838,7 +836,7 @@ export class CommunityClientsManager extends PKCClientsManager {
         } catch {
             cleanUp();
             throwIfAbortSignalAborted(stopSignal);
-            const gatewayToError = remeda.mapValues(gatewayFetches, (gatewayFetch) => gatewayFetch.error!);
+            const gatewayToError = mapValues(gatewayFetches, (gatewayFetch) => gatewayFetch.error!);
             const hasGatewayConfirmingCurrentRecord = Object.keys(gatewayFetches)
                 .map((gatewayUrl) => gatewayFetches[gatewayUrl].error!)
                 .some(

--- a/src/community/community-gateway-selection.ts
+++ b/src/community/community-gateway-selection.ts
@@ -1,4 +1,4 @@
-import * as remeda from "remeda";
+import { firstBy, keys } from "remeda";
 import { timestamp } from "../util.js";
 import type { CommunityIpfsType, CommunityJson } from "./types.js";
 import type { PKCError } from "../pkc-error.js";
@@ -33,12 +33,12 @@ export function selectWinningGatewayCommunity(opts: {
     fallbackIpnsName: string;
 }): { community: CommunityIpfsType; cid: string; ipnsHops: string[]; bestGatewayUrl: string; recordAgeSeconds: number } | undefined {
     const { gatewayFetches, currentUpdatedAt, totalGateways, fallbackIpnsName } = opts;
-    const gatewaysWithCommunity = remeda.keys.strict(gatewayFetches).filter((gatewayUrl) => gatewayFetches[gatewayUrl].communityRecord);
+    const gatewaysWithCommunity = keys(gatewayFetches).filter((gatewayUrl) => gatewayFetches[gatewayUrl].communityRecord);
     if (gatewaysWithCommunity.length === 0) return undefined;
 
-    const gatewaysWithError = remeda.keys.strict(gatewayFetches).filter((gatewayUrl) => gatewayFetches[gatewayUrl].error);
+    const gatewaysWithError = keys(gatewayFetches).filter((gatewayUrl) => gatewayFetches[gatewayUrl].error);
     const bestGatewayUrl = <string>(
-        remeda.maxBy(gatewaysWithCommunity, (gatewayUrl) => gatewayFetches[gatewayUrl].communityRecord!.updatedAt)
+        firstBy(gatewaysWithCommunity, [(gatewayUrl) => gatewayFetches[gatewayUrl].communityRecord!.updatedAt, "desc"])
     );
     const best = gatewayFetches[bestGatewayUrl];
 

--- a/src/community/community-wire.ts
+++ b/src/community/community-wire.ts
@@ -1,4 +1,4 @@
-import * as remeda from "remeda";
+import { isEmpty, omit } from "remeda";
 import type { CommunityIpfsType } from "./types.js";
 import { getPKCAddressFromPublicKeySync } from "../signer/util.js";
 import { isStringDomain } from "../util.js";
@@ -16,12 +16,12 @@ export function omitRuntimeCommunityFields<Community extends LooseCommunityIpfs 
     community: Community
 ): Partial<CommunityIpfsType> & Record<string, unknown> {
     if (!community) return {};
-    return remeda.omit(community, runtimeOnlyCommunityFields) as Partial<CommunityIpfsType> & Record<string, unknown>;
+    return omit(community, runtimeOnlyCommunityFields) as Partial<CommunityIpfsType> & Record<string, unknown>;
 }
 
 export function cleanWireCommunity(community?: LooseCommunityIpfs): Partial<CommunityIpfsType> | undefined {
     const wireCommunity = omitRuntimeCommunityFields(community);
-    if (remeda.isEmpty(wireCommunity)) return undefined;
+    if (isEmpty(wireCommunity)) return undefined;
     return wireCommunity as Partial<CommunityIpfsType>;
 }
 

--- a/src/community/remote-community.ts
+++ b/src/community/remote-community.ts
@@ -33,7 +33,7 @@ import type {
     ExportCommunityModLogsOptions
 } from "./types.js";
 import type { CommentModerationTableRow } from "../publications/comment-moderation/types.js";
-import * as remeda from "remeda";
+import { difference, keys, omit, pick } from "remeda";
 import { ModQueuePages, PostsPages } from "../pages/pages.js";
 import type { PostsPagesTypeIpfs } from "../pages/types.js";
 import { parseRawPages } from "../pages/util.js";
@@ -284,10 +284,10 @@ export class RemoteCommunity extends TypedEmitter<CommunityEvents> implements Om
         const log = Logger("pkc-js:remote-community:initCommunityIpfsPropsNoMerge");
         this.raw.communityIpfs = newProps;
         this.initRemoteCommunityPropsNoMerge(newProps);
-        const unknownProps = remeda.difference(remeda.keys.strict(this.raw.communityIpfs), remeda.keys.strict(CommunityIpfsSchema.shape));
+        const unknownProps = difference(keys(this.raw.communityIpfs), keys(CommunityIpfsSchema.shape));
         if (unknownProps.length > 0) {
             log(`Found unknown props on community (${this.address}) ipfs record`, unknownProps);
-            Object.assign(this, remeda.pick(this.raw.communityIpfs, unknownProps));
+            Object.assign(this, pick(this.raw.communityIpfs, unknownProps));
         }
     }
 
@@ -455,9 +455,12 @@ export class RemoteCommunity extends TypedEmitter<CommunityEvents> implements Om
         this._assertHasIdentity();
     }
 
-    _toJSONIpfsBaseNoPosts() {
-        const communityIpfsKeys = remeda.keys.strict(remeda.omit(CommunityIpfsSchema.shape, ["posts", "modQueue"]));
-        return remeda.pick(this, communityIpfsKeys);
+    // Explicit return type: remeda v2's pick infers a PickFromArray<this, ...> branded type that
+    // references non-exported remeda symbols, which tsc cannot serialize into the .d.ts. This is
+    // the CommunityIpfs record without the paginated posts/modQueue fields.
+    _toJSONIpfsBaseNoPosts(): Omit<CommunityIpfsType, "posts" | "modQueue"> {
+        const communityIpfsKeys = keys(omit(CommunityIpfsSchema.shape, ["posts", "modQueue"]));
+        return pick(this, communityIpfsKeys) as unknown as Omit<CommunityIpfsType, "posts" | "modQueue">;
     }
 
     toJSONRpcRemote(): RpcRemoteCommunityType {
@@ -708,7 +711,7 @@ export class RemoteCommunity extends TypedEmitter<CommunityEvents> implements Om
         this._updatingCommunityInstanceWithListeners.community.on("error", this._updatingCommunityInstanceWithListeners.error);
         this._updatingCommunityInstanceWithListeners.community.on("statechange", this._updatingCommunityInstanceWithListeners.statechange);
 
-        const clientKeys = remeda.keys.strict(this.clients);
+        const clientKeys = keys(this.clients);
         for (const clientType of clientKeys)
             if (this.clients[clientType])
                 for (const clientUrl of Object.keys(this.clients[clientType]))
@@ -762,7 +765,7 @@ export class RemoteCommunity extends TypedEmitter<CommunityEvents> implements Om
         );
         this._updatingCommunityInstanceWithListeners.community.removeListener("error", this._updatingCommunityInstanceWithListeners.error);
 
-        const clientKeys = remeda.keys.strict(this.clients);
+        const clientKeys = keys(this.clients);
 
         for (const clientType of clientKeys)
             if (this.clients[clientType])

--- a/src/community/rpc-local-community.ts
+++ b/src/community/rpc-local-community.ts
@@ -15,7 +15,7 @@ import type { CommentModerationTableRow } from "../publications/comment-moderati
 import { RpcRemoteCommunity } from "./rpc-remote-community.js";
 import { z } from "zod";
 import { messages } from "../errors.js";
-import * as remeda from "remeda";
+import { keys, pick } from "remeda";
 import { PKC } from "../pkc/pkc.js";
 import { PKCError } from "../pkc-error.js";
 
@@ -84,7 +84,7 @@ export class RpcLocalCommunity extends RpcRemoteCommunity {
         this.edit = this.edit.bind(this);
         this._setStartedStateWithEmission("stopped");
         this.on("update", () => {
-            this.editable = remeda.pick(this, remeda.keys.strict(CommunityEditOptionsSchema.shape));
+            this.editable = pick(this, keys(CommunityEditOptionsSchema.shape)) as Pick<RpcLocalCommunity, keyof CommunityEditOptions>;
         });
         hideClassPrivateProps(this);
     }
@@ -146,7 +146,7 @@ export class RpcLocalCommunity extends RpcRemoteCommunity {
         this.started = newProps.localCommunity.started;
         this.updateCid = newProps.runtimeFields.updateCid;
         this.raw.localCommunity = newProps;
-        this.editable = remeda.pick(this, remeda.keys.strict(CommunityEditOptionsSchema.shape));
+        this.editable = pick(this, keys(CommunityEditOptionsSchema.shape)) as Pick<RpcLocalCommunity, keyof CommunityEditOptions>;
     }
 
     protected _updateRpcClientStateFromStartedState(startedState: RpcLocalCommunity["startedState"]) {

--- a/src/community/rpc-remote-community.ts
+++ b/src/community/rpc-remote-community.ts
@@ -1,7 +1,7 @@
 import Logger from "../logger.js";
 import { RemoteCommunity } from "./remote-community.js";
 import type { RpcRemoteCommunityType, CommunityEvents, CommunityRpcErrorToTransmit } from "./types.js";
-import * as remeda from "remeda";
+import { keys } from "remeda";
 import { PKCError } from "../pkc-error.js";
 import { parseRpcRemoteCommunityUpdateEventWithPKCErrorIfItFails } from "../schema/schema-util.js";
 import { deepMergeRuntimeFields } from "../util.js";
@@ -29,14 +29,14 @@ export class RpcRemoteCommunity extends RemoteCommunity {
     > = undefined; // The pkc._updatingCommunities we're subscribed to
 
     protected _setRpcClientStateWithoutEmission(newState: RemoteCommunity["clients"]["pkcRpcClients"][""]["state"]) {
-        const currentRpcUrl = remeda.keys.strict(this.clients.pkcRpcClients)[0];
+        const currentRpcUrl = keys(this.clients.pkcRpcClients)[0];
         const currentState = this.clients.pkcRpcClients[currentRpcUrl].state;
         if (newState === currentState) return;
         this.clients.pkcRpcClients[currentRpcUrl].state = newState;
     }
 
     protected _setRpcClientStateWithEmission(newState: RemoteCommunity["clients"]["pkcRpcClients"][""]["state"]) {
-        const currentRpcUrl = remeda.keys.strict(this.clients.pkcRpcClients)[0];
+        const currentRpcUrl = keys(this.clients.pkcRpcClients)[0];
         const currentState = this.clients.pkcRpcClients[currentRpcUrl].state;
         if (newState === currentState) return;
         this.clients.pkcRpcClients[currentRpcUrl].state = newState;
@@ -180,7 +180,7 @@ export class RpcRemoteCommunity extends RemoteCommunity {
             this._updatingRpcCommunityInstanceWithListeners.startedstatechange
         );
 
-        const clientKeys = remeda.keys.strict(this.clients);
+        const clientKeys = keys(this.clients);
 
         for (const clientType of clientKeys)
             if (updatingCommunity.clients[clientType])
@@ -325,7 +325,7 @@ export class RpcRemoteCommunity extends RemoteCommunity {
             "startedstatechange",
             this._updatingRpcCommunityInstanceWithListeners.startedstatechange
         );
-        const clientKeys = remeda.keys.strict(this.clients);
+        const clientKeys = keys(this.clients);
 
         for (const clientType of clientKeys)
             if (this.clients[clientType])

--- a/src/community/schema.ts
+++ b/src/community/schema.ts
@@ -14,7 +14,7 @@ import {
 } from "../schema/schema.js";
 import { ModQueuePagesIpfsSchema, PostsPagesIpfsSchema } from "../pages/schema.js";
 import type { LocalCommunity } from "../runtime/node/community/local-community.js";
-import * as remeda from "remeda";
+import { difference, isEmpty, keys, omit } from "remeda";
 import type { DecryptedChallengeRequestMessageTypeWithCommunityAuthor } from "../pubsub-messages/types.js";
 import { messages } from "../errors.js";
 
@@ -140,7 +140,7 @@ export const ChallengeExcludePublicationTypeSchema = z
         communityEdit: excludePublicationFieldSchema
     })
     .refine(
-        (args) => !remeda.isEmpty(JSON.parse(JSON.stringify(args))), // is it empty object {} or {field: undefined}? throw if so
+        (args) => !isEmpty(JSON.parse(JSON.stringify(args))), // is it empty object {} or {field: undefined}? throw if so
         messages.ERR_CAN_NOT_SET_EXCLUDE_PUBLICATION_TO_EMPTY_OBJECT
     );
 
@@ -236,7 +236,7 @@ export const CommunityIpfsSchema = z
     })
     .strict();
 
-export const CommunitySignedPropertyNames = remeda.keys.strict(remeda.omit(CommunityIpfsSchema.shape, ["signature"]));
+export const CommunitySignedPropertyNames = keys(omit(CommunityIpfsSchema.shape, ["signature"]));
 
 // This is object transmitted by RPC server to RPC client when it's fetching a remote community
 // When resetInstance is true, community/updateCid are absent — the client should clear its state
@@ -401,7 +401,7 @@ export const CommunityExportRecordsSchema = CommunityExportRecordSchema.array();
 // Reserved fields
 
 // TODO should make the array of class props typed
-export const CommunityIpfsReservedFields = remeda.difference(
+export const CommunityIpfsReservedFields = difference(
     [
         "cid",
         "shortCid",
@@ -424,5 +424,5 @@ export const CommunityIpfsReservedFields = remeda.difference(
         "started",
         "exports"
     ],
-    remeda.keys.strict(CommunityIpfsSchema.shape)
+    keys(CommunityIpfsSchema.shape)
 );

--- a/src/pages/pages-client-manager.ts
+++ b/src/pages/pages-client-manager.ts
@@ -1,6 +1,6 @@
 import { BaseClientsManager, OptionsToLoadFromGateway } from "../clients/base-client-manager.js";
 import type { ModQueuePageIpfs, ModQueueSortName, PageIpfs } from "./types.js";
-import * as remeda from "remeda";
+import { isEmpty, keys, unique } from "remeda";
 import Logger from "../logger.js";
 import { BasePages, ModQueuePages, PostsPages, RepliesPages } from "./pages.js";
 import { POSTS_SORT_TYPES, POST_REPLIES_SORT_TYPES, type PageRuntimeFields } from "./util.js";
@@ -44,7 +44,7 @@ export class BasePagesClientsManager extends BaseClientsManager {
         if (!this.clients.ipfsGateways) this.clients.ipfsGateways = {};
         for (const sortType of sortTypes) {
             if (!this.clients.ipfsGateways[sortType]) this.clients.ipfsGateways[sortType] = {};
-            for (const gatewayUrl of remeda.keys.strict(this._pkc.clients.ipfsGateways))
+            for (const gatewayUrl of keys(this._pkc.clients.ipfsGateways))
                 if (!this.clients.ipfsGateways[sortType][gatewayUrl])
                     this.clients.ipfsGateways[sortType][gatewayUrl] = new PagesIpfsGatewayClient("stopped");
         }
@@ -54,7 +54,7 @@ export class BasePagesClientsManager extends BaseClientsManager {
         if (this._pkc.clients.kuboRpcClients && !this.clients.kuboRpcClients) this.clients.kuboRpcClients = {};
         for (const sortType of sortTypes) {
             if (!this.clients.kuboRpcClients[sortType]) this.clients.kuboRpcClients[sortType] = {};
-            for (const kuboRpcUrl of remeda.keys.strict(this._pkc.clients.kuboRpcClients))
+            for (const kuboRpcUrl of keys(this._pkc.clients.kuboRpcClients))
                 if (!this.clients.kuboRpcClients[sortType][kuboRpcUrl])
                     this.clients.kuboRpcClients[sortType][kuboRpcUrl] = new PagesKuboRpcClient("stopped");
         }
@@ -64,7 +64,7 @@ export class BasePagesClientsManager extends BaseClientsManager {
         if (this._pkc.clients.libp2pJsClients && !this.clients.libp2pJsClients) this.clients.libp2pJsClients = {};
         for (const sortType of sortTypes) {
             if (!this.clients.libp2pJsClients[sortType]) this.clients.libp2pJsClients[sortType] = {};
-            for (const libp2pJsClientKey of remeda.keys.strict(this._pkc.clients.libp2pJsClients))
+            for (const libp2pJsClientKey of keys(this._pkc.clients.libp2pJsClients))
                 if (!this.clients.libp2pJsClients[sortType][libp2pJsClientKey])
                     this.clients.libp2pJsClients[sortType][libp2pJsClientKey] = new PagesLibp2pJsClient("stopped");
         }
@@ -74,7 +74,7 @@ export class BasePagesClientsManager extends BaseClientsManager {
         if (this._pkc.clients.pkcRpcClients && !this.clients.pkcRpcClients) this.clients.pkcRpcClients = {};
         for (const sortType of sortTypes) {
             if (!this.clients.pkcRpcClients[sortType]) this.clients.pkcRpcClients[sortType] = {};
-            for (const rpcUrl of remeda.keys.strict(this._pkc.clients.pkcRpcClients))
+            for (const rpcUrl of keys(this._pkc.clients.pkcRpcClients))
                 if (!this.clients.pkcRpcClients[sortType][rpcUrl])
                     this.clients.pkcRpcClients[sortType][rpcUrl] = new PagesPKCRpcStateClient("stopped");
         }
@@ -109,7 +109,7 @@ export class BasePagesClientsManager extends BaseClientsManager {
         if (!curSortTypes) {
             this._pkc._memCaches.pageCidToSortTypes.set(pageCid, sortTypes);
         } else {
-            const newSortTypes = remeda.unique([...curSortTypes, ...sortTypes]);
+            const newSortTypes = unique([...curSortTypes, ...sortTypes]);
             this._pkc._memCaches.pageCidToSortTypes.set(pageCid, newSortTypes);
         }
     }
@@ -128,9 +128,9 @@ export class BasePagesClientsManager extends BaseClientsManager {
     }
 
     updatePagesMaxSizeCache(newPageCids: string[], pageMaxSizeBytes: number) {
-        remeda
-            .unique(newPageCids)
-            .forEach((pageCid) => this._pkc._memCaches.pagesMaxSize.set(this._calculatePageMaxSizeCacheKey(pageCid), pageMaxSizeBytes));
+        unique(newPageCids).forEach((pageCid) =>
+            this._pkc._memCaches.pagesMaxSize.set(this._calculatePageMaxSizeCacheKey(pageCid), pageMaxSizeBytes)
+        );
     }
 
     updatePageCidsToSortTypesToIncludeSubsequent(nextPageCid: string, previousPageCid: string) {
@@ -285,15 +285,13 @@ export class BasePagesClientsManager extends BaseClientsManager {
     }): Promise<{ page: PageIpfs | ModQueuePageIpfs; runtimeFields?: PageRuntimeFields }> {
         const { pageCid } = opts;
         const log = Logger("pkc-js:pages:getPage");
-        const sortTypesFromPageCids = remeda.keys
-            .strict(this._pages.pageCids)
-            .filter((sortType) => this._pages.pageCids[sortType] === pageCid);
+        const sortTypesFromPageCids = keys(this._pages.pageCids).filter((sortType) => this._pages.pageCids[sortType] === pageCid);
         if (sortTypesFromPageCids.length > 0) {
             this.updatePageCidsToSortTypes(this._pages.pageCids);
         }
         const sortTypesFromMemcache: string[] | undefined = this._pkc._memCaches.pageCidToSortTypes.get(pageCid);
 
-        const isFirstPage = Object.values(this._pages.pageCids).includes(pageCid) || remeda.isEmpty(this._pages.pageCids);
+        const isFirstPage = Object.values(this._pages.pageCids).includes(pageCid) || isEmpty(this._pages.pageCids);
         const pageMaxSize = opts.pageMaxSize
             ? opts.pageMaxSize
             : this._pkc._memCaches.pagesMaxSize.get(this._calculatePageMaxSizeCacheKey(pageCid))
@@ -356,7 +354,7 @@ export class RepliesPagesClientsManager extends BasePagesClientsManager {
     };
 
     protected override getSortTypes() {
-        return remeda.keys.strict(POST_REPLIES_SORT_TYPES);
+        return keys(POST_REPLIES_SORT_TYPES);
     }
 
     protected override preFetchPage(): void {
@@ -390,7 +388,7 @@ export class CommunityPostsPagesClientsManager extends BasePagesClientsManager {
     };
 
     protected override getSortTypes() {
-        return remeda.keys.strict(POSTS_SORT_TYPES);
+        return keys(POSTS_SORT_TYPES);
     }
 
     protected override preFetchPage(): void {

--- a/src/pages/util.ts
+++ b/src/pages/util.ts
@@ -14,7 +14,7 @@ import { Comment } from "../publications/comment/comment.js";
 import assert from "assert";
 import { BasePages, PostsPages, RepliesPages } from "./pages.js";
 
-import * as remeda from "remeda";
+import { find, fromEntries, keys as remedaKeys, omit, pick, round } from "remeda";
 import type { CommentWithinModQueuePageJson, CommentWithinRepliesPostsPageJson, CommentUpdateType } from "../publications/comment/types.js";
 import { shortifyAddress, shortifyCid } from "../util.js";
 import { RemoteCommunity } from "../community/remote-community.js";
@@ -57,7 +57,7 @@ export const POSTS_SORT_TYPES: PostSort = {
 };
 
 export const POST_REPLIES_SORT_TYPES: ReplySort = {
-    ...remeda.pick(POSTS_SORT_TYPES, ["new"]),
+    ...pick(POSTS_SORT_TYPES, ["new"]),
     best: { score: (...args) => bestScore(...args) },
     old: { score: (...args) => oldScore(...args) },
     newFlat: { ...POSTS_SORT_TYPES["new"], flat: true },
@@ -65,7 +65,7 @@ export const POST_REPLIES_SORT_TYPES: ReplySort = {
 };
 
 export const REPLY_REPLIES_SORT_TYPES: ReplySort = {
-    ...remeda.pick(POSTS_SORT_TYPES, ["new"]),
+    ...pick(POSTS_SORT_TYPES, ["new"]),
     best: { score: (...args) => bestScore(...args) },
     old: { score: (...args) => oldScore(...args) }
 };
@@ -84,7 +84,7 @@ export function hotScore(comment: CommentToSort) {
     const order = Math.log10(Math.max(Math.abs(score), 1));
     const sign = score > 0 ? 1 : score < 0 ? -1 : 0;
     const seconds = comment.comment.timestamp - 1134028003;
-    return remeda.round(sign * order + seconds / 45000, 7);
+    return round(sign * order + seconds / 45000, 7);
 }
 
 export function bestScore(comment: CommentToSort) {
@@ -243,18 +243,18 @@ export function mapPageIpfsCommentToPageJsonComment(pageComment: PageIpfs["comme
 export function parsePageIpfs(pageIpfs: PageIpfs): PageTypeJson {
     const finalComments = pageIpfs.comments.map(mapPageIpfsCommentToPageJsonComment);
 
-    return { comments: finalComments, ...remeda.omit(pageIpfs, ["comments"]) };
+    return { comments: finalComments, ...omit(pageIpfs, ["comments"]) };
 }
 
 export function parseModQueuePageIpfs(modqueuePageIpfs: ModQueuePageIpfs): ModQueuePageTypeJson {
     const finalComments = modqueuePageIpfs.comments.map(mapModqueuePageIpfsCommentToModQueuePageJsonComment);
-    return { comments: finalComments, ...remeda.omit(modqueuePageIpfs, ["comments"]) };
+    return { comments: finalComments, ...omit(modqueuePageIpfs, ["comments"]) };
 }
 
 export function parsePagesIpfs(pagesRaw: PagesTypeIpfs): Omit<PagesTypeJson, "clients"> {
-    const keys = remeda.keys.strict(pagesRaw.pages);
+    const keys = remedaKeys(pagesRaw.pages);
     const parsedPages = Object.values(pagesRaw.pages).map((pageIpfs) => parsePageIpfs(pageIpfs));
-    const pagesType = remeda.fromEntries.strict(keys.map((key, i) => [key, parsedPages[i]]));
+    const pagesType = fromEntries(keys.map((key, i) => [key, parsedPages[i]]));
     return { pages: pagesType, pageCids: pagesRaw.pageCids || {} };
 }
 
@@ -327,7 +327,7 @@ export function findCommentInParsedPages(pageJson: PageTypeJson, targetCommentCi
     if (!pageJson) throw Error("should define page json");
     if (!targetCommentCid) throw Error("should define target comment cid");
 
-    return remeda.find(pageJson.comments, (comment) => comment.cid === targetCommentCid);
+    return find(pageJson.comments, (comment) => comment.cid === targetCommentCid);
 }
 
 export function findCommentInHierarchicalPageIpfsRecursively(page: PageIpfs, targetCid: string): PageIpfs["comments"][0] | undefined {

--- a/src/pkc/pkc-client-manager.ts
+++ b/src/pkc/pkc-client-manager.ts
@@ -2,7 +2,7 @@ import { PKC } from "./pkc.js";
 import { hideClassPrivateProps, isIpfsCid, isIpfsPath } from "../util.js";
 import { PKCError } from "../pkc-error.js";
 import assert from "assert";
-import * as remeda from "remeda";
+import { clone, keys } from "remeda";
 import { NameResolverClient } from "../clients/name-resolver-client.js";
 
 import {
@@ -41,19 +41,19 @@ export class PKCClientsManager extends BaseClientsManager {
 
     protected _initIpfsGateways() {
         this.clients.ipfsGateways = {};
-        for (const gatewayUrl of remeda.keys.strict(this._pkc.clients.ipfsGateways))
+        for (const gatewayUrl of keys(this._pkc.clients.ipfsGateways))
             this.clients.ipfsGateways = { ...this.clients.ipfsGateways, [gatewayUrl]: new PKCIpfsGatewayClient("stopped") };
     }
 
     protected _initKuboRpcClients() {
         this.clients.kuboRpcClients = {};
-        for (const kuboRpcUrl of remeda.keys.strict(this._pkc.clients.kuboRpcClients))
+        for (const kuboRpcUrl of keys(this._pkc.clients.kuboRpcClients))
             this.clients.kuboRpcClients = { ...this.clients.kuboRpcClients, [kuboRpcUrl]: new PKCKuboRpcClient("stopped") };
     }
 
     protected _initPubsubKuboRpcClients() {
         this.clients.pubsubKuboRpcClients = {};
-        for (const pubsubUrl of remeda.keys.strict(this._pkc.clients.pubsubKuboRpcClients))
+        for (const pubsubUrl of keys(this._pkc.clients.pubsubKuboRpcClients))
             this.clients.pubsubKuboRpcClients = {
                 ...this.clients.pubsubKuboRpcClients,
                 [pubsubUrl]: new GenericStateClient<string>("stopped")
@@ -62,7 +62,7 @@ export class PKCClientsManager extends BaseClientsManager {
 
     protected _initLibp2pJsClients() {
         this.clients.libp2pJsClients = {};
-        for (const libp2pJsClientKey of remeda.keys.strict(this._pkc.clients.libp2pJsClients))
+        for (const libp2pJsClientKey of keys(this._pkc.clients.libp2pJsClients))
             this.clients.libp2pJsClients = { ...this.clients.libp2pJsClients, [libp2pJsClientKey]: new PKCLibp2pJsClient("stopped") };
     }
 
@@ -159,7 +159,7 @@ export class PKCClientsManager extends BaseClientsManager {
     }
 
     async fetchCid(cid: string): Promise<string> {
-        let finalCid = remeda.clone(cid);
+        let finalCid = clone(cid);
         if (!isIpfsCid(finalCid) && isIpfsPath(finalCid)) finalCid = finalCid.split("/")[2];
         if (!isIpfsCid(finalCid)) throw new PKCError("ERR_CID_IS_INVALID", { cid });
         const timeoutMs = this._pkc._timeouts["generic-ipfs"];

--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -65,7 +65,7 @@ import { RpcLocalCommunity } from "../community/rpc-local-community.js";
 import type { LocalCommunity } from "../runtime/node/community/local-community.js";
 import { extractCommunityRuntimeFieldsFromParsedPages } from "../pages/util.js";
 import pTimeout, { TimeoutError } from "p-timeout";
-import * as remeda from "remeda";
+import { clone, flat, isEmpty, omit, pick, unique } from "remeda";
 import { z } from "zod";
 import type { CreateSignerOptions } from "../signer/types.js";
 import type {
@@ -353,8 +353,8 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
                 _clientOptions: clientOptions,
                 peers: async () => {
                     const topics = await kuboRpcClient.pubsub.ls();
-                    const topicPeers = remeda.flattenDeep(await Promise.all(topics.map((topic) => kuboRpcClient.pubsub.peers(topic))));
-                    const peers = remeda.unique(topicPeers.map((topicPeer) => topicPeer.toString()));
+                    const topicPeers = flat(await Promise.all(topics.map((topic) => kuboRpcClient.pubsub.peers(topic))));
+                    const peers = unique(topicPeers.map((topicPeer) => topicPeer.toString()));
                     return peers;
                 },
                 url: clientOptions.url!.toString(),
@@ -509,7 +509,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
             | CreateCommunityEditPublicationOptions,
         log: Logger
     ): Promise<CommentOptionsToSign | VoteOptionsToSign | CommentEditOptionsToSign | CommunityEditPublicationOptionsToSign> {
-        const finalOptions = remeda.clone(pubOptions);
+        const finalOptions = clone(pubOptions);
         if (!finalOptions.signer) throw Error("User did not provide a signer to create a local publication");
         const normalizedAuthor = normalizeCreatePublicationAuthor(finalOptions.author);
         let cleanedAuthor = cleanWireAuthor(normalizedAuthor);
@@ -520,7 +520,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
                 if (typeof val === "object" && val !== null && !Array.isArray(val) && Object.keys(val).length === 0)
                     delete (cleanedAuthor as Record<string, unknown>)[key];
             }
-            if (remeda.isEmpty(cleanedAuthor)) cleanedAuthor = undefined;
+            if (isEmpty(cleanedAuthor)) cleanedAuthor = undefined;
         }
         const filledTimestamp = typeof finalOptions.timestamp !== "number" ? timestamp() : finalOptions.timestamp;
         const filledSigner = await this.createSigner(finalOptions.signer);
@@ -638,7 +638,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
             // Options is CommentIpfs | CommentIpfsWithCidDefined | MinimumCommentFieldsToFetchPages
             if ("cid" in options) commentInstance.setCid(parseCidStringSchemaWithPKCErrorIfItFails(options.cid));
             //@ts-expect-error
-            const commentIpfs: CommentIpfsType = remeda.omit(options, ["cid"]); // remove cid to make sure if options:CommentIpfsWithCidDefined that cid doesn't become part of comment.raw.comment
+            const commentIpfs: CommentIpfsType = omit(options, ["cid"]); // remove cid to make sure if options:CommentIpfsWithCidDefined that cid doesn't become part of comment.raw.comment
 
             // if it has signature it means it's a full CommentIpfs
             if (!("signature" in options)) Object.assign(commentInstance, options);
@@ -709,7 +709,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         if (!community.raw.communityIpfs) {
             if (options.signature) {
                 const resParseCommunityIpfs = CommunityIpfsSchema.loose().safeParse(
-                    remeda.pick(options, <(keyof CommunityIpfsType)[]>[...options.signature.signedPropertyNames, "signature"])
+                    pick(options, <(keyof CommunityIpfsType)[]>[...options.signature.signedPropertyNames, "signature"])
                 );
                 if (resParseCommunityIpfs.success) {
                     const cleanedRecord = removeUndefinedValuesRecursively(resParseCommunityIpfs.data); // safe way to replicate JSON.stringify() which is done before adding record to ipfs

--- a/src/publications/comment-edit/schema.ts
+++ b/src/publications/comment-edit/schema.ts
@@ -12,7 +12,7 @@ import {
     hasAtLeastOneCommunityIdentifier,
     atLeastOneCommunityIdentifierMessage
 } from "../../schema/schema.js";
-import * as remeda from "remeda";
+import { difference, keys, mapToObj, omit, unique } from "remeda";
 import { keysToOmitFromSignedPropertyNames } from "../../signer/constants.js";
 
 export const AuthorCommentEditOptionsSchema = z
@@ -34,11 +34,9 @@ export const CreateCommentEditOptionsWithRefinementSchema = CreateCommentEditOpt
     atLeastOneCommunityIdentifierMessage
 );
 
-export const CommentEditSignedPropertyNames = remeda.keys.strict(
-    remeda.omit(CreateCommentEditOptionsSchema.shape, keysToOmitFromSignedPropertyNames)
-);
+export const CommentEditSignedPropertyNames = keys(omit(CreateCommentEditOptionsSchema.shape, keysToOmitFromSignedPropertyNames));
 const editPubsubPickOptions = <Record<(typeof CommentEditSignedPropertyNames)[number] | "signature", true>>(
-    remeda.mapToObj([...CommentEditSignedPropertyNames, "signature"], (x) => [x, true])
+    mapToObj([...CommentEditSignedPropertyNames, "signature"], (x) => [x, true])
 );
 
 // ChallengeRequest.commentEdit
@@ -65,10 +63,10 @@ export const CommentEditChallengeRequestToEncryptSchema = CreateCommentEditOptio
     commentEdit: CommentEditPubsubMessagePublicationWithFlexibleAuthorSchema.loose()
 });
 
-export const CommentEditReservedFields = remeda.difference(
-    remeda.unique([
-        ...remeda.keys.strict(CommentEditsTableRowSchema.shape),
-        ...remeda.keys.strict(CommentEditChallengeRequestToEncryptSchema.shape),
+export const CommentEditReservedFields = difference(
+    unique([
+        ...keys(CommentEditsTableRowSchema.shape),
+        ...keys(CommentEditChallengeRequestToEncryptSchema.shape),
         "shortCommentCid",
         "shortCommunityAddress",
         "shortCommunityAddress",
@@ -82,5 +80,5 @@ export const CommentEditReservedFields = remeda.difference(
         "commentEdit",
         "nameResolved"
     ]),
-    remeda.keys.strict(CommentEditPubsubMessagePublicationSchema.shape)
+    keys(CommentEditPubsubMessagePublicationSchema.shape)
 );

--- a/src/publications/comment-moderation/schema.ts
+++ b/src/publications/comment-moderation/schema.ts
@@ -11,7 +11,7 @@ import {
     hasAtLeastOneCommunityIdentifier,
     atLeastOneCommunityIdentifierMessage
 } from "../../schema/schema.js";
-import { difference, keys, mapToObj, omit } from "remeda";
+import { difference, keys, mapToObj, omit, unique } from "remeda";
 import { keysToOmitFromSignedPropertyNames } from "../../signer/constants.js";
 
 export const ModeratorOptionsSchema = z
@@ -74,7 +74,10 @@ export const CommentModerationChallengeRequestToEncryptSchema = CreateCommentMod
     });
 
 export const CommentModerationReservedFields = difference(
-    [
+    // unique() because remeda v2's difference is multiset (removes each `other` element once, not
+    // all occurrences); a candidate that appears in both source schemas AND the pubsub schema would
+    // otherwise survive as reserved. v1's difference was set-based. (Matches comment-edit's guard.)
+    unique([
         ...keys(CommentModerationsTableRowSchema.shape),
         ...keys(CommentModerationChallengeRequestToEncryptSchema.shape),
         "shortCommunityAddress",
@@ -88,6 +91,6 @@ export const CommentModerationReservedFields = difference(
         "signer",
         "clients",
         "nameResolved"
-    ],
+    ]),
     keys(CommentModerationPubsubMessagePublicationSchema.shape)
 );

--- a/src/publications/comment-moderation/schema.ts
+++ b/src/publications/comment-moderation/schema.ts
@@ -11,7 +11,7 @@ import {
     hasAtLeastOneCommunityIdentifier,
     atLeastOneCommunityIdentifierMessage
 } from "../../schema/schema.js";
-import * as remeda from "remeda";
+import { difference, keys, mapToObj, omit } from "remeda";
 import { keysToOmitFromSignedPropertyNames } from "../../signer/constants.js";
 
 export const ModeratorOptionsSchema = z
@@ -42,12 +42,12 @@ export const CreateCommentModerationOptionsWithRefinementSchema = CreateCommentM
 
 // ChallengeRequest.publication
 
-export const CommentModerationSignedPropertyNames = remeda.keys.strict(
-    remeda.omit(CreateCommentModerationOptionsSchema.shape, keysToOmitFromSignedPropertyNames)
+export const CommentModerationSignedPropertyNames = keys(
+    omit(CreateCommentModerationOptionsSchema.shape, keysToOmitFromSignedPropertyNames)
 );
 
 const commentModerationPickOptions = <Record<(typeof CommentModerationSignedPropertyNames)[number] | "signature", true>>(
-    remeda.mapToObj([...CommentModerationSignedPropertyNames, "signature"], (x) => [x, true])
+    mapToObj([...CommentModerationSignedPropertyNames, "signature"], (x) => [x, true])
 );
 
 // Will be used by the community when parsing request.publication
@@ -73,10 +73,10 @@ export const CommentModerationChallengeRequestToEncryptSchema = CreateCommentMod
         commentModeration: CommentModerationPubsubMessagePublicationSchema.loose()
     });
 
-export const CommentModerationReservedFields = remeda.difference(
+export const CommentModerationReservedFields = difference(
     [
-        ...remeda.keys.strict(CommentModerationsTableRowSchema.shape),
-        ...remeda.keys.strict(CommentModerationChallengeRequestToEncryptSchema.shape),
+        ...keys(CommentModerationsTableRowSchema.shape),
+        ...keys(CommentModerationChallengeRequestToEncryptSchema.shape),
         "shortCommunityAddress",
         "shortCommunityAddress",
         "communityAddress",
@@ -89,5 +89,5 @@ export const CommentModerationReservedFields = remeda.difference(
         "clients",
         "nameResolved"
     ],
-    remeda.keys.strict(CommentModerationPubsubMessagePublicationSchema.shape)
+    keys(CommentModerationPubsubMessagePublicationSchema.shape)
 );

--- a/src/publications/comment/comment-client-manager.ts
+++ b/src/publications/comment/comment-client-manager.ts
@@ -3,7 +3,7 @@ import type { PageIpfs, PageTypeJson } from "../../pages/types.js";
 import type { CommunityIpfsType } from "../../community/types.js";
 import { NameResolverClient } from "../../clients/name-resolver-client.js";
 import { Comment } from "./comment.js";
-import * as remeda from "remeda";
+import { clone, keys } from "remeda";
 import type { CommentIpfsType, CommentUpdateType } from "./types.js";
 import {
     parseCommentIpfsSchemaWithPKCErrorIfItFails,
@@ -100,17 +100,17 @@ export class CommentClientsManager extends PublicationClientsManager {
 
     protected override _initKuboRpcClients(): void {
         if (this._pkc.clients.kuboRpcClients)
-            for (const ipfsUrl of remeda.keys.strict(this._pkc.clients.kuboRpcClients))
+            for (const ipfsUrl of keys(this._pkc.clients.kuboRpcClients))
                 this.clients.kuboRpcClients = { ...this.clients.kuboRpcClients, [ipfsUrl]: new CommentKuboRpcClient("stopped") };
     }
 
     protected override _initLibp2pJsClients(): void {
-        for (const libp2pJsClientKey of remeda.keys.strict(this._pkc.clients.libp2pJsClients))
+        for (const libp2pJsClientKey of keys(this._pkc.clients.libp2pJsClients))
             this.clients.libp2pJsClients = { ...this.clients.libp2pJsClients, [libp2pJsClientKey]: new CommentLibp2pJsClient("stopped") };
     }
 
     protected override _initPKCRpcClients() {
-        for (const rpcUrl of remeda.keys.strict(this._pkc.clients.pkcRpcClients))
+        for (const rpcUrl of keys(this._pkc.clients.pkcRpcClients))
             this.clients.pkcRpcClients = { ...this.clients.pkcRpcClients, [rpcUrl]: new CommentPKCRpcStateClient("stopped") };
     }
 
@@ -570,7 +570,7 @@ export class CommentClientsManager extends PublicationClientsManager {
         const cachedComment = this._pkc._memCaches.commentIpfs.get(cid);
         if (cachedComment) {
             fetchCommentLogger.trace("Serving comment CID from cache", cid);
-            return remeda.clone(cachedComment);
+            return clone(cachedComment);
         }
 
         const verifiedComment = await this._pkc._inflightFetchManager.withResource(InflightResourceTypes.COMMENT_IPFS, cid, async () => {

--- a/src/publications/comment/comment.ts
+++ b/src/publications/comment/comment.ts
@@ -19,7 +19,7 @@ import { PKC } from "../../pkc/pkc.js";
 import { signComment, verifyCommentIpfs, verifyCommentPubsubMessage, verifyCommentUpdate } from "../../signer/signatures.js";
 import assert from "assert";
 import { FailedToFetchCommentIpfsFromGatewaysError, PKCError } from "../../pkc-error.js";
-import * as remeda from "remeda";
+import { difference, isDeepEqual, keys, omit, pick } from "remeda";
 import { of as calculateIpfsHash } from "typestub-ipfs-only-hash";
 
 import type {
@@ -238,9 +238,9 @@ export class Comment
         this.raw.comment = props;
         this._initProps(props);
 
-        const unknownProps = remeda.difference(remeda.keys.strict(props), remeda.keys.strict(CommentIpfsSchema.shape));
+        const unknownProps = difference(keys(props), keys(CommentIpfsSchema.shape));
         if (unknownProps.length > 0) {
-            const unknownPropsWithValues = remeda.pick(props, unknownProps);
+            const unknownPropsWithValues = pick(props, unknownProps);
             log(
                 `Found unknown props on loaded CommentIpfs (cid: ${this.cid})`,
                 unknownPropsWithValues,
@@ -351,10 +351,10 @@ export class Comment
             // CommentUpdate
             this.raw.commentUpdate = props;
 
-            const unknownProps = remeda.difference(remeda.keys.strict(props), remeda.keys.strict(CommentUpdateSchema.shape));
+            const unknownProps = difference(keys(props), keys(CommentUpdateSchema.shape));
             if (unknownProps.length > 0) {
                 log("Found unknown props on CommentUpdate record", unknownProps, "Will set them on Comment instance");
-                Object.assign(this, remeda.pick(props, unknownProps));
+                Object.assign(this, pick(props, unknownProps));
             }
         }
 
@@ -431,7 +431,7 @@ export class Comment
             });
         } else if ("pages" in newReplies && newReplies.pages && "pageCids" in newReplies && newReplies.pageCids) {
             // both pageCids and pages are provided
-            const shouldUpdateReplies = !remeda.isDeepEqual(this.replies.pageCids, newReplies.pageCids);
+            const shouldUpdateReplies = !isDeepEqual(this.replies.pageCids, newReplies.pageCids);
 
             if (shouldUpdateReplies) {
                 log.trace(`Updating the props of comment instance (${this.cid}) replies`);
@@ -454,11 +454,11 @@ export class Comment
 
         if (!this.raw.pubsubMessageToPublish) throw Error("comment._pubsubMsgToPublish should be defined at this point");
         // verify that the community did not change any props that we published
-        const keysToCompare = remeda.keys.strict(remeda.omit(this.raw.pubsubMessageToPublish, ["signature", "author"])); // we're omitting these two because that would fail because of anonymity features in community
-        const pubsubMsgFromCommentIpfs = remeda.pick(decryptedVerification.comment, keysToCompare);
-        const pubsubMsgFromPublishedPubsubMsg = remeda.pick(this.raw.pubsubMessageToPublish, keysToCompare);
+        const keysToCompare = keys(omit(this.raw.pubsubMessageToPublish, ["signature", "author"])); // we're omitting these two because that would fail because of anonymity features in community
+        const pubsubMsgFromCommentIpfs = pick(decryptedVerification.comment, keysToCompare);
+        const pubsubMsgFromPublishedPubsubMsg = pick(this.raw.pubsubMessageToPublish, keysToCompare);
 
-        if (!remeda.isDeepEqual(pubsubMsgFromCommentIpfs, pubsubMsgFromPublishedPubsubMsg)) {
+        if (!isDeepEqual(pubsubMsgFromCommentIpfs, pubsubMsgFromPublishedPubsubMsg)) {
             const error = new PKCError("ERR_COMMUNITY_CHANGED_COMMENT_PUBSUB_PUBLICATION_PROPS", {
                 pubsubMsgFromSub: pubsubMsgFromCommentIpfs,
                 originalPubsubMsg: this.raw.pubsubMessageToPublish
@@ -580,13 +580,10 @@ export class Comment
         this._initCommentUpdateFromChallengeVerificationProps(decryptedVerification.commentUpdate);
 
         // handle extra props here
-        const unknownProps = remeda.difference(
-            remeda.keys.strict(decryptedVerification.commentUpdate),
-            remeda.keys.strict(CommentUpdateForChallengeVerificationSchema.shape)
-        );
+        const unknownProps = difference(keys(decryptedVerification.commentUpdate), keys(CommentUpdateForChallengeVerificationSchema.shape));
         if (unknownProps.length > 0) {
             log("Found unknown props on decryptedVerification.commentUpdate record", unknownProps, "Will set them on Comment instance");
-            Object.assign(this, remeda.pick(decryptedVerification.commentUpdate, unknownProps));
+            Object.assign(this, pick(decryptedVerification.commentUpdate, unknownProps));
         }
         this.emit("update", this);
         // RPC clients rely on the server for name resolution (sent via runtimeFields)
@@ -845,7 +842,7 @@ export class Comment
         this.emit("updatingstatechange", this._updatingState);
     }
     protected override _setRpcClientState(newState: Comment["clients"]["pkcRpcClients"][""]["state"]) {
-        const currentRpcUrl = remeda.keys.strict(this.clients.pkcRpcClients)[0];
+        const currentRpcUrl = keys(this.clients.pkcRpcClients)[0];
         if (newState === this.clients.pkcRpcClients[currentRpcUrl].state) return;
         this.clients.pkcRpcClients[currentRpcUrl].state = newState;
         this.clients.pkcRpcClients[currentRpcUrl].emit("statechange", newState);
@@ -1129,7 +1126,7 @@ export class Comment
         updatingCommentInstance.on("updatingstatechange", this._updatingCommentInstance.updatingstatechange);
         updatingCommentInstance.on("statechange", this._updatingCommentInstance.statechange);
 
-        const clientKeys = remeda.keys.strict(this.clients);
+        const clientKeys = keys(this.clients);
         for (const clientType of clientKeys)
             if (this.clients[clientType])
                 for (const clientUrl of Object.keys(this.clients[clientType]))
@@ -1232,7 +1229,7 @@ export class Comment
             this._updatingCommentInstance.comment.removeListener("update", this._updatingCommentInstance.update);
             this._updatingCommentInstance.comment.removeListener("error", this._updatingCommentInstance.error);
 
-            const clientKeys = remeda.keys.strict(this.clients);
+            const clientKeys = keys(this.clients);
 
             for (const clientType of clientKeys)
                 if (this.clients[clientType])

--- a/src/publications/comment/schema.ts
+++ b/src/publications/comment/schema.ts
@@ -14,7 +14,7 @@ import {
     atLeastOneCommunityIdentifierMessage
 } from "../../schema/schema.js";
 import { CommentEditPubsubMessagePublicationWithFlexibleAuthorSchema } from "../comment-edit/schema.js";
-import * as remeda from "remeda";
+import { difference, keys, mapToObj, omit, unique } from "remeda";
 import { messages } from "../../errors.js";
 import { keysToOmitFromSignedPropertyNames } from "../../signer/constants.js";
 import { RepliesPagesIpfsSchema } from "../../pages/schema.js";
@@ -59,12 +59,10 @@ export const CreateCommentOptionsWithRefinementSchema = CreateCommentOptionsSche
 
 // Below is what's used to initialize a local publication to be published
 
-export const CommentSignedPropertyNames = remeda.keys.strict(
-    remeda.omit(CreateCommentOptionsSchema.shape, keysToOmitFromSignedPropertyNames)
-);
+export const CommentSignedPropertyNames = keys(omit(CreateCommentOptionsSchema.shape, keysToOmitFromSignedPropertyNames));
 
 const commentPubsubKeys = <Record<(typeof CommentSignedPropertyNames)[number] | "signature", true>>(
-    remeda.mapToObj([...CommentSignedPropertyNames, "signature"], (x) => [x, true])
+    mapToObj([...CommentSignedPropertyNames, "signature"], (x) => [x, true])
 );
 
 export const CommentPubsubMessagePublicationSchema = CreateCommentOptionsSchema.merge(PublicationBaseBeforeSigning)
@@ -158,7 +156,7 @@ export const CommentUpdateSchema = z
     })
     .strict();
 
-export const CommentUpdateSignedPropertyNames = remeda.keys.strict(remeda.omit(CommentUpdateSchema.shape, ["signature"]));
+export const CommentUpdateSignedPropertyNames = keys(omit(CommentUpdateSchema.shape, ["signature"]));
 
 // Community-computed fields on CommentUpdate. Challenges may not set these via the `commentUpdate`
 // field on a ChallengeResult; any other key (including new unknown ones invented by external
@@ -202,8 +200,8 @@ export const CommentUpdateForDisapprovedPendingComment = CommentUpdateSchema.pic
     approved: true
 }).strict();
 
-export const CommentUpdateForDisapprovedPendingCommentSignedPropertyNames = remeda.keys.strict(
-    remeda.omit(CommentUpdateForDisapprovedPendingComment.shape, ["signature"])
+export const CommentUpdateForDisapprovedPendingCommentSignedPropertyNames = keys(
+    omit(CommentUpdateForDisapprovedPendingComment.shape, ["signature"])
 );
 
 // Strict for declared fields; challenge-supplied unknown keys (e.g. `reason`, `countryCode`) are
@@ -221,8 +219,8 @@ export const CommentUpdateForChallengeVerificationSchema = CommentUpdateSchema.p
     .merge(z.object({ pendingApproval: z.boolean().optional() }))
     .strict();
 
-export const CommentUpdateForChallengeVerificationSignedPropertyNames = remeda.keys.strict(
-    remeda.omit(CommentUpdateForChallengeVerificationSchema.shape, ["signature"])
+export const CommentUpdateForChallengeVerificationSignedPropertyNames = keys(
+    omit(CommentUpdateForChallengeVerificationSchema.shape, ["signature"])
 );
 
 // Comment table here
@@ -294,21 +292,21 @@ type CommentReservedFieldCandidate =
     | (typeof CommentUpdateForDisapprovedPendingCommentSignedPropertyNames)[number]
     | AdditionalCommentReservedField;
 
-const commentReservedFieldCandidates = remeda.unique<CommentReservedFieldCandidate>([
-    ...remeda.keys.strict(CommentIpfsSchema.shape),
-    ...remeda.keys.strict(CommentsTableRowSchema.shape),
-    ...remeda.keys.strict(CommentUpdateTableRowSchema.shape),
-    ...remeda.keys.strict(CommentChallengeRequestToEncryptSchema.shape),
-    ...remeda.keys.strict(CreateCommentOptionsSchema.shape),
+const commentReservedFieldCandidates = unique([
+    ...keys(CommentIpfsSchema.shape),
+    ...keys(CommentsTableRowSchema.shape),
+    ...keys(CommentUpdateTableRowSchema.shape),
+    ...keys(CommentChallengeRequestToEncryptSchema.shape),
+    ...keys(CreateCommentOptionsSchema.shape),
     ...CommentUpdateForChallengeVerificationSignedPropertyNames,
     ...CommentUpdateSignedPropertyNames,
     ...CommentUpdateForDisapprovedPendingCommentSignedPropertyNames,
     ...additionalCommentReservedFields
-]);
+] as CommentReservedFieldCandidate[]);
 
-export const CommentPubsubMessageReservedFields = remeda.difference<CommentReservedFieldCandidate>(
+export const CommentPubsubMessageReservedFields = difference(
     commentReservedFieldCandidates,
-    remeda.keys.strict(CommentPubsubMessagePublicationSchema.shape) as CommentReservedFieldCandidate[]
+    keys(CommentPubsubMessagePublicationSchema.shape) as CommentReservedFieldCandidate[]
 );
 
 type AssertTrue<T extends true> = T;
@@ -322,14 +320,14 @@ type MissingCommentReservedField = Exclude<CommentJsonFields, CommentPublication
 type _EnsureAllCommentFieldsAreReserved = AssertTrue<MissingCommentReservedField extends never ? true : false>;
 
 // Reserved fields for CommentIpfs — CommentPubsubMessage reserved fields minus fields that are legitimate in CommentIpfs
-export const CommentIpfsReservedFields = remeda.difference(
+export const CommentIpfsReservedFields = difference(
     CommentPubsubMessageReservedFields,
-    remeda.keys.strict(CommentIpfsSchema.shape) as typeof CommentPubsubMessageReservedFields
+    keys(CommentIpfsSchema.shape) as typeof CommentPubsubMessageReservedFields
 );
 
-export const CommentUpdateReservedFields = remeda.difference(CommentPubsubMessageReservedFields, [
-    ...remeda.keys.strict(CommentUpdateSchema.shape),
-    ...remeda.keys.strict(CommentUpdateTableRowSchema.shape),
+export const CommentUpdateReservedFields = difference(CommentPubsubMessageReservedFields, [
+    ...keys(CommentUpdateSchema.shape),
+    ...keys(CommentUpdateTableRowSchema.shape),
     "pendingApproval"
 ]);
 

--- a/src/publications/community-edit/schema.ts
+++ b/src/publications/community-edit/schema.ts
@@ -6,7 +6,7 @@ import {
     hasAtLeastOneCommunityIdentifier,
     atLeastOneCommunityIdentifierMessage
 } from "../../schema/schema.js";
-import * as remeda from "remeda";
+import { difference, keys, mapToObj, omit } from "remeda";
 import { keysToOmitFromSignedPropertyNames } from "../../signer/constants.js";
 
 export const CreateCommunityEditPublicationOptionsSchema = CreatePublicationUserOptionsSchema.extend({
@@ -18,12 +18,12 @@ export const CreateCommunityEditPublicationOptionsWithRefinementSchema = CreateC
     atLeastOneCommunityIdentifierMessage
 );
 
-export const CommunityEditPublicationSignedPropertyNames = remeda.keys.strict(
-    remeda.omit(CreateCommunityEditPublicationOptionsSchema.shape, keysToOmitFromSignedPropertyNames)
+export const CommunityEditPublicationSignedPropertyNames = keys(
+    omit(CreateCommunityEditPublicationOptionsSchema.shape, keysToOmitFromSignedPropertyNames)
 );
 
 const communityEditPublicationPickOptions = <Record<(typeof CommunityEditPublicationSignedPropertyNames)[number] | "signature", true>>(
-    remeda.mapToObj([...CommunityEditPublicationSignedPropertyNames, "signature"], (x) => [x, true])
+    mapToObj([...CommunityEditPublicationSignedPropertyNames, "signature"], (x) => [x, true])
 );
 
 // Will be used by the community when parsing request.communityEdit
@@ -41,9 +41,9 @@ export const CommunityEditPublicationChallengeRequestToEncryptSchema = CreateCom
         communityEdit: CommunityEditPubsubMessagePublicationSchema.loose()
     });
 
-export const CommunityEditPublicationPubsubReservedFields = remeda.difference(
+export const CommunityEditPublicationPubsubReservedFields = difference(
     [
-        ...remeda.keys.strict(CommunityEditPublicationChallengeRequestToEncryptSchema.shape),
+        ...keys(CommunityEditPublicationChallengeRequestToEncryptSchema.shape),
         "shortCommunityAddress",
         "shortCommunityAddress",
         "communityAddress",
@@ -55,5 +55,5 @@ export const CommunityEditPublicationPubsubReservedFields = remeda.difference(
         "clients",
         "nameResolved"
     ],
-    remeda.keys.strict(CommunityEditPubsubMessagePublicationSchema.shape)
+    keys(CommunityEditPubsubMessagePublicationSchema.shape)
 );

--- a/src/publications/publication-author.ts
+++ b/src/publications/publication-author.ts
@@ -1,4 +1,4 @@
-import * as remeda from "remeda";
+import { isEmpty, omit } from "remeda";
 import type { AuthorPubsubType, RuntimeAuthorType, RuntimeAuthorWithCommentUpdateType } from "../types.js";
 import { getPKCAddressFromPublicKeySync } from "../signer/util.js";
 import { isStringDomain } from "../util.js";
@@ -11,12 +11,12 @@ export function omitRuntimeAuthorFields<Author extends LooseAuthor | undefined>(
     author: Author
 ): Partial<AuthorPubsubType> & Record<string, unknown> {
     if (!author) return {};
-    return remeda.omit(author, runtimeOnlyAuthorFields) as Partial<AuthorPubsubType> & Record<string, unknown>;
+    return omit(author, runtimeOnlyAuthorFields) as Partial<AuthorPubsubType> & Record<string, unknown>;
 }
 
 export function cleanWireAuthor(author?: LooseAuthor): AuthorPubsubType | undefined {
     const wireAuthor = omitRuntimeAuthorFields(author);
-    if (remeda.isEmpty(wireAuthor)) return undefined;
+    if (isEmpty(wireAuthor)) return undefined;
     return wireAuthor as AuthorPubsubType;
 }
 

--- a/src/publications/publication-client-manager.ts
+++ b/src/publications/publication-client-manager.ts
@@ -3,7 +3,7 @@ import { PKCError } from "../pkc-error.js";
 import { RemoteCommunity } from "../community/remote-community.js";
 import { NameResolverClient } from "../clients/name-resolver-client.js";
 import Publication from "./publication.js";
-import * as remeda from "remeda";
+import { keys } from "remeda";
 import {
     PublicationIpfsGatewayClient,
     PublicationKuboPubsubClient,
@@ -46,12 +46,12 @@ export class PublicationClientsManager extends PKCClientsManager {
 
     protected override _initKuboRpcClients(): void {
         if (this._pkc.clients.kuboRpcClients)
-            for (const ipfsUrl of remeda.keys.strict(this._pkc.clients.kuboRpcClients))
+            for (const ipfsUrl of keys(this._pkc.clients.kuboRpcClients))
                 this.clients.kuboRpcClients = { ...this.clients.kuboRpcClients, [ipfsUrl]: new PublicationKuboRpcClient("stopped") };
     }
 
     protected override _initPubsubKuboRpcClients(): void {
-        for (const pubsubUrl of remeda.keys.strict(this._pkc.clients.pubsubKuboRpcClients))
+        for (const pubsubUrl of keys(this._pkc.clients.pubsubKuboRpcClients))
             this.clients.pubsubKuboRpcClients = {
                 ...this.clients.pubsubKuboRpcClients,
                 [pubsubUrl]: new PublicationKuboPubsubClient("stopped")
@@ -59,7 +59,7 @@ export class PublicationClientsManager extends PKCClientsManager {
     }
 
     protected _initPKCRpcClients() {
-        for (const rpcUrl of remeda.keys.strict(this._pkc.clients.pkcRpcClients))
+        for (const rpcUrl of keys(this._pkc.clients.pkcRpcClients))
             this.clients.pkcRpcClients = {
                 ...this.clients.pkcRpcClients,
                 [rpcUrl]: new PublicationPKCRpcStateClient("stopped")

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -44,7 +44,7 @@ import { PKCError } from "../pkc-error.js";
 import { getHeliaDebugContext, type HeliaDebugContext } from "../helia/util.js";
 import { getBufferedPKCAddressFromPublicKey } from "../signer/util.js";
 import * as cborg from "cborg";
-import * as remeda from "remeda";
+import { isDeepEqual, keys, omit } from "remeda";
 import type { CommunityIpfsType } from "../community/types.js";
 import { findStartedCommunity, findUpdatingCommunity } from "../pkc/tracked-instance-registry-util.js";
 import type { CommentIpfsType } from "./comment/types.js";
@@ -529,7 +529,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
             log.trace("Received unrelated pubsub message of type", pubsubMsgParsed.type);
         } else if (
             !Object.values(this._challengeExchanges).some((exchange) =>
-                remeda.isDeepEqual(pubsubMsgParsed.challengeRequestId, exchange.challengeRequest.challengeRequestId)
+                isDeepEqual(pubsubMsgParsed.challengeRequestId, exchange.challengeRequest.challengeRequestId)
             )
         ) {
             log.trace(`Received pubsub message with different challenge request id, ignoring it`);
@@ -703,7 +703,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
     }
 
     protected _setRpcClientState(newState: Publication["clients"]["pkcRpcClients"][""]["state"]) {
-        const currentRpcUrl = remeda.keys.strict(this.clients.pkcRpcClients)[0];
+        const currentRpcUrl = keys(this.clients.pkcRpcClients)[0];
         if (newState === this.clients.pkcRpcClients[currentRpcUrl].state) return;
         this.clients.pkcRpcClients[currentRpcUrl].state = newState;
         this.clients.pkcRpcClients[currentRpcUrl].emit("statechange", newState);
@@ -993,7 +993,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
 
         const omitEncrypted = <T extends { encrypted?: unknown }>(msg: T | undefined) => {
             if (!msg) return undefined;
-            return remeda.omit(msg, ["encrypted"]);
+            return omit(msg, ["encrypted"]);
         };
 
         return Object.values(this._challengeExchanges).map((exchange) => ({
@@ -1144,9 +1144,9 @@ class Publication extends TypedEmitter<PublicationEvents> {
 
     private _getPubsubProviders() {
         const providers =
-            this.clients.libp2pJsClients && remeda.keys.strict(this.clients.libp2pJsClients).length > 0
-                ? remeda.keys.strict(this.clients.libp2pJsClients)
-                : remeda.keys.strict(this.clients.pubsubKuboRpcClients);
+            this.clients.libp2pJsClients && keys(this.clients.libp2pJsClients).length > 0
+                ? keys(this.clients.libp2pJsClients)
+                : keys(this.clients.pubsubKuboRpcClients);
         if (providers.length === 0) throw new PKCError("ERR_NO_PUBSUB_PROVIDERS_AVAILABLE_TO_PUBLISH_OVER_PUBSUB", { providers });
         if (providers.length === 1) providers.push(providers[0]); // Same provider should be retried twice if publishing fails
 
@@ -1166,7 +1166,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
                 const encryptedFields = ["challenges"] as const;
 
                 log("Received a challenge from the local community", challenge);
-                await this._handleIncomingChallengePubsubMessage(remeda.omit(challenge, encryptedFields));
+                await this._handleIncomingChallengePubsubMessage(omit(challenge, encryptedFields));
             }
         };
 
@@ -1180,7 +1180,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
                 // need to remove publicatioon fields from challenge verification otherwise verifyChallengeVerification will throw
                 const publicationFieldsToRemove = ["comment", "commentUpdate"] as const;
                 await this._handleIncomingChallengeVerificationPubsubMessage(
-                    remeda.omit(decryptedChallengeVerification, publicationFieldsToRemove)
+                    omit(decryptedChallengeVerification, publicationFieldsToRemove)
                 );
             }
         };

--- a/src/publications/vote/schema.ts
+++ b/src/publications/vote/schema.ts
@@ -11,7 +11,7 @@ import {
     hasAtLeastOneCommunityIdentifier,
     atLeastOneCommunityIdentifierMessage
 } from "../../schema/schema.js";
-import { difference, keys, mapToObj, omit } from "remeda";
+import { difference, keys, mapToObj, omit, unique } from "remeda";
 import { keysToOmitFromSignedPropertyNames } from "../../signer/constants.js";
 
 export const CreateVoteUserOptionsSchema = CreatePublicationUserOptionsSchema.extend({
@@ -52,7 +52,10 @@ export const VoteChallengeRequestToEncryptSchema = CreateVoteUserOptionsSchema.s
 });
 
 export const VotePubsubReservedFields = difference(
-    [
+    // unique() because remeda v2's difference is multiset (removes each `other` element once, not
+    // all occurrences); `vote` appears in both source schemas AND the pubsub schema and would
+    // otherwise survive as reserved. v1's difference was set-based. (Matches comment-edit's guard.)
+    unique([
         ...keys(VoteTablesRowSchema.shape),
         ...keys(VoteChallengeRequestToEncryptSchema.shape),
         "shortCommunityAddress",
@@ -65,6 +68,6 @@ export const VotePubsubReservedFields = difference(
         "signer",
         "clients",
         "nameResolved"
-    ],
+    ]),
     keys(VotePubsubMessagePublicationSchema.shape)
 );

--- a/src/publications/vote/schema.ts
+++ b/src/publications/vote/schema.ts
@@ -11,7 +11,7 @@ import {
     hasAtLeastOneCommunityIdentifier,
     atLeastOneCommunityIdentifierMessage
 } from "../../schema/schema.js";
-import * as remeda from "remeda";
+import { difference, keys, mapToObj, omit } from "remeda";
 import { keysToOmitFromSignedPropertyNames } from "../../signer/constants.js";
 
 export const CreateVoteUserOptionsSchema = CreatePublicationUserOptionsSchema.extend({
@@ -24,12 +24,10 @@ export const CreateVoteUserOptionsWithRefinementSchema = CreateVoteUserOptionsSc
     atLeastOneCommunityIdentifierMessage
 );
 
-export const VoteSignedPropertyNames = remeda.keys.strict(
-    remeda.omit(CreateVoteUserOptionsSchema.shape, keysToOmitFromSignedPropertyNames)
-);
+export const VoteSignedPropertyNames = keys(omit(CreateVoteUserOptionsSchema.shape, keysToOmitFromSignedPropertyNames));
 
 const votePickOptions = <Record<(typeof VoteSignedPropertyNames)[number] | "signature", true>>(
-    remeda.mapToObj([...VoteSignedPropertyNames, "signature"], (x) => [x, true])
+    mapToObj([...VoteSignedPropertyNames, "signature"], (x) => [x, true])
 );
 
 // Will be used by the community when parsing request.publication
@@ -53,10 +51,10 @@ export const VoteChallengeRequestToEncryptSchema = CreateVoteUserOptionsSchema.s
     vote: VotePubsubMessagePublicationSchema.loose()
 });
 
-export const VotePubsubReservedFields = remeda.difference(
+export const VotePubsubReservedFields = difference(
     [
-        ...remeda.keys.strict(VoteTablesRowSchema.shape),
-        ...remeda.keys.strict(VoteChallengeRequestToEncryptSchema.shape),
+        ...keys(VoteTablesRowSchema.shape),
+        ...keys(VoteChallengeRequestToEncryptSchema.shape),
         "shortCommunityAddress",
         "shortCommunityAddress",
         "communityAddress",
@@ -68,5 +66,5 @@ export const VotePubsubReservedFields = remeda.difference(
         "clients",
         "nameResolved"
     ],
-    remeda.keys.strict(VotePubsubMessagePublicationSchema.shape)
+    keys(VotePubsubMessagePublicationSchema.shape)
 );

--- a/src/publications/vote/vote.ts
+++ b/src/publications/vote/vote.ts
@@ -5,7 +5,6 @@ import { signVote, verifyVote } from "../../signer/signatures.js";
 import { hideClassPrivateProps } from "../../util.js";
 import { PKCError } from "../../pkc-error.js";
 import type { CreateVoteOptions, VoteOptionsToSign, VotePubsubMessagePublication } from "./types.js";
-import * as remeda from "remeda";
 import type { SignerType } from "../../signer/types.js";
 import type { CreatePublicationOptions } from "../../types.js";
 

--- a/src/pubsub-messages/schema.ts
+++ b/src/pubsub-messages/schema.ts
@@ -14,7 +14,7 @@ import {
     CommentUpdateForChallengeVerificationSchema
 } from "../publications/comment/schema.js";
 import { ChallengeFileSchema, ChallengeFromGetChallengeSchema } from "../community/schema.js";
-import * as remeda from "remeda";
+import { keys, omit } from "remeda";
 import { CommentModerationPubsubMessagePublicationSchema } from "../publications/comment-moderation/schema.js";
 import { CommunityEditPubsubMessagePublicationSchema } from "../publications/community-edit/schema.js";
 import { Uint8ArraySchema, nonNegativeIntStringSchema } from "../schema.js";
@@ -71,9 +71,7 @@ export const DecryptedChallengeRequestSchema = DecryptedChallengeRequestPublicat
     CreatePublicationUserOptionsSchema.shape.challengeRequest.unwrap()
 );
 
-export const ChallengeRequestMessageSignedPropertyNames = remeda.keys.strict(
-    remeda.omit(ChallengeRequestMessageSchema.shape, ["signature"])
-);
+export const ChallengeRequestMessageSignedPropertyNames = keys(omit(ChallengeRequestMessageSchema.shape, ["signature"]));
 // Challenge message
 
 export const ChallengeInChallengePubsubMessageSchema = z
@@ -94,7 +92,7 @@ export const DecryptedChallengeSchema = z
         challenges: ChallengeInChallengePubsubMessageSchema.array()
     })
     .strict();
-export const ChallengeMessageSignedPropertyNames = remeda.keys.strict(remeda.omit(ChallengeMessageSchema.shape, ["signature"]));
+export const ChallengeMessageSignedPropertyNames = keys(omit(ChallengeMessageSchema.shape, ["signature"]));
 
 // Challenge answer
 
@@ -109,7 +107,7 @@ export const DecryptedChallengeAnswerSchema = z
     })
     .strict();
 
-export const ChallengeAnswerMessageSignedPropertyNames = remeda.keys.strict(remeda.omit(ChallengeAnswerMessageSchema.shape, ["signature"]));
+export const ChallengeAnswerMessageSignedPropertyNames = keys(omit(ChallengeAnswerMessageSchema.shape, ["signature"]));
 
 // Challenge Verification
 
@@ -128,8 +126,6 @@ export const DecryptedChallengeVerificationSchema = z
     })
     .strict();
 
-export const ChallengeVerificationMessageSignedPropertyNames = remeda.keys.strict(
-    remeda.omit(ChallengeVerificationMessageSchema.shape, ["signature"])
-);
+export const ChallengeVerificationMessageSignedPropertyNames = keys(omit(ChallengeVerificationMessageSchema.shape, ["signature"]));
 
 // Handling challenges for community

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -39,7 +39,7 @@ import { PKCError } from "../../pkc-error.js";
 import { LocalCommunity } from "../../runtime/node/community/local-community.js";
 import { RemoteCommunity } from "../../community/remote-community.js";
 import { hideClassPrivateProps, replaceXWithY } from "../../util.js";
-import * as remeda from "remeda";
+import { keys, mapValues, omit } from "remeda";
 import type { IncomingMessage } from "http";
 import type {
     CommentChallengeRequestToEncryptType,
@@ -926,8 +926,8 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
             ...builtInChallenges, // built-ins first
             ...(pkc.settings?.challenges || {}) // user-defined override
         };
-        const challenges = remeda.mapValues(allChallengeFactories, (challengeFactory) =>
-            remeda.omit(challengeFactory({ challengeSettings: {} }), ["getChallenge"])
+        const challenges = mapValues(allChallengeFactories, (challengeFactory) =>
+            omit(challengeFactory({ challengeSettings: {} }), ["getChallenge"])
         );
 
         return <PKCWsServerSettingsSerialized>{ pkcOptions, challenges };
@@ -988,10 +988,10 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
             this._initPKC(newPKC); // swap to new instance first so new RPC calls don't hit a destroyed pkc
 
             // send a settingsNotification to all subscribers
-            for (const connectionId of remeda.keys.strict(this._onSettingsChange)) {
+            for (const connectionId of keys(this._onSettingsChange)) {
                 const connectionHandlers = this._onSettingsChange[connectionId];
                 if (!connectionHandlers) continue;
-                for (const subscriptionId of remeda.keys.strict(connectionHandlers)) {
+                for (const subscriptionId of keys(connectionHandlers)) {
                     const handler = connectionHandlers[subscriptionId];
                     if (!handler) continue;
                     try {
@@ -1238,7 +1238,7 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
     private async _createCommentInstanceFromPublishCommentParams(params: CommentChallengeRequestToEncryptType) {
         const pkc = await this._getPKCInstance();
         const comment = await pkc.createComment(params.comment);
-        comment.challengeRequest = remeda.omit(params, ["comment"]);
+        comment.challengeRequest = omit(params, ["comment"]);
         return comment;
     }
 
@@ -1328,7 +1328,7 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
     private async _createVoteInstanceFromPublishVoteParams(params: VoteChallengeRequestToEncryptType) {
         const pkc = await this._getPKCInstance();
         const vote = await pkc.createVote(params.vote);
-        vote.challengeRequest = remeda.omit(params, ["vote"]);
+        vote.challengeRequest = omit(params, ["vote"]);
         return vote;
     }
     async publishVote(params: any, connectionId: string): Promise<RpcSubscriptionIdResult> {
@@ -1396,7 +1396,7 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
     private async _createCommunityEditInstanceFromPublishCommunityEditParams(params: CommunityEditChallengeRequestToEncryptType) {
         const pkc = await this._getPKCInstance();
         const communityEdit = await pkc.createCommunityEdit(params.communityEdit);
-        communityEdit.challengeRequest = remeda.omit(params, ["communityEdit"]);
+        communityEdit.challengeRequest = omit(params, ["communityEdit"]);
         return communityEdit;
     }
 
@@ -1469,7 +1469,7 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
     private async _createCommentEditInstanceFromPublishCommentEditParams(params: CommentEditChallengeRequestToEncryptType) {
         const pkc = await this._getPKCInstance();
         const commentEdit = await pkc.createCommentEdit(params.commentEdit);
-        commentEdit.challengeRequest = remeda.omit(params, ["commentEdit"]);
+        commentEdit.challengeRequest = omit(params, ["commentEdit"]);
         return commentEdit;
     }
 
@@ -1544,7 +1544,7 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
     private async _createCommentModerationInstanceFromPublishCommentModerationParams(params: CommentModerationChallengeRequestToEncrypt) {
         const pkc = await this._getPKCInstance();
         const commentModeration = await pkc.createCommentModeration(params.commentModeration);
-        commentModeration.challengeRequest = remeda.omit(params, ["commentModeration"]);
+        commentModeration.challengeRequest = omit(params, ["commentModeration"]);
         return commentModeration;
     }
 
@@ -1897,15 +1897,15 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
     }
 
     async destroy() {
-        for (const connectionId of remeda.keys.strict(this.subscriptionCleanups))
-            for (const subscriptionId of remeda.keys.strict(this.subscriptionCleanups[connectionId]))
+        for (const connectionId of keys(this.subscriptionCleanups))
+            for (const subscriptionId of keys(this.subscriptionCleanups[connectionId]))
                 await this.unsubscribe([{ subscriptionId: Number(subscriptionId) }], connectionId);
 
         this.ws.close();
         if (this._ownsHttpServer && this._httpServer) await new Promise<void>((r) => this._httpServer!.close(() => r()));
         const pkc = await this._getPKCInstance();
         await pkc.destroy(); // this will stop all started communities
-        for (const communityAddress of remeda.keys.strict(this._startedCommunities)) {
+        for (const communityAddress of keys(this._startedCommunities)) {
             delete this._startedCommunities[communityAddress];
         }
         this._exportCommunityInstances.clear();

--- a/src/runtime/browser/localforage-lru.ts
+++ b/src/runtime/browser/localforage-lru.ts
@@ -1,5 +1,5 @@
 import localForage from "localforage";
-import * as remeda from "remeda";
+import { omit } from "remeda";
 
 type ForageOptions = {
     size: number;
@@ -10,7 +10,7 @@ function createLocalForageInstance(localForageLruOptions: ForageOptions) {
     if (typeof localForageLruOptions?.size !== "number") {
         throw Error(`LocalForageLru.createInstance localForageLruOptions.size '${localForageLruOptions?.size}' not a number`);
     }
-    const localForageOptions = remeda.omit(localForageLruOptions, ["size"]);
+    const localForageOptions = omit(localForageLruOptions, ["size"]);
     let database1: LocalForage,
         database2: LocalForage,
         databaseSize: number,

--- a/src/runtime/node/addresses-rewriter-proxy-server.ts
+++ b/src/runtime/node/addresses-rewriter-proxy-server.ts
@@ -2,7 +2,7 @@ import http from "node:http";
 import https from "node:https";
 import path from "node:path";
 import Logger from "../../logger.js";
-import * as remeda from "remeda";
+import { flat, unique } from "remeda";
 import retry from "retry";
 import { PKC } from "../../pkc/pkc.js";
 import { hideClassPrivateProps } from "../../util.js";
@@ -18,7 +18,7 @@ const MAX_BODY_PREVIEW_BYTES = 4096;
 // `/p2p/<peerId>` and dedupe before announcing.
 export function normalizeSelfAddrsForProvider(addrs: string[], peerId: string): string[] {
     const suffix = `/p2p/${peerId}`;
-    return remeda.unique(addrs.map((addr) => (addr.endsWith(suffix) ? addr.slice(0, -suffix.length) : addr)));
+    return unique(addrs.map((addr) => (addr.endsWith(suffix) ? addr.slice(0, -suffix.length) : addr)));
 }
 
 type AddressesRewriterOptions = {
@@ -397,9 +397,7 @@ export class AddressesRewriterProxyServer {
                         const addresses: string[] = normalizeSelfAddrsForProvider(
                             [
                                 ...idRes.addresses.map((addr) => addr.toString()),
-                                ...remeda.flatten(
-                                    swarmListeningAddresses.map((swarmAddr) => swarmAddr.addrs.map((addr) => addr.toString()))
-                                )
+                                ...flat(swarmListeningAddresses.map((swarmAddr) => swarmAddr.addrs.map((addr) => addr.toString())))
                             ],
                             peerId
                         );

--- a/src/runtime/node/community/challenges/index.ts
+++ b/src/runtime/node/community/challenges/index.ts
@@ -27,7 +27,7 @@ import type {
     CommunityChallengeSetting
 } from "../../../../community/types.js";
 import { LocalCommunity } from "../local-community.js";
-import * as remeda from "remeda";
+import { omit } from "remeda";
 import { ChallengeFileFactorySchema, ChallengeFileSchema, CommunityChallengeSettingSchema } from "../../../../community/schema.js";
 import { PKCError } from "../../../../pkc-error.js";
 import { pathToFileURL } from "node:url";
@@ -788,9 +788,7 @@ const getChallengeVerification = async ({
     let challengeVerification: Pick<ChallengeVerificationMessageType, "challengeSuccess" | "challengeErrors"> & ChallengeResultAggregate;
     // was able to verify without asking author for challenges
     if ("pendingChallenges" in res) {
-        const challengeAnswers = await getChallengeAnswers(
-            res.pendingChallenges.map((challenge) => remeda.omit(challenge, ["index", "verify"]))
-        );
+        const challengeAnswers = await getChallengeAnswers(res.pendingChallenges.map((challenge) => omit(challenge, ["index", "verify"])));
         const verificationFromPending = await getChallengeVerificationFromChallengeAnswers({
             pendingChallenges: res.pendingChallenges,
             challengeAnswers,
@@ -802,7 +800,7 @@ const getChallengeVerification = async ({
         });
         if ("pendingApprovalSuccess" in verificationFromPending) {
             pendingApprovalSuccess = pendingApprovalSuccess || verificationFromPending.pendingApprovalSuccess;
-            challengeVerification = remeda.omit(verificationFromPending, ["pendingApprovalSuccess"]);
+            challengeVerification = omit(verificationFromPending, ["pendingApprovalSuccess"]);
         } else {
             pendingApprovalSuccess = false;
             challengeVerification = verificationFromPending;

--- a/src/runtime/node/community/challenges/pkc-js-challenges/publication-match.ts
+++ b/src/runtime/node/community/challenges/pkc-js-challenges/publication-match.ts
@@ -6,7 +6,7 @@ import type {
     CommunityChallengeSetting
 } from "../../../../../community/types.js";
 import { derivePublicationFromChallengeRequest } from "../../../../../util.js";
-import * as remeda from "remeda";
+import { pathOr, stringToPath } from "remeda";
 
 // Define the match object structure
 interface Match {
@@ -91,10 +91,10 @@ const getChallenge = async ({ challengeSettings, challengeRequestMessage }: GetC
     for (const match of matches) {
         const { propertyName, regexp } = match;
 
-        // Get the property value using remeda.pathOr with stringToPath to handle nested properties
-        const pathSegments = remeda.stringToPath(propertyName);
+        // Get the property value using pathOr with stringToPath to handle nested properties
+        const pathSegments = stringToPath(propertyName);
         //@ts-expect-error
-        const value = remeda.pathOr(publication, pathSegments, undefined);
+        const value = pathOr(publication, pathSegments, undefined);
 
         // If property doesn't exist, consider it a failure
         if (value === undefined) {

--- a/src/runtime/node/community/db-handler.ts
+++ b/src/runtime/node/community/db-handler.ts
@@ -29,7 +29,7 @@ import { isDefaultChallengeStructure } from "./local-community/defaults.js";
 import { addAllCidsUnderPurgedCommentToBeRemoved } from "./local-community/cleanup.js";
 import { updateDbInternalState } from "./local-community/db-state.js";
 import { getPKCAddressFromPublicKey, getPKCAddressFromPublicKeySync } from "../../../signer/util.js";
-import * as remeda from "remeda";
+import { clone, entries as remedaEntries, firstBy, isPlainObject, keys, mapToObj, mapValues, omit, pick, sumBy, uniqueBy } from "remeda";
 import type {
     CommentEditPubsubMessagePublication,
     CommentEditSignature,
@@ -447,7 +447,7 @@ export class DbHandler {
 
     _migrateOldSettings(oldSettings: InternalCommunityRecordBeforeFirstUpdateType["settings"]) {
         const fieldsToRemove = ["post", "reply", "vote"] as const;
-        const newSettings = remeda.clone(oldSettings);
+        const newSettings = clone(oldSettings);
         if (Array.isArray(newSettings.challenges)) {
             // Filter out challenges that reference removed built-in names
             newSettings.challenges = newSettings.challenges.filter((cs) => !cs.name || cs.path || cs.name in pkcJsChallenges);
@@ -752,7 +752,7 @@ export class DbHandler {
                     srcRecord["isAuthorEdit"] = parsedSig.publicKey === commentToBeEdited.signature.publicKey;
 
                     const commentEditFieldsNotIncludedAnymore = ["removed"];
-                    const extraProps = removeNullUndefinedValues(remeda.pick(srcRecord, commentEditFieldsNotIncludedAnymore)) as Record<
+                    const extraProps = removeNullUndefinedValues(pick(srcRecord, commentEditFieldsNotIncludedAnymore)) as Record<
                         string,
                         any
                     >;
@@ -765,7 +765,7 @@ export class DbHandler {
                 }
                 if (srcTable === TABLES.COMMENTS) {
                     const commentIpfsFieldsNotIncludedAnymore = ["ipnsName"];
-                    const extraProps = removeNullUndefinedValues(remeda.pick(srcRecord, commentIpfsFieldsNotIncludedAnymore)) as Record<
+                    const extraProps = removeNullUndefinedValues(pick(srcRecord, commentIpfsFieldsNotIncludedAnymore)) as Record<
                         string,
                         any
                     >;
@@ -931,7 +931,7 @@ export class DbHandler {
             }
 
             const commentEditWithExtraProps = this._spreadExtraProps({ ...commentEditRecord });
-            const commentEditPubsub = remeda.pick(commentEditWithExtraProps, [
+            const commentEditPubsub = pick(commentEditWithExtraProps, [
                 ...(commentEditWithExtraProps.signature.signedPropertyNames as CommentEditSignature["signedPropertyNames"]),
                 "signature"
             ]) as CommentEditPubsubMessagePublication;
@@ -1051,7 +1051,7 @@ export class DbHandler {
         `);
 
         // Create default object with null values for all columns
-        const defaults = remeda.mapToObj(columnNames, (column) => [column, null]);
+        const defaults = mapToObj(columnNames, (column) => [column, null]);
 
         const insertMany = this._db.transaction((items: CommentsTableRowInsert[]) => {
             for (const comment of items) {
@@ -1102,7 +1102,7 @@ export class DbHandler {
                 insertedAt = excluded.insertedAt
         `);
 
-        const defaults = remeda.mapToObj(columnNames, (column) => [column, null]);
+        const defaults = mapToObj(columnNames, (column) => [column, null]);
 
         const upsertMany = this._db.transaction((items: CommentUpdatesTableRowInsert[]) => {
             for (const update of items) {
@@ -1130,7 +1130,7 @@ export class DbHandler {
             VALUES (@commentCid, @author, @signature, @modSignerAddress, @protocolVersion, @communityPublicKey, @communityName, @timestamp, @commentModeration, @insertedAt, @extraProps, @targetAuthorSignerAddress, @targetAuthorDomain)
         `);
 
-        const defaults = remeda.mapToObj(columnNames, (column) => [column, null]);
+        const defaults = mapToObj(columnNames, (column) => [column, null]);
         const insertMany = this._db.transaction((items: CommentModerationsTableRowInsert[]) => {
             for (const mod of items) {
                 // Create default object with null values for all columns
@@ -1157,7 +1157,7 @@ export class DbHandler {
             VALUES (@commentCid, @authorSignerAddress, @author, @signature, @protocolVersion, @communityPublicKey, @communityName, @timestamp, @content, @reason, @deleted, @flairs, @spoiler, @nsfw, @isAuthorEdit, @insertedAt, @extraProps)
         `);
 
-        const defaults = remeda.mapToObj(columnNames, (column) => [column, null]);
+        const defaults = mapToObj(columnNames, (column) => [column, null]);
         const insertMany = this._db.transaction((items: CommentEditsTableRowInsert[]) => {
             for (const edit of items) {
                 // Create default object with null values for all columns
@@ -1292,13 +1292,13 @@ export class DbHandler {
     }
 
     queryPageComments(options: Omit<PageOptions, "firstPageSizeBytes">): PageIpfs["comments"] {
-        const commentUpdateCols = remeda.keys.strict(
+        const commentUpdateCols = keys(
             options.commentUpdateFieldsToExclude
-                ? remeda.omit(CommentUpdateSchema.shape, options.commentUpdateFieldsToExclude)
+                ? omit(CommentUpdateSchema.shape, options.commentUpdateFieldsToExclude)
                 : CommentUpdateSchema.shape
         );
         const commentUpdateSelects = commentUpdateCols.map((col) => `${TABLES.COMMENT_UPDATES}.${col} AS commentUpdate_${col}`);
-        const commentIpfsCols = [...remeda.keys.strict(CommentIpfsSchema.shape), "extraProps"];
+        const commentIpfsCols = [...keys(CommentIpfsSchema.shape), "extraProps"];
         const commentIpfsSelects = commentIpfsCols.map((col) => `${TABLES.COMMENTS}.${col} AS commentIpfs_${col}`);
 
         const { whereClauses, params } = this._buildPageQueryParts(options);
@@ -1322,8 +1322,8 @@ export class DbHandler {
         // Recursive case: follow $.best.commentCids from each node's replies JSON.
         // Returns flat rows with tree_parent for JS tree assembly.
 
-        const commentUpdateCols = remeda.keys.strict(CommentUpdateSchema.shape);
-        const commentIpfsCols = [...remeda.keys.strict(CommentIpfsSchema.shape), "extraProps"];
+        const commentUpdateCols = keys(CommentUpdateSchema.shape);
+        const commentIpfsCols = [...keys(CommentIpfsSchema.shape), "extraProps"];
 
         // Base case uses full table names (not aliases) to match _buildPageQueryParts WHERE clauses
         const baseCommentUpdateSelects = commentUpdateCols.map((col) => `${TABLES.COMMENT_UPDATES}.${col} AS commentUpdate_${col}`);
@@ -1450,8 +1450,8 @@ export class DbHandler {
     resolveRepliesCidRefsForEntries(entries: PageIpfs["comments"]): PageIpfs["comments"] {
         // For entries whose replies are in CID-ref format, resolve them by fetching descendants.
         // Collects all root CIDs from all entries, runs a single recursive query, then distributes results.
-        const commentUpdateCols = remeda.keys.strict(CommentUpdateSchema.shape);
-        const commentIpfsCols = [...remeda.keys.strict(CommentIpfsSchema.shape), "extraProps"];
+        const commentUpdateCols = keys(CommentUpdateSchema.shape);
+        const commentIpfsCols = [...keys(CommentIpfsSchema.shape), "extraProps"];
 
         // Gather all CIDs from CID-ref replies across all entries
         const allCids: string[] = [];
@@ -1627,14 +1627,14 @@ export class DbHandler {
     }
 
     queryFlattenedPageReplies(options: Omit<PageOptions, "firstPageSizeBytes"> & { parentCid: string }): PageIpfs["comments"] {
-        const commentUpdateCols = remeda.keys.strict(
+        const commentUpdateCols = keys(
             options.commentUpdateFieldsToExclude
-                ? remeda.omit(CommentUpdateSchema.shape, options.commentUpdateFieldsToExclude)
+                ? omit(CommentUpdateSchema.shape, options.commentUpdateFieldsToExclude)
                 : CommentUpdateSchema.shape
         );
         // TODO, is it omitting replies?
         const commentUpdateSelects = commentUpdateCols.map((col) => `c_updates.${col} AS commentUpdate_${col}`);
-        const commentIpfsCols = [...remeda.keys.strict(CommentIpfsSchema.shape), "extraProps"];
+        const commentIpfsCols = [...keys(CommentIpfsSchema.shape), "extraProps"];
         const commentIpfsSelects = commentIpfsCols.map((col) => `comments_alias.${col} AS commentIpfs_${col}`);
 
         let baseWhereClausesStr = "";
@@ -2280,9 +2280,9 @@ export class DbHandler {
 
         const signedKeys = parsed.signature.signedPropertyNames as CommentEditSignature["signedPropertyNames"];
 
-        const commentEditFields = remeda.keys.strict(CommentEditPubsubMessagePublicationSchema.shape);
+        const commentEditFields = keys(CommentEditPubsubMessagePublicationSchema.shape);
 
-        return remeda.pick(parsed, ["signature", ...signedKeys, ...commentEditFields]) as CommentEditPubsubMessagePublication;
+        return pick(parsed, ["signature", ...signedKeys, ...commentEditFields]) as CommentEditPubsubMessagePublication;
     }
 
     removeCommentFromPendingApproval(comment: Pick<CommentsTableRow, "cid">): void {
@@ -2492,7 +2492,7 @@ export class DbHandler {
             | undefined;
         if (!flags) return {};
 
-        return remeda.mapValues(removeNullUndefinedValues(flags), Boolean);
+        return mapValues(removeNullUndefinedValues(flags), Boolean);
     }
 
     queryAuthorEditDeleted(cid: string): Pick<CommentEditsTableRow, "deleted"> | undefined {
@@ -2845,11 +2845,11 @@ export class DbHandler {
 
         const authorPosts = authorCommentsData.filter((c) => c.depth === 0);
         const authorReplies = authorCommentsData.filter((c) => c.depth > 0);
-        const postScore = remeda.sumBy(authorPosts, (p) => p.upvoteCount) - remeda.sumBy(authorPosts, (p) => p.downvoteCount);
-        const replyScore = remeda.sumBy(authorReplies, (r) => r.upvoteCount) - remeda.sumBy(authorReplies, (r) => r.downvoteCount);
-        const lastCommentCid = remeda.maxBy(authorCommentsData, (c) => c.rowid)?.cid;
+        const postScore = sumBy(authorPosts, (p) => p.upvoteCount) - sumBy(authorPosts, (p) => p.downvoteCount);
+        const replyScore = sumBy(authorReplies, (r) => r.upvoteCount) - sumBy(authorReplies, (r) => r.downvoteCount);
+        const lastCommentCid = firstBy(authorCommentsData, [(c) => c.rowid, "desc"])?.cid;
         if (!lastCommentCid) throw Error("Failed to query communityAuthor.lastCommentCid");
-        const firstCommentTimestamp = remeda.minBy(authorCommentsData, (c) => c.rowid)?.timestamp;
+        const firstCommentTimestamp = firstBy(authorCommentsData, (c) => c.rowid)?.timestamp;
         if (typeof firstCommentTimestamp !== "number") throw Error("Failed to query communityAuthor.firstCommentTimestamp");
         return { postScore, replyScore, lastCommentCid, ...modAuthorEdits, firstCommentTimestamp };
     }
@@ -3007,7 +3007,7 @@ export class DbHandler {
             }
 
             if (!isNestedCall) this.commitTransaction();
-            const uniquePurgedRecords = remeda.uniqueBy(purgedRecords, (record) => record.commentTableRow.cid);
+            const uniquePurgedRecords = uniqueBy(purgedRecords, (record) => record.commentTableRow.cid);
             return uniquePurgedRecords;
         } catch (error) {
             log.error(`Error during comment purge for ${cid}: ${error}`);
@@ -3220,13 +3220,13 @@ export class DbHandler {
                 ${activeScoreDescendantWhere}
             ) SELECT post_cid, MAX(timestamp) as active_score FROM descendants GROUP BY post_cid
         `;
-        const commentUpdateCols = remeda.keys.strict(
+        const commentUpdateCols = keys(
             pageOptions.commentUpdateFieldsToExclude
-                ? remeda.omit(CommentUpdateSchema.shape, pageOptions.commentUpdateFieldsToExclude)
+                ? omit(CommentUpdateSchema.shape, pageOptions.commentUpdateFieldsToExclude)
                 : CommentUpdateSchema.shape
         );
         const commentUpdateSelects = commentUpdateCols.map((col) => `cu.${col} AS commentUpdate_${col}`);
-        const commentIpfsCols = [...remeda.keys.strict(CommentIpfsSchema.shape), "extraProps"];
+        const commentIpfsCols = [...keys(CommentIpfsSchema.shape), "extraProps"];
         const commentIpfsSelects = commentIpfsCols.map((col) => `c.${col} AS commentIpfs_${col}`);
 
         let postsQueryStr = `
@@ -3263,8 +3263,8 @@ export class DbHandler {
     private _processRecordsForDbBeforeInsert<T extends Record<string, any>>(records: T[]): T[] {
         return records.map((record) => {
             const processed = { ...record };
-            for (const [key, value] of remeda.entries(processed)) {
-                if (remeda.isPlainObject(value) || Array.isArray(value)) (processed as any)[key] = JSON.stringify(value);
+            for (const [key, value] of remedaEntries(processed)) {
+                if (isPlainObject(value) || Array.isArray(value)) (processed as any)[key] = JSON.stringify(value);
                 else if (typeof value === "boolean") (processed as any)[key] = value ? 1 : 0;
             }
             return processed;

--- a/src/runtime/node/community/local-community.ts
+++ b/src/runtime/node/community/local-community.ts
@@ -31,7 +31,7 @@ import { verifyCommunity } from "../../../signer/signatures.js";
 import { deriveCommentIpfsFromCommentTableRow } from "../util.js";
 import { SignerWithPublicKeyAddress } from "../../../signer/index.js";
 import { RpcLocalCommunity } from "../../../community/rpc-local-community.js";
-import * as remeda from "remeda";
+import { omit, pick } from "remeda";
 import type { CommentsTableRow } from "../../../publications/comment/types.js";
 import { CommunityIpfsSchema } from "../../../community/schema.js";
 import { MAX_FILE_SIZE_BYTES_FOR_COMMUNITY_IPFS } from "../../../community/community-client-manager.js";
@@ -180,9 +180,9 @@ export class LocalCommunity extends RpcLocalCommunity implements CreateNewLocalC
         const rpcJson = this.toJSONInternalRpcAfterFirstUpdate();
         return {
             ...rpcJson.community,
-            ...remeda.omit(rpcJson.localCommunity, ["started", "startedState"]),
+            ...omit(rpcJson.localCommunity, ["started", "startedState"]),
             updateCid: rpcJson.runtimeFields.updateCid,
-            signer: remeda.pick(this.signer, ["privateKey", "type", "address", "shortAddress", "publicKey"]),
+            signer: pick(this.signer, ["privateKey", "type", "address", "shortAddress", "publicKey"]),
             _internalStateUpdateId: this._internalStateUpdateId,
             _cidsToUnPin: [...this._cidsToUnPin],
             _mfsPathsToRemove: [...this._mfsPathsToRemove],
@@ -193,8 +193,8 @@ export class LocalCommunity extends RpcLocalCommunity implements CreateNewLocalC
     toJSONInternalBeforeFirstUpdate(): InternalCommunityRecordBeforeFirstUpdateType {
         const rpcJson = this.toJSONInternalRpcBeforeFirstUpdate();
         return {
-            ...remeda.omit(rpcJson.localCommunity, ["started", "startedState"]),
-            signer: remeda.pick(this.signer, ["privateKey", "type", "address", "shortAddress", "publicKey"]),
+            ...omit(rpcJson.localCommunity, ["started", "startedState"]),
+            signer: pick(this.signer, ["privateKey", "type", "address", "shortAddress", "publicKey"]),
             _internalStateUpdateId: this._internalStateUpdateId,
             _pendingEditProps: this._pendingEditProps
         };
@@ -206,7 +206,7 @@ export class LocalCommunity extends RpcLocalCommunity implements CreateNewLocalC
             ...base,
             localCommunity: {
                 ...base.localCommunity,
-                signer: remeda.pick(this.signer, ["publicKey", "address", "shortAddress", "type"])
+                signer: pick(this.signer, ["publicKey", "address", "shortAddress", "type"])
             }
         };
     }
@@ -216,7 +216,7 @@ export class LocalCommunity extends RpcLocalCommunity implements CreateNewLocalC
         return {
             localCommunity: {
                 ...base.localCommunity,
-                signer: remeda.pick(this.signer, ["publicKey", "address", "shortAddress", "type"])
+                signer: pick(this.signer, ["publicKey", "address", "shortAddress", "type"])
             }
         };
     }

--- a/src/runtime/node/community/local-community/challenges.ts
+++ b/src/runtime/node/community/local-community/challenges.ts
@@ -1,5 +1,5 @@
 import Logger from "../../../../logger.js";
-import * as remeda from "remeda";
+import { clone, keys, omit, pick } from "remeda";
 import * as cborg from "cborg";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
 import { derivePublicationFromChallengeRequest, getErrorCodeFromMessage, timestamp } from "../../../../util.js";
@@ -111,7 +111,7 @@ export async function publishChallenges(
         await community._clientsManager.pubsubPublish(pubsubTopicWithfallback(community), challengeMessage);
     log(
         `Community ${community.address} with pubsub topic ${pubsubTopicWithfallback(community)} published ${challengeMessage.type} over pubsub: `,
-        remeda.pick(toSignChallenge, ["timestamp"]),
+        pick(toSignChallenge, ["timestamp"]),
         toEncryptChallenge.challenges.map((challenge) => challenge.type)
     );
     community._clientsManager.updateKuboRpcPubsubState("waiting-challenge-answers", pubsubClient.url);
@@ -149,7 +149,7 @@ export async function publishFailedChallengeVerification(
     community._clientsManager.updateKuboRpcPubsubState("publishing-challenge-verification", pubsubClient.url);
     log(
         `Will publish ${challengeVerification.type} over pubsub topic ${pubsubTopicWithfallback(community)} on community ${community.address}:`,
-        remeda.omit(toSignVerification, ["challengeRequestId"])
+        omit(toSignVerification, ["challengeRequestId"])
     );
 
     if (!community._challengeExchangesFromLocalPublishers[challengeRequestId.toString()])
@@ -346,7 +346,7 @@ export async function publishChallengeVerification(
         cleanUpChallengeAnswerPromise(community, request.challengeRequestId.toString());
         log.trace(
             `Published ${challengeVerification.type} over pubsub topic ${pubsubTopicWithfallback(community)}:`,
-            remeda.omit(objectToEmit, ["signature", "encrypted", "challengeRequestId"])
+            omit(objectToEmit, ["signature", "encrypted", "challengeRequestId"])
         );
     }
 }
@@ -410,7 +410,7 @@ export function buildRuntimeChallengeRequest({
     authorCommunity?: PublicationWithCommunityAuthorFromDecryptedChallengeRequest["author"]["community"];
 }): DecryptedChallengeRequestMessageTypeWithCommunityAuthor {
     // This function needs to be updated everytime we add a new publication type
-    const runtimeRequest = remeda.clone(request) as DecryptedChallengeRequestMessageTypeWithCommunityAuthor;
+    const runtimeRequest = clone(request) as DecryptedChallengeRequestMessageTypeWithCommunityAuthor;
 
     if (request.comment)
         runtimeRequest.comment = buildRuntimeChallengeRequestPublication({
@@ -460,7 +460,7 @@ async function parseAndValidateChallengeRequest(
 
     const decryptedRequest = await parseChallengeRequestPublicationOrRespondWithFailure(community, request, decryptedRawString);
 
-    const publicationFieldNames = remeda.keys.strict(DecryptedChallengeRequestPublicationSchema.shape);
+    const publicationFieldNames = keys(DecryptedChallengeRequestPublicationSchema.shape);
     let publication: PublicationFromDecryptedChallengeRequest;
     try {
         publication = derivePublicationFromChallengeRequest(decryptedRequest);
@@ -640,7 +640,7 @@ export async function handleChallengeRequest(community: LocalCommunity, request:
     const requestSignatureValidation = await verifyChallengeRequest({ request, validateTimestampRange: true });
     if (!requestSignatureValidation.valid)
         throw new PKCError(getErrorCodeFromMessage(requestSignatureValidation.reason), {
-            challengeRequest: remeda.omit(request, ["encrypted"])
+            challengeRequest: omit(request, ["encrypted"])
         });
 
     const parsed = await parseAndValidateChallengeRequest(community, request, log);

--- a/src/runtime/node/community/local-community/comment-updates.ts
+++ b/src/runtime/node/community/local-community/comment-updates.ts
@@ -1,5 +1,5 @@
 import { stringify as deterministicStringify } from "safe-stable-stringify";
-import * as remeda from "remeda";
+import { groupBy, keys, pick } from "remeda";
 import pLimit from "p-limit";
 import Logger from "../../../../logger.js";
 import { timestamp, writeKuboFilesWithTimeout } from "../../../../util.js";
@@ -89,7 +89,7 @@ export async function calculateNewCommentUpdate(
         else if (generatedRepliesPages.pageCids) {
             commentUpdatePriorToSigning.replies = {
                 pageCids: generatedRepliesPages.pageCids,
-                pages: remeda.pick(generatedRepliesPages.pages, [preloadedRepliesPages])
+                pages: pick(generatedRepliesPages.pages, [preloadedRepliesPages])
             };
         }
     }
@@ -186,7 +186,7 @@ export async function updateCommentsThatNeedToBeUpdated(community: LocalCommunit
     log(`Will update ${commentsToUpdate.length} comments in this update loop for community (${community.address})`);
 
     // Group by postCid
-    const commentsByPostCid = remeda.groupBy.strict(commentsToUpdate, (x) => x.postCid);
+    const commentsByPostCid = groupBy(commentsToUpdate, (x) => x.postCid);
     const allCommentUpdateRows: CommentUpdateToWriteToDbAndPublishToIpfs[] = [];
 
     // Process different post trees in parallel
@@ -196,8 +196,8 @@ export async function updateCommentsThatNeedToBeUpdated(community: LocalCommunit
         postLimit(async () => {
             try {
                 // Group by depth
-                const commentsByDepth = remeda.groupBy.strict(commentsForPost, (x) => x.depth);
-                const depthsKeySorted = remeda.keys.strict(commentsByDepth).sort((a, b) => Number(b) - Number(a)); // Sort depths from highest to lowest
+                const commentsByDepth = groupBy(commentsForPost, (x) => x.depth);
+                const depthsKeySorted = keys(commentsByDepth).sort((a, b) => Number(b) - Number(a)); // Sort depths from highest to lowest
 
                 const postUpdateRows: CommentUpdateToWriteToDbAndPublishToIpfs[] = [];
 

--- a/src/runtime/node/community/local-community/db-state.ts
+++ b/src/runtime/node/community/local-community/db-state.ts
@@ -1,5 +1,5 @@
 import Logger from "../../../../logger.js";
-import * as remeda from "remeda";
+import { clone, isDeepEqual, isEmpty, omit, pick } from "remeda";
 import { v4 as uuidV4 } from "uuid";
 import { ipnsNameToIpnsOverPubsubTopic, pubsubTopicToDhtKey, timestamp } from "../../../../util.js";
 import { PKCError } from "../../../../pkc-error.js";
@@ -79,7 +79,7 @@ export async function updateDbInternalState(
     props: Partial<InternalCommunityRecordBeforeFirstUpdateType | InternalCommunityRecordAfterFirstUpdateType>
 ): Promise<InternalCommunityRecordBeforeFirstUpdateType | InternalCommunityRecordAfterFirstUpdateType> {
     const log = Logger("pkc-js:local-community:_updateDbInternalState");
-    if (remeda.isEmpty(props)) throw Error("props to update DB internal state should not be empty");
+    if (isEmpty(props)) throw Error("props to update DB internal state should not be empty");
     await community._dbHandler.initDbIfNeeded();
 
     props._internalStateUpdateId = uuidV4();
@@ -215,7 +215,7 @@ export async function setChallengesToDefaultIfNotDefined(community: LocalCommuni
             community._defaultCommunityChallenges = generateDefaultChallenges(currentAnswer);
         }
 
-        if (!remeda.isDeepEqual(community.settings?.challenges, community._defaultCommunityChallenges)) {
+        if (!isDeepEqual(community.settings?.challenges, community._defaultCommunityChallenges)) {
             await community.edit({ settings: { ...community.settings, challenges: community._defaultCommunityChallenges } });
             // edit() recalculates _usingDefaultChallenge via _isDefaultChallengeStructure,
             // which may return false for non-standard defaults (e.g. []).
@@ -240,7 +240,7 @@ export async function createNewLocalCommunityDb(community: LocalCommunity) {
     await community._dbHandler.createOrMigrateTablesIfNeeded();
     await initSignerProps(community, community.signer); // init this.encryption as well
 
-    if (!community.pubsubTopic) community.pubsubTopic = remeda.clone(community.signer.address);
+    if (!community.pubsubTopic) community.pubsubTopic = clone(community.signer.address);
     if (typeof community.createdAt !== "number") community.createdAt = timestamp();
     if (!community.protocolVersion) community.protocolVersion = env.PROTOCOL_VERSION;
     if (!community.settings?.maxPendingApprovalCount) community.settings = { ...community.settings, maxPendingApprovalCount: 500 };
@@ -318,9 +318,9 @@ export async function initInternalCommunityAfterFirstUpdateNoMerge(
     }
     const keysOfCommunityIpfs = <(keyof CommunityIpfsType)[]>[...CommunitySignedPropertyNames, "signature"];
     community.initRpcInternalCommunityAfterFirstUpdateNoMerge({
-        community: remeda.pick(newProps, keysOfCommunityIpfs) as CommunityIpfsType,
+        community: pick(newProps, keysOfCommunityIpfs) as CommunityIpfsType,
         localCommunity: {
-            signer: remeda.pick(newProps.signer as SignerWithPublicKeyAddress, ["publicKey", "address", "shortAddress", "type"]),
+            signer: pick(newProps.signer as SignerWithPublicKeyAddress, ["publicKey", "address", "shortAddress", "type"]),
             settings: newProps.settings,
             _usingDefaultChallenge: newProps._usingDefaultChallenge,
             address: newProps.address,
@@ -344,8 +344,8 @@ export async function initInternalCommunityBeforeFirstUpdateNoMerge(
 ) {
     community.initRpcInternalCommunityBeforeFirstUpdateNoMerge({
         localCommunity: {
-            ...remeda.omit(newProps, ["signer", "_internalStateUpdateId", "_pendingEditProps"]),
-            signer: remeda.pick(newProps.signer as SignerWithPublicKeyAddress, ["publicKey", "address", "shortAddress", "type"]),
+            ...omit(newProps, ["signer", "_internalStateUpdateId", "_pendingEditProps"]),
+            signer: pick(newProps.signer as SignerWithPublicKeyAddress, ["publicKey", "address", "shortAddress", "type"]),
             started: community.started,
             startedState: community.startedState
         }

--- a/src/runtime/node/community/local-community/editing.ts
+++ b/src/runtime/node/community/local-community/editing.ts
@@ -1,5 +1,5 @@
 import Logger from "../../../../logger.js";
-import * as remeda from "remeda";
+import { clone, keys, omit, omitBy, pick } from "remeda";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
 import { sha256 } from "js-sha256";
 import { areEquivalentCommunityAddresses, doesDomainAddressHaveCapitalLetter, isStringDomain } from "../../../../util.js";
@@ -58,7 +58,7 @@ export async function parseRolesToEdit(
             if (!resolved) throw new PKCError("ERR_ROLE_ADDRESS_NAME_COULD_NOT_BE_RESOLVED", { roleAddress });
         }
     }
-    return <NonNullable<CommunityIpfsType["roles"]>>remeda.omitBy(newRawRoles, (val, key) => val === undefined || val === null);
+    return <NonNullable<CommunityIpfsType["roles"]>>omitBy(newRawRoles, (val, key) => val === undefined || val === null);
 }
 
 export async function parseChallengesToEdit(
@@ -104,7 +104,7 @@ export async function editPropsOnStartedCommunity(
     // 'community' is the started community with state="started"
     // community._pkc._startedCommunities[community.address] === community
     const log = Logger("pkc-js:local-community:start:editPropsOnStartedCommunity");
-    const oldAddress = remeda.clone(community.address);
+    const oldAddress = clone(community.address);
     if (typeof parsedEditOptions.address === "string" && community.address !== parsedEditOptions.address) {
         await validateNewAddressBeforeEditing(community, parsedEditOptions.address, log);
 
@@ -134,8 +134,8 @@ export async function editPropsOnStartedCommunity(
         });
     community._communityUpdateTrigger = true;
     log(
-        `Community (${community.address}) props (${remeda.keys.strict(parsedEditOptions)}) has been edited. Will be including edited props in next update: `,
-        remeda.pick(community, remeda.keys.strict(parsedEditOptions))
+        `Community (${community.address}) props (${keys(parsedEditOptions)}) has been edited. Will be including edited props in next update: `,
+        pick(community, keys(parsedEditOptions))
     );
     community.emit("update", community);
     if (community.address !== oldAddress) {
@@ -151,7 +151,7 @@ export async function editPropsOnNotStartedCommunity(
 ): Promise<LocalCommunity> {
     // sceneario 3, the community is not running anywhere, we need to edit the db and update this instance
     const log = Logger("pkc-js:local-community:edit:editPropsOnNotStartedCommunity");
-    const oldAddress = remeda.clone(community.address);
+    const oldAddress = clone(community.address);
     await community.initDbHandlerIfNeeded();
     await community._dbHandler.initDbIfNeeded();
     if (typeof parsedEditOptions.address === "string" && community.address !== parsedEditOptions.address) {
@@ -224,7 +224,7 @@ export async function edit(community: LocalCommunity, newCommunityOptions: Commu
     };
 
     const newProps = <ParsedCommunityEditOptions>{
-        ...remeda.omit(editWithDerivedName, ["roles"]), // we omit here to make tsc shut up
+        ...omit(editWithDerivedName, ["roles"]), // we omit here to make tsc shut up
         ...newInternalProps
     };
 

--- a/src/runtime/node/community/local-community/ipns-publishing.ts
+++ b/src/runtime/node/community/local-community/ipns-publishing.ts
@@ -1,5 +1,5 @@
 import Logger from "../../../../logger.js";
-import * as remeda from "remeda";
+import { difference, isEmpty, keys, omit, pick } from "remeda";
 import * as cborg from "cborg";
 import { sha256 } from "js-sha256";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
@@ -36,7 +36,7 @@ export async function calculateNewPostUpdates(community: LocalCommunity): Promis
             if (statRes.blocks !== 0) postUpdates[String(timeBucket)] = String(statRes.cid);
         } catch {}
     }
-    if (remeda.isEmpty(postUpdates)) return undefined;
+    if (isEmpty(postUpdates)) return undefined;
     return postUpdates;
 }
 
@@ -115,7 +115,7 @@ export async function addOldPageCidsToCidsToUnpin(
             pages: newPages,
             clientManager: community._clientsManager
         });
-        const cidsToUnpin = remeda.difference(allPageCidsUnderCurPages, allPageCidsUnderNewPages);
+        const cidsToUnpin = difference(allPageCidsUnderCurPages, allPageCidsUnderNewPages);
         cidsToUnpin.forEach((cid) => {
             community._cidsToUnPin.add(cid);
             if (addToBlockRm) community._blocksToRm.push(cid);
@@ -202,12 +202,12 @@ async function calculateNextCommunityRecord(
     const editIdsToIncludeInNextUpdate = community._pendingEditProps.map((editProps) => editProps.editId);
     const pendingCommunityIpfsEditProps = Object.assign(
         {}, //@ts-expect-error
-        ...community._pendingEditProps.map((editProps) => remeda.pick(editProps, remeda.keys.strict(CommunityIpfsSchema.shape)))
+        ...community._pendingEditProps.map((editProps) => pick(editProps, keys(CommunityIpfsSchema.shape)))
     );
     if (community._pendingEditProps.length > 0) log("Including edit props in next IPNS update", community._pendingEditProps);
     const newIpns: Omit<CommunityIpfsType, "signature"> = {
         ...cleanUpBeforePublishing({
-            ...remeda.omit(community._toJSONIpfsBaseNoPosts(), ["signature"]),
+            ...omit(community._toJSONIpfsBaseNoPosts(), ["signature"]),
             ...pendingCommunityIpfsEditProps,
             lastPostCid: latestPost?.cid,
             lastCommentCid: latestComment?.cid,
@@ -241,7 +241,7 @@ async function calculateNextCommunityRecord(
             // multiple pages
             newIpns.posts = {
                 pageCids: generatedPosts.pageCids,
-                pages: remeda.pick(generatedPosts.pages, [preloadedPostsPages])
+                pages: pick(generatedPosts.pages, [preloadedPostsPages])
             };
         }
     } else {
@@ -354,7 +354,7 @@ async function publishCommunityRecordToIpns(
     if (community._pendingEditProps.length > 0) {
         const remainingEditProps = Object.assign(
             {}, //@ts-expect-error
-            ...community._pendingEditProps.map((editProps) => remeda.pick(editProps, remeda.keys.strict(CommunityIpfsSchema.shape)))
+            ...community._pendingEditProps.map((editProps) => pick(editProps, keys(CommunityIpfsSchema.shape)))
         );
         Object.assign(community, remainingEditProps);
     }

--- a/src/runtime/node/community/local-community/ipns-publishing.ts
+++ b/src/runtime/node/community/local-community/ipns-publishing.ts
@@ -1,5 +1,5 @@
 import Logger from "../../../../logger.js";
-import { difference, isEmpty, keys, omit, pick } from "remeda";
+import { difference, isEmpty, keys, omit, pick, unique } from "remeda";
 import * as cborg from "cborg";
 import { sha256 } from "js-sha256";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
@@ -115,7 +115,10 @@ export async function addOldPageCidsToCidsToUnpin(
             pages: newPages,
             clientManager: community._clientsManager
         });
-        const cidsToUnpin = difference(allPageCidsUnderCurPages, allPageCidsUnderNewPages);
+        // unique() first: remeda v2's difference is multiset, so a cid appearing twice under the
+        // current pages but once under the new pages would otherwise be unpinned despite still being
+        // referenced. Set semantics (v1) is what we want here — only unpin cids absent from newPages.
+        const cidsToUnpin = difference(unique(allPageCidsUnderCurPages), allPageCidsUnderNewPages);
         cidsToUnpin.forEach((cid) => {
             community._cidsToUnPin.add(cid);
             if (addToBlockRm) community._blocksToRm.push(cid);

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -1,5 +1,5 @@
 import Logger from "../../../../logger.js";
-import * as remeda from "remeda";
+import { clone, keys } from "remeda";
 import { LRUCache } from "lru-cache";
 import { PKCError } from "../../../../pkc-error.js";
 import env from "../../../../version.js";
@@ -229,7 +229,7 @@ export async function initMirroringStartedOrUpdatingCommunity(community: LocalCo
     );
     community._mirroredStartedOrUpdatingCommunity.community.on("challenge", community._mirroredStartedOrUpdatingCommunity.challenge);
 
-    const clientKeys = remeda.keys.strict(community.clients);
+    const clientKeys = keys(community.clients);
     for (const clientType of clientKeys)
         if (community.clients[clientType])
             for (const clientUrl of Object.keys(community.clients[clientType]))
@@ -277,7 +277,7 @@ export async function cleanUpMirroredStartedOrUpdatingCommunity(community: Local
         community._mirroredStartedOrUpdatingCommunity.challenge
     );
 
-    const clientKeys = remeda.keys.strict(community.clients);
+    const clientKeys = keys(community.clients);
 
     for (const clientType of clientKeys)
         if (community.clients[clientType])
@@ -310,7 +310,7 @@ export async function updateOnce(community: LocalCommunity) {
         }
         // this community is not started or updated anywhere, but maybe another process will call edit() on it
         trackUpdatingCommunity(community._pkc, community);
-        const oldUpdateId = remeda.clone(community._internalStateUpdateId);
+        const oldUpdateId = clone(community._internalStateUpdateId);
         await updateInstancePropsWithStartedCommunityOrDb(community); // will update this instance props with DB
         if (community._internalStateUpdateId !== oldUpdateId) {
             log(

--- a/src/runtime/node/community/local-community/publication-store.ts
+++ b/src/runtime/node/community/local-community/publication-store.ts
@@ -1,5 +1,5 @@
 import Logger from "../../../../logger.js";
-import * as remeda from "remeda";
+import { clone, difference, keys, pick } from "remeda";
 import { default as lodashDeepMerge } from "lodash.merge";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
 import { calculateIpfsCidV0, isStringDomain, retryKuboIpfsAddAndProvide, timestamp } from "../../../../util.js";
@@ -136,7 +136,7 @@ export async function prepareCommentWithAnonymity(
     const displayName = originalComment.author?.displayName;
     const sanitizedAuthor = cleanWireAuthor(displayName !== undefined ? { displayName } : undefined);
 
-    const anonymizedComment = remeda.clone(originalComment);
+    const anonymizedComment = clone(originalComment);
 
     if (sanitizedAuthor !== undefined) {
         anonymizedComment.author = sanitizedAuthor;
@@ -167,7 +167,7 @@ export async function prepareCommentEditWithAlias(community: LocalCommunity, ori
         privateKey: aliasSignerOfComment.aliasPrivateKey,
         type: "ed25519"
     });
-    const commentEditSignedByAlias = remeda.clone(originalEdit);
+    const commentEditSignedByAlias = clone(originalEdit);
     delete commentEditSignedByAlias.author;
     commentEditSignedByAlias.signature = await signCommentEdit({
         edit: { ...commentEditSignedByAlias, signer: aliasSigner, communityAddress: community.address },
@@ -204,12 +204,12 @@ export async function storeCommentEdit(
         insertedAt: timestamp()
     };
 
-    const extraPropsInEdit = remeda
-        .difference(remeda.keys.strict(commentEditRaw), remeda.keys.strict(CommentEditPubsubMessagePublicationSchema.shape))
-        .filter((key) => (key as string) !== "communityAddress"); // communityAddress is excluded because it's been converted to communityPublicKey/communityName above
+    const extraPropsInEdit = difference(keys(commentEditRaw), keys(CommentEditPubsubMessagePublicationSchema.shape)).filter(
+        (key) => (key as string) !== "communityAddress"
+    ); // communityAddress is excluded because it's been converted to communityPublicKey/communityName above
     if (extraPropsInEdit.length > 0) {
         log("Found extra props on CommentEdit", extraPropsInEdit, "Will be adding them to extraProps column");
-        editTableRow.extraProps = remeda.pick(commentEditRaw, extraPropsInEdit);
+        editTableRow.extraProps = pick(commentEditRaw, extraPropsInEdit);
     }
 
     const isEditDuplicate = community._dbHandler.hasCommentEditWithSignatureEncoded(editTableRow.signature.signature);
@@ -279,12 +279,12 @@ export async function storeCommentModeration(
         throw new PKCError("ERR_DUPLICATE_COMMENT_MODERATION", { modTableRow });
     }
 
-    const extraPropsInMod = remeda
-        .difference(remeda.keys.strict(commentModRaw), remeda.keys.strict(CommentModerationPubsubMessagePublicationSchema.shape))
-        .filter((key) => (key as string) !== "communityAddress"); // communityAddress is excluded because it's been converted to communityPublicKey/communityName above
+    const extraPropsInMod = difference(keys(commentModRaw), keys(CommentModerationPubsubMessagePublicationSchema.shape)).filter(
+        (key) => (key as string) !== "communityAddress"
+    ); // communityAddress is excluded because it's been converted to communityPublicKey/communityName above
     if (extraPropsInMod.length > 0) {
         log("Found extra props on CommentModeration", extraPropsInMod, "Will be adding them to extraProps column");
-        modTableRow.extraProps = remeda.pick(commentModRaw, extraPropsInMod);
+        modTableRow.extraProps = pick(commentModRaw, extraPropsInMod);
     }
 
     if (modTableRow.commentModeration.purged) {
@@ -349,17 +349,14 @@ export async function storeVote(
     const authorSignerAddress = await getPKCAddressFromPublicKey(newVoteProps.signature.publicKey);
     community._dbHandler.deleteVote(authorSignerAddress, newVoteProps.commentCid);
     const voteTableRow = <VotesTableRow>{
-        ...remeda.pick(newVoteProps, ["vote", "commentCid", "protocolVersion", "timestamp"]),
+        ...pick(newVoteProps, ["vote", "commentCid", "protocolVersion", "timestamp"]),
         authorSignerAddress,
         insertedAt: timestamp()
     };
-    const extraPropsInVote = remeda.difference(
-        remeda.keys.strict(newVoteProps),
-        remeda.keys.strict(VotePubsubMessagePublicationSchema.shape)
-    );
+    const extraPropsInVote = difference(keys(newVoteProps), keys(VotePubsubMessagePublicationSchema.shape));
     if (extraPropsInVote.length > 0) {
         log("Found extra props on Vote", extraPropsInVote, "Will be adding them to extraProps column");
-        voteTableRow.extraProps = remeda.pick(newVoteProps, extraPropsInVote);
+        voteTableRow.extraProps = pick(newVoteProps, extraPropsInVote);
     }
 
     community._dbHandler.insertVotes([voteTableRow]);
@@ -386,7 +383,7 @@ export async function storeCommunityEditPublication(
         "Will be using these props to edit the community props"
     );
 
-    const propsAfterEdit = remeda.pick(community, remeda.keys.strict(editProps.communityEdit));
+    const propsAfterEdit = pick(community, keys(editProps.communityEdit));
     log("Current props from community edit (not edited yet)", propsAfterEdit);
     lodashDeepMerge(propsAfterEdit, editProps.communityEdit);
     await community.edit(propsAfterEdit);
@@ -473,13 +470,13 @@ export async function storeComment(
     // challengeAggregate.aggregatedComment extras spread on top of commentPubsub above — must
     // round-trip through extraProps so deriveCommentIpfsFromCommentTableRow can reconstruct the
     // original CID for page generation.
-    const unknownProps = remeda
-        .difference(remeda.keys.strict(commentIpfs), remeda.keys.strict(CommentIpfsSchema.shape))
-        .filter((key) => (key as string) !== "communityAddress"); // communityAddress is excluded because it's been converted to communityPublicKey/communityName above
+    const unknownProps = difference(keys(commentIpfs), keys(CommentIpfsSchema.shape)).filter(
+        (key) => (key as string) !== "communityAddress"
+    ); // communityAddress is excluded because it's been converted to communityPublicKey/communityName above
 
     if (unknownProps.length > 0) {
         log("Found extra props on Comment", unknownProps, "Will be adding them to extraProps column");
-        commentRow.extraProps = remeda.pick(commentIpfs, unknownProps);
+        commentRow.extraProps = pick(commentIpfs, unknownProps);
     }
     if (challengeAggregate?.aggregatedCommentUpdate && Object.keys(challengeAggregate.aggregatedCommentUpdate).length > 0) {
         commentRow.challengeCommentUpdate = challengeAggregate.aggregatedCommentUpdate;

--- a/src/runtime/node/community/local-community/publication-validation.ts
+++ b/src/runtime/node/community/local-community/publication-validation.ts
@@ -1,5 +1,5 @@
 import Logger from "../../../../logger.js";
-import * as remeda from "remeda";
+import { difference, intersection, isDeepEqual, keys } from "remeda";
 import {
     contentContainsMarkdownAudio,
     contentContainsMarkdownImages,
@@ -45,7 +45,7 @@ import type { LocalCommunity } from "../local-community.js";
 import { publishFailedChallengeVerification } from "./challenges.js";
 
 export function isFlairInAllowedList(flair: Flair, allowedFlairs: Flair[]): boolean {
-    return allowedFlairs.some((allowed) => remeda.isDeepEqual(allowed, flair));
+    return allowedFlairs.some((allowed) => isDeepEqual(allowed, flair));
 }
 
 export async function isPublicationAuthorPartOfRoles(
@@ -153,7 +153,7 @@ async function checkAuthorIdentity(
     publication: PublicationFromDecryptedChallengeRequest,
     log: Logger
 ): Promise<messages | undefined> {
-    if (publication.author && remeda.intersection(remeda.keys.strict(publication.author), AuthorReservedFields).length > 0)
+    if (publication.author && intersection(keys(publication.author), AuthorReservedFields).length > 0)
         return messages.ERR_PUBLICATION_AUTHOR_HAS_RESERVED_FIELD;
 
     // Reject publications with non-domain author.name — author.name must be a domain or absent
@@ -263,7 +263,7 @@ async function checkCommentPublication(
 ): Promise<messages | undefined> {
     if (!request.comment) return undefined;
     const commentPublication = request.comment;
-    if (remeda.intersection(remeda.keys.strict(commentPublication), CommentPubsubMessageReservedFields).length > 0)
+    if (intersection(keys(commentPublication), CommentPubsubMessageReservedFields).length > 0)
         return messages.ERR_COMMENT_HAS_RESERVED_FIELD;
     if (
         community.features?.requirePostLink &&
@@ -450,8 +450,7 @@ async function checkVotePublication(
 ): Promise<messages | undefined> {
     if (!request.vote) return undefined;
     const votePublication = request.vote;
-    if (remeda.intersection(VotePubsubReservedFields, remeda.keys.strict(votePublication)).length > 0)
-        return messages.ERR_VOTE_HAS_RESERVED_FIELD;
+    if (intersection(VotePubsubReservedFields, keys(votePublication)).length > 0) return messages.ERR_VOTE_HAS_RESERVED_FIELD;
     if (community.features?.noUpvotes && votePublication.vote === 1) return messages.ERR_NOT_ALLOWED_TO_PUBLISH_UPVOTES;
     if (community.features?.noDownvotes && votePublication.vote === -1) return messages.ERR_NOT_ALLOWED_TO_PUBLISH_DOWNVOTES;
 
@@ -479,7 +478,7 @@ async function checkCommentModerationPublication(
 ): Promise<messages | undefined> {
     if (!request.commentModeration) return undefined;
     const commentModerationPublication = request.commentModeration;
-    if (remeda.intersection(CommentModerationReservedFields, remeda.keys.strict(commentModerationPublication)).length > 0)
+    if (intersection(CommentModerationReservedFields, keys(commentModerationPublication)).length > 0)
         return messages.ERR_COMMENT_MODERATION_HAS_RESERVED_FIELD;
 
     const isAuthorMod = await isPublicationAuthorPartOfRoles(community, commentModerationPublication, ["owner", "moderator", "admin"]);
@@ -506,7 +505,7 @@ async function checkCommunityEditPublication(
 ): Promise<messages | undefined> {
     if (!request.communityEdit) return undefined;
     const communityEdit = request.communityEdit;
-    if (remeda.intersection(CommunityEditPublicationPubsubReservedFields, remeda.keys.strict(communityEdit)).length > 0)
+    if (intersection(CommunityEditPublicationPubsubReservedFields, keys(communityEdit)).length > 0)
         return messages.ERR_COMMUNITY_EDIT_HAS_RESERVED_FIELD;
 
     if (communityEdit.communityEdit.roles || communityEdit.communityEdit.address) {
@@ -519,8 +518,8 @@ async function checkCommunityEditPublication(
         return messages.ERR_COMMUNITY_EDIT_ATTEMPTED_TO_MODIFY_COMMUNITY_WITHOUT_BEING_OWNER_OR_ADMIN;
     }
 
-    const allowedCommunityEditKeys = [...remeda.keys.strict(CommunityIpfsSchema.shape), "address"] as string[];
-    if (remeda.difference(remeda.keys.strict(communityEdit.communityEdit), allowedCommunityEditKeys).length > 0) {
+    const allowedCommunityEditKeys = [...keys(CommunityIpfsSchema.shape), "address"] as string[];
+    if (difference(keys(communityEdit.communityEdit), allowedCommunityEditKeys).length > 0) {
         // should only be allowed to modify public props from CommunityIpfs
         // shouldn't be able to modify settings for example
         return messages.ERR_COMMUNITY_EDIT_ATTEMPTED_TO_NON_PUBLIC_PROPS;
@@ -534,7 +533,7 @@ async function checkCommentEditPublication(
 ): Promise<messages | undefined> {
     if (!request.commentEdit) return undefined;
     const commentEditPublication = request.commentEdit;
-    if (remeda.intersection(CommentEditReservedFields, remeda.keys.strict(commentEditPublication)).length > 0)
+    if (intersection(CommentEditReservedFields, keys(commentEditPublication)).length > 0)
         return messages.ERR_COMMENT_EDIT_HAS_RESERVED_FIELD;
 
     const commentToBeEdited = community._dbHandler.queryComment(commentEditPublication.commentCid); // We assume commentToBeEdited to be defined because we already tested for its existence above

--- a/src/runtime/node/community/local-community/reprovide-on-address-change.ts
+++ b/src/runtime/node/community/local-community/reprovide-on-address-change.ts
@@ -1,5 +1,5 @@
 import Logger from "../../../../logger.js";
-import * as remeda from "remeda";
+import { flat, isDeepEqual, unique } from "remeda";
 import { CID } from "multiformats/cid";
 import { normalizeSelfAddrsForProvider } from "../../addresses-rewriter-proxy-server.js";
 
@@ -46,12 +46,12 @@ export async function getBrowserDialableSelfAddrs(client: ReprovideKuboRpcClient
     const normalized = normalizeSelfAddrsForProvider(
         [
             ...idRes.addresses.map((addr) => addr.toString()),
-            ...remeda.flatten(swarmListeningAddresses.map((swarmAddr) => swarmAddr.addrs.map((addr) => addr.toString())))
+            ...flat(swarmListeningAddresses.map((swarmAddr) => swarmAddr.addrs.map((addr) => addr.toString())))
         ],
         peerId
     );
 
-    return remeda.unique(normalized.filter(isBrowserDialableAddr)).sort();
+    return unique(normalized.filter(isBrowserDialableAddr)).sort();
 }
 
 // The CIDs a browser needs a fresh provider record for in order to bootstrap a connection to the community:
@@ -60,7 +60,7 @@ export async function getBrowserDialableSelfAddrs(client: ReprovideKuboRpcClient
 // when the node's addresses rotate. updateCid is intentionally excluded: it rotates every <=15 min and is
 // re-provided with fresh addresses on every publish, so it is already self-healing.
 function connectionCriticalCids(community: AddressChangeReprovidable): string[] {
-    return remeda.unique(
+    return unique(
         [community.pubsubTopicRoutingCid, community.ipnsPubsubTopicRoutingCid].filter((cid): cid is string => typeof cid === "string")
     );
 }
@@ -87,7 +87,7 @@ export async function reprovideConnectionCidsIfBrowserAddrsChanged(
         return { reprovided: false, providedCids: [], browserAddrs: current };
     }
 
-    if (remeda.isDeepEqual(previous, current)) return { reprovided: false, providedCids: [], browserAddrs: current };
+    if (isDeepEqual(previous, current)) return { reprovided: false, providedCids: [], browserAddrs: current };
 
     // Record the snapshot before providing so a slow/failing provide doesn't make us re-announce every tick.
     community._lastProvidedBrowserDialableSelfAddrs = current;

--- a/src/runtime/node/community/page-generator.ts
+++ b/src/runtime/node/community/page-generator.ts
@@ -13,7 +13,7 @@ import type {
     ReplySortName,
     SortProps
 } from "../../../pages/types.js";
-import * as remeda from "remeda";
+import { keys, omit } from "remeda";
 import type { CommentsTableRow, CommentUpdateType } from "../../../publications/comment/types.js";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
 import env from "../../../version.js";
@@ -326,7 +326,7 @@ export class PageGenerator {
             unpinnedComments = unpinnedComments.filter((obj) => obj.comment.timestamp >= timestampLower);
         }
 
-        const commentsSorted = pinnedComments.concat(unpinnedComments).map((comment) => remeda.omit(comment, ["activeScore"]));
+        const commentsSorted = pinnedComments.concat(unpinnedComments).map((comment) => omit(comment, ["activeScore"]));
 
         if (commentsSorted.length === 0) return [];
 
@@ -409,7 +409,7 @@ export class PageGenerator {
 
         sortResults.push(await this.addPreloadedCommentChunksToIpfs(preloadedChunk, preloadedPageSortName));
 
-        const nonPreloadedSorts = remeda.keys.strict(POSTS_SORT_TYPES).filter((sortName) => sortName !== preloadedPageSortName);
+        const nonPreloadedSorts = keys(POSTS_SORT_TYPES).filter((sortName) => sortName !== preloadedPageSortName);
         await Promise.all(
             nonPreloadedSorts.map(async (sortName) => {
                 sortResults.push(
@@ -510,7 +510,7 @@ export class PageGenerator {
             sortResults.push(await this.addPreloadedCommentChunksToIpfs(preloadedChunk, preloadedReplyPageSortName));
         }
 
-        const nonPreloadedSorts = remeda.keys.strict(POST_REPLIES_SORT_TYPES).filter((sortName) => sortName !== preloadedReplyPageSortName);
+        const nonPreloadedSorts = keys(POST_REPLIES_SORT_TYPES).filter((sortName) => sortName !== preloadedReplyPageSortName);
 
         const flattenedReplies = this._community._dbHandler.queryFlattenedPageReplies({
             ...pageOptions,
@@ -561,9 +561,7 @@ export class PageGenerator {
         if (!disablePreload && preloadedChunk.length === 1)
             return { singlePreloadedPage: { [preloadedReplyPageSortName]: { comments: preloadedChunk[0] } } }; // all comments fit in one page
 
-        const nonPreloadedSorts = remeda.keys
-            .strict(REPLY_REPLIES_SORT_TYPES)
-            .filter((sortName) => sortName !== preloadedReplyPageSortName);
+        const nonPreloadedSorts = keys(REPLY_REPLIES_SORT_TYPES).filter((sortName) => sortName !== preloadedReplyPageSortName);
 
         const sortResults: (PageGenerationRes | undefined)[] = [];
 

--- a/src/runtime/node/setup-kubo-address-rewriter-and-http-router.ts
+++ b/src/runtime/node/setup-kubo-address-rewriter-and-http-router.ts
@@ -3,7 +3,7 @@ import retry, { RetryOperation } from "retry";
 import { AddressesRewriterProxyServer } from "./addresses-rewriter-proxy-server.js";
 import Logger from "../../logger.js";
 import { PKCError } from "../../pkc-error.js";
-import * as remeda from "remeda";
+import { isDeepEqual } from "remeda";
 import tcpPortUsed from "tcp-port-used";
 
 type KuboRouterEntry = {
@@ -114,7 +114,7 @@ async function _setHttpRouterOptionsOnKuboNode(kuboClient: PKC["clients"]["kuboR
     const endpointsAfter: string[] = Object.values(mergedRoutingValue.Routers)
         .map((router) => router.Parameters?.Endpoint)
         .filter((endpoint): endpoint is string => endpoint !== undefined);
-    if (!remeda.isDeepEqual(endpointsBefore.sort(), endpointsAfter.sort())) {
+    if (!isDeepEqual(endpointsBefore.sort(), endpointsAfter.sort())) {
         log(
             "Config on kubo node has been changed. PKC-js will send shutdown command to node",
             kuboClient._clientOptions.url,

--- a/src/runtime/node/sqlite-lru-cache.ts
+++ b/src/runtime/node/sqlite-lru-cache.ts
@@ -1,7 +1,7 @@
 import Database from "better-sqlite3";
 import cbor from "cbor";
 import debounce from "debounce";
-import * as remeda from "remeda";
+import { isPlainObject } from "remeda";
 
 export interface SqliteCacheConfiguration {
     /**
@@ -103,7 +103,7 @@ export class SqliteCache<TData = any> {
             now: now()
         });
 
-        if (!remeda.isPlainObject(res) || !("value" in res)) {
+        if (!isPlainObject(res) || !("value" in res)) {
             return undefined;
         }
 

--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -29,7 +29,7 @@ import { stringify as deterministicStringify } from "safe-stable-stringify";
 import { create as CreateKuboRpcClient } from "kubo-rpc-client";
 import Logger from "../../logger.js";
 import retry from "retry";
-import * as remeda from "remeda";
+import { difference, keys, pick } from "remeda";
 import type { CommunityIpfsType } from "../../community/types.js";
 import type {
     CommentIpfsType,
@@ -217,7 +217,7 @@ export async function tryToDeleteCommunitiesThatFailedToBeDeletedBefore(pkc: PKC
                 );
             }
         }
-        const newPersistentDeletedCommunities = remeda.difference(deletedPersistentCommunities, communitiesThatWereDeletedSuccessfully);
+        const newPersistentDeletedCommunities = difference(deletedPersistentCommunities, communitiesThatWereDeletedSuccessfully);
         if (newPersistentDeletedCommunities.length === 0) {
             await pkc._storage.removeItem(STORAGE_KEYS[STORAGE_KEYS.PERSISTENT_DELETED_COMMUNITIES]);
             log("Removed persistent deleted communities from storage because there are none left");
@@ -564,8 +564,8 @@ export function calculateExpectedSignatureSize(
 }
 
 export function deriveCommentIpfsFromCommentTableRow(commentTableRow: CommentsTableRow): CommentIpfsType {
-    const commentIpfs = remeda.pick(commentTableRow, remeda.keys.strict(CommentIpfsSchema.shape)) as CommentIpfsType;
-    const commentPubsub = remeda.pick(
+    const commentIpfs = pick(commentTableRow, keys(CommentIpfsSchema.shape)) as CommentIpfsType;
+    const commentPubsub = pick(
         commentTableRow,
         (commentTableRow.signature as CommentPubsubMessagPublicationSignature).signedPropertyNames
     ) as CommentPubsubMessagePublication;
@@ -710,8 +710,8 @@ export function resolveDbPostsCidRefs(opts: { dbPosts: DbPostsFormat; dbHandler:
     // For preloaded sorts (with commentCids): query those posts from DB and resolve their nested replies.
     // For non-preloaded sorts (allPageCids only): reconstruct pageCids.
     const { dbPosts, dbHandler } = opts;
-    const commentUpdateCols = remeda.keys.strict(CommentUpdateSchema.shape);
-    const commentIpfsCols = [...remeda.keys.strict(CommentIpfsSchema.shape), "extraProps"];
+    const commentUpdateCols = keys(CommentUpdateSchema.shape);
+    const commentIpfsCols = [...keys(CommentIpfsSchema.shape), "extraProps"];
 
     const pages: Record<string, PageIpfs> = {};
     const pageCids: Record<string, string> = {};

--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -29,7 +29,7 @@ import { stringify as deterministicStringify } from "safe-stable-stringify";
 import { create as CreateKuboRpcClient } from "kubo-rpc-client";
 import Logger from "../../logger.js";
 import retry from "retry";
-import { difference, keys, pick } from "remeda";
+import { difference, keys, pick, unique } from "remeda";
 import type { CommunityIpfsType } from "../../community/types.js";
 import type {
     CommentIpfsType,
@@ -217,7 +217,9 @@ export async function tryToDeleteCommunitiesThatFailedToBeDeletedBefore(pkc: PKC
                 );
             }
         }
-        const newPersistentDeletedCommunities = difference(deletedPersistentCommunities, communitiesThatWereDeletedSuccessfully);
+        // unique() first: remeda v2's difference is multiset; guard against a duplicated address
+        // leaving a community wrongly marked deleted-pending. This list is conceptually a set.
+        const newPersistentDeletedCommunities = difference(unique(deletedPersistentCommunities), communitiesThatWereDeletedSuccessfully);
         if (newPersistentDeletedCommunities.length === 0) {
             await pkc._storage.removeItem(STORAGE_KEYS[STORAGE_KEYS.PERSISTENT_DELETED_COMMUNITIES]);
             log("Removed persistent deleted communities from storage because there are none left");

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { CID } from "kubo-rpc-client";
 import { messages } from "../errors.js";
-import * as remeda from "remeda";
+import { difference, keys } from "remeda";
 
 export const nonNegativeIntStringSchema = z
     .string()
@@ -183,10 +183,10 @@ export const AuthorWithOptionalCommentUpdateSchema = AuthorPubsubSchema.extend({
     community: CommunityAuthorSchema.optional() // (added by CommentUpdate) up to date author properties specific to the community it's in
 });
 
-export const AuthorReservedFields = remeda.difference(
-    [...remeda.keys.strict(AuthorWithOptionalCommentUpdateSchema.shape), "address", "publicKey", "shortAddress", "nameResolved"],
-    remeda.keys.strict(AuthorPubsubSchema.shape)
+export const AuthorReservedFields = difference(
+    [...keys(AuthorWithOptionalCommentUpdateSchema.shape), "address", "publicKey", "shortAddress", "nameResolved"],
+    keys(AuthorPubsubSchema.shape)
 );
 
 // Old CommentIpfs records had author.address — exclude it from the CommentIpfs verification check
-export const AuthorCommentIpfsReservedFields = remeda.difference(AuthorReservedFields, ["address"]);
+export const AuthorCommentIpfsReservedFields = difference(AuthorReservedFields, ["address"]);

--- a/src/signer/constants.ts
+++ b/src/signer/constants.ts
@@ -2,6 +2,12 @@
 
 import type { CreatePublicationOptions } from "../types.js";
 
-export const keysToOmitFromSignedPropertyNames = <
-    (keyof Pick<CreatePublicationOptions, "signer" | "challengeRequest" | "communityAddress">)[]
->["signer", "challengeRequest", "communityAddress"];
+// `as const` (a readonly literal tuple) is required so remeda v2's `omit`/`pick` — whose key
+// params are typed `const Keys extends readonly KeysOfUnion<T>[]` — remove exactly these keys at
+// the type level. A plain `(...)[]` array degrades them to optional/leaked keys, which cascades
+// through the `*SignedPropertyNames = keys(omit(shape, ...))` types into the zod `.pick()` schemas.
+export const keysToOmitFromSignedPropertyNames = [
+    "signer",
+    "challengeRequest",
+    "communityAddress"
+] as const satisfies readonly (keyof CreatePublicationOptions)[];

--- a/src/signer/signatures.ts
+++ b/src/signer/signatures.ts
@@ -36,7 +36,7 @@ import assert from "assert";
 import { BaseClientsManager } from "../clients/base-client-manager.js";
 import type { CommunityIpfsType, CommunitySignature } from "../community/types.js";
 import { sha256 } from "js-sha256";
-import * as remeda from "remeda"; // tree-shaking supported!
+import { intersection, isPlainObject, keys, omit, pick } from "remeda"; // tree-shaking supported!
 import type { JsonSignature, PKCRecordToVerify, PubsubMsgToSign, PubsubSignature, SignerType } from "./types.js";
 import type {
     CommentEditOptionsToSign,
@@ -149,7 +149,7 @@ export async function _signJson(
 
     // we assume here that publication already has been cleaned
     //@ts-expect-error
-    const propsToSign = remeda.pick(cleanedPublication, signedPropertyNames);
+    const propsToSign = pick(cleanedPublication, signedPropertyNames);
     let publicationEncoded: ReturnType<(typeof cborg)["encode"]>;
     try {
         publicationEncoded = cborg.encode(propsToSign, cborgEncodeOptions);
@@ -163,7 +163,7 @@ export async function _signJson(
         signature: signatureData,
         publicKey: signer.publicKey,
         type: signer.type,
-        signedPropertyNames: remeda.keys.strict(propsToSign)
+        signedPropertyNames: keys(propsToSign)
     };
 }
 
@@ -182,7 +182,7 @@ export async function _signPubsubMsg({
 
     // we assume here that pubsub msg already has been cleaned
     //@ts-expect-error
-    const propsToSign = remeda.pick(msg, signedPropertyNames);
+    const propsToSign = pick(msg, signedPropertyNames);
     let publicationEncoded;
     try {
         publicationEncoded = cborg.encode(propsToSign, cborgEncodeOptions); // The comment instances get jsoned over the pubsub, so it makes sense that we would json them before signing, to make sure the data is the same before and after getting jsoned
@@ -196,7 +196,7 @@ export async function _signPubsubMsg({
         signature: signatureData,
         publicKey: publicKeyBuffer,
         type: signer.type,
-        signedPropertyNames: remeda.keys.strict(propsToSign)
+        signedPropertyNames: keys(propsToSign)
     };
 }
 
@@ -543,13 +543,15 @@ export async function verifyCommentIpfs(opts: {
         return { valid: false, reason: messages.ERR_COMMENT_IPFS_RECORD_INCLUDES_RESERVED_FIELD };
 
     // Reject CommentIpfs records where author contains reserved fields (e.g. nameResolved)
-    if (opts.comment.author && remeda.intersection(Object.keys(opts.comment.author), AuthorCommentIpfsReservedFields).length > 0)
+    if (opts.comment.author && intersection(Object.keys(opts.comment.author), AuthorCommentIpfsReservedFields).length > 0)
         return { valid: false, reason: messages.ERR_COMMENT_IPFS_AUTHOR_INCLUDES_RESERVED_FIELD };
 
     const keysCasted = <(keyof CommentPubsubMessagePublication)[]>opts.comment.signature.signedPropertyNames;
 
     const validRes = await verifyCommentPubsubMessage({
-        comment: remeda.pick(opts.comment, ["signature", ...keysCasted]),
+        // remeda v2 infers a partial from the spread (non-literal) key array; the runtime object
+        // has exactly the signed fields + signature, so restore the concrete type.
+        comment: pick(opts.comment, ["signature", ...keysCasted]) as CommentPubsubMessagePublication,
         resolveAuthorNames: opts.resolveAuthorNames,
         clientsManager: opts.clientsManager,
         abortSignal: opts.abortSignal
@@ -569,7 +571,7 @@ function _allFieldsOfRecordInSignedPropertyNames(
         | CommentUpdateType
         | CommentUpdateForChallengeVerification
 ): boolean {
-    const fieldsOfRecord = remeda.keys.strict(remeda.omit(record, ["signature"]));
+    const fieldsOfRecord = keys(omit(record, ["signature"]));
     for (const field of fieldsOfRecord) if (!record.signature.signedPropertyNames.includes(field)) return false;
 
     return true;
@@ -610,10 +612,10 @@ export async function verifyCommunity({
     };
 
     if (community.posts?.pages && validatePages)
-        for (const preloadedPageSortName of remeda.keys.strict(community.posts.pages)) {
+        for (const preloadedPageSortName of keys(community.posts.pages)) {
             const pageCid: string | undefined = community.posts.pageCids?.[preloadedPageSortName];
             const preloadedPage = community.posts.pages[preloadedPageSortName];
-            if (!remeda.isPlainObject(preloadedPage)) throw Error("failed to find page ipfs of community to verify");
+            if (!isPlainObject(preloadedPage)) throw Error("failed to find page ipfs of community to verify");
             const pageValidity = await verifyPage({
                 pageCid,
                 page: preloadedPage,
@@ -660,7 +662,7 @@ function _isThereReservedFieldInRecord(
     record: CommentUpdateType | CommunityIpfsType | CommentUpdateForChallengeVerification | CommentIpfsType,
     reservedFields: readonly string[]
 ) {
-    return remeda.intersection(Object.keys(record), reservedFields).length > 0;
+    return intersection(Object.keys(record), reservedFields).length > 0;
 }
 
 export async function verifyCommentUpdate({
@@ -715,7 +717,7 @@ export async function verifyCommentUpdate({
 
     if ("replies" in update && update.replies && validatePages) {
         // Validate update.replies
-        const replyPageKeys = remeda.keys.strict(update.replies.pages);
+        const replyPageKeys = keys(update.replies.pages);
         for (const replySortName of replyPageKeys) {
             const pageCid: string | undefined = update.replies.pageCids?.[replySortName];
             const page = update.replies.pages[replySortName];

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,6 +1,6 @@
 import { PKC } from "./pkc/pkc.js";
 import assert from "assert";
-import * as remeda from "remeda";
+import { keys, sortBy } from "remeda";
 
 type StatTypes = "ipns" | "ipfs" | "pubsub-publish" | "pubsub-subscribe" | "pubsub-unsubscribe";
 export default class Stats {
@@ -64,14 +64,14 @@ export default class Stats {
             type === "ipfs" || type === "ipns"
                 ? "ipfsGateways"
                 : type === "pubsub-publish" || type === "pubsub-subscribe"
-                  ? remeda.keys.strict(this._pkc.clients.pubsubKuboRpcClients).length > 0
+                  ? keys(this._pkc.clients.pubsubKuboRpcClients).length > 0
                       ? "pubsubKuboRpcClients"
-                      : remeda.keys.strict(this._pkc.clients.libp2pJsClients).length > 0
+                      : keys(this._pkc.clients.libp2pJsClients).length > 0
                         ? "libp2pJsClients"
                         : undefined
                   : undefined;
         assert(gatewayType, "Can't find the gateway type to sort");
-        const gateways = remeda.keys.strict(this._pkc.clients[gatewayType]);
+        const gateways = keys(this._pkc.clients[gatewayType]);
 
         const score = async (gatewayUrl: string) => {
             const failureCounts: number = (await this._pkc._storage.getItem(this._getFailuresCountKey(gatewayUrl, type))) || 0;
@@ -81,7 +81,7 @@ export default class Stats {
             return this._gatewayScore(failureCounts, successCounts, successAverageMs);
         };
 
-        const gatewaysSorted = remeda.sortBy.strict(gateways, score);
+        const gatewaysSorted = sortBy(gateways, score);
         return gatewaysSorted;
     }
 }

--- a/src/test/test-util.ts
+++ b/src/test/test-util.ts
@@ -14,7 +14,7 @@ import { v4 as uuidv4 } from "uuid";
 import { createMockPubsubClient } from "./mock-ipfs-client.js";
 import { EventEmitter } from "events";
 import Logger from "../logger.js";
-import * as remeda from "remeda";
+import { clone, flat, isEmpty, keys, mergeDeep, omit, pick } from "remeda";
 import { LocalCommunity } from "../runtime/node/community/local-community.js";
 import { RpcLocalCommunity } from "../community/rpc-local-community.js";
 import { findUpdatingComment, findUpdatingCommunity } from "../pkc/tracked-instance-registry-util.js";
@@ -166,7 +166,7 @@ function generateRandomTimestamp(parentTimestamp?: number): number {
 
     let randomTimestamp: number = -1;
     while (randomTimestamp === -1) {
-        const randomTimeframeIndex = (remeda.keys.strict(TIMEFRAMES_TO_SECONDS).length * Math.random()) << 0;
+        const randomTimeframeIndex = (keys(TIMEFRAMES_TO_SECONDS).length * Math.random()) << 0;
         const tempTimestamp = lowerLimit + Object.values(TIMEFRAMES_TO_SECONDS)[randomTimeframeIndex];
         if (tempTimestamp >= lowerLimit && tempTimestamp <= upperLimit) randomTimestamp = tempTimestamp;
     }
@@ -198,7 +198,7 @@ export async function generateMockPost({
         timestamp: postTimestamp
     };
 
-    const finalPostProps = <CreateCommentOptions>remeda.mergeDeep(baseProps, postProps);
+    const finalPostProps = <CreateCommentOptions>mergeDeep(baseProps, postProps);
     const post = await pkc.createComment(finalPostProps);
 
     return post;
@@ -365,7 +365,7 @@ async function _publishVotes(
     votesPerCommentToPublish: number,
     pkc: PKC
 ) {
-    const votes: Vote[] = remeda.flattenDeep(
+    const votes: Vote[] = flat(
         await Promise.all(comments.map((comment) => _publishVotesOnOneComment(comment, votesPerCommentToPublish, pkc)))
     );
 
@@ -453,7 +453,7 @@ export async function startCommunities(props: {
     startOnlineSub: boolean;
 }): Promise<TestServerSubs> {
     const pkc = await _mockCommunityPKC(props.signers, {
-        ...remeda.pick(props, ["noData", "dataPath"]),
+        ...pick(props, ["noData", "dataPath"]),
         publishInterval: 1000,
         updateInterval: 1000
     });
@@ -625,7 +625,7 @@ export async function mockPKC(pkcOptions?: InputPKCOptions, forceMockPubsub = fa
 
     // TODO should have multiple pubsub providers here to emulate a real browser/mobile environment
     if (!pkcOptions?.pubsubKuboRpcClientsOptions || forceMockPubsub)
-        for (const pubsubUrl of remeda.keys.strict(pkc.clients.pubsubKuboRpcClients)) {
+        for (const pubsubUrl of keys(pkc.clients.pubsubKuboRpcClients)) {
             const mockClient = createMockPubsubClient();
             pkc.clients.pubsubKuboRpcClients[pubsubUrl]._client = mockClient;
             pkc.clients.pubsubKuboRpcClients[pubsubUrl].destroy = mockClient.destroy.bind(mockClient);
@@ -821,7 +821,7 @@ async function _publishWithExpectedResultOnce({
             communityAddress: publication.communityAddress,
             signerAddress: (publication as any).signer?.address,
             commentModeration: (publication as any).commentModeration
-                ? remeda.pick((publication as any).commentModeration, ["approved", "reason", "spoiler", "nsfw", "pinned", "removed"])
+                ? pick((publication as any).commentModeration, ["approved", "reason", "spoiler", "nsfw", "pinned", "removed"])
                 : undefined
         });
 
@@ -832,11 +832,11 @@ async function _publishWithExpectedResultOnce({
             if (verificationMsg.challengeSuccess !== expectedChallengeSuccess) {
                 const msg = `Expected challengeSuccess to be (${expectedChallengeSuccess}) and got (${
                     verificationMsg.challengeSuccess
-                }). Reason (${verificationMsg.reason}): ${JSON.stringify(remeda.omit(verificationMsg, ["encrypted", "signature", "challengeRequestId"]))}`;
+                }). Reason (${verificationMsg.reason}): ${JSON.stringify(omit(verificationMsg, ["encrypted", "signature", "challengeRequestId"]))}`;
                 reject(msg);
             } else if (expectedReason && expectedReason !== verificationMsg.reason) {
                 const msg = `Expected reason to be (${expectedReason}) and got (${verificationMsg.reason}): ${JSON.stringify(
-                    remeda.omit(verificationMsg, ["encrypted", "signature", "challengeRequestId"])
+                    omit(verificationMsg, ["encrypted", "signature", "challengeRequestId"])
                 )}`;
                 reject(msg);
             } else resolve(1);
@@ -906,7 +906,7 @@ export async function publishWithExpectedResult({
 export async function iterateThroughPageCidToFindComment(commentCid: string, pageCid: string, pages: PostsPages | RepliesPages) {
     if (!commentCid) throw Error("Can't find comment with undefined commentCid");
     if (!pageCid) throw Error("Can't find comment with undefined pageCid");
-    let currentPageCid: string | undefined = remeda.clone(pageCid);
+    let currentPageCid: string | undefined = clone(pageCid);
     while (currentPageCid) {
         const loadedPage = (await pages.getPage({ cid: currentPageCid })) as PageTypeJson;
         const commentInPage = loadedPage.comments.find((c) => c.cid === commentCid);
@@ -1126,7 +1126,7 @@ export async function overrideCommentInstancePropsAndSign(comment: Comment, prop
     // modify the unsigned options so publish() will sign with the overridden props
     const unsignedOpts = (comment.raw as { unsignedPublicationOptions?: CreateCommentOptions }).unsignedPublicationOptions;
     if (!comment.raw.pubsubMessageToPublish && unsignedOpts) {
-        for (const optionKey of remeda.keys.strict(props)) {
+        for (const optionKey of keys(props)) {
             //@ts-expect-error
             comment[optionKey] = unsignedOpts[optionKey] = props[optionKey];
         }
@@ -1134,9 +1134,9 @@ export async function overrideCommentInstancePropsAndSign(comment: Comment, prop
         return;
     }
 
-    const pubsubPublication = remeda.clone(comment.raw.pubsubMessageToPublish!);
+    const pubsubPublication = clone(comment.raw.pubsubMessageToPublish!);
 
-    for (const optionKey of remeda.keys.strict(props)) {
+    for (const optionKey of keys(props)) {
         //@ts-expect-error
         comment[optionKey] = pubsubPublication[optionKey] = props[optionKey];
     }
@@ -1206,7 +1206,7 @@ export async function setExtraPropOnCommentAndSign(comment: Comment, extraProps:
     const publicationWithExtraProp = { ...comment.raw.pubsubMessageToPublish!, ...extraProps };
     if (includeExtraPropInSignedPropertyNames)
         publicationWithExtraProp.signature = await _signJson(
-            [...comment.signature.signedPropertyNames, ...remeda.keys.strict(extraProps)],
+            [...comment.signature.signedPropertyNames, ...keys(extraProps)],
             cleanUpBeforePublishing(publicationWithExtraProp),
             comment.signer!,
             log
@@ -1299,7 +1299,7 @@ export async function setExtraPropOnCommentModerationAndSign(
     }
 
     const newPubsubPublicationWithExtraProp = <CommentModerationPubsubMessagePublication>(
-        remeda.mergeDeep(commentModeration.raw.pubsubMessageToPublish!, extraProps)
+        mergeDeep(commentModeration.raw.pubsubMessageToPublish!, extraProps)
     );
     if (includeExtraPropInSignedPropertyNames)
         newPubsubPublicationWithExtraProp.signature = await _signJson(
@@ -1369,7 +1369,7 @@ export async function publishChallengeAnswerMessageWithExtraProps({
         protocolVersion: env.PROTOCOL_VERSION,
         timestamp: timestamp()
     });
-    const signedPropertyNames = remeda.keys.strict(toSignAnswer);
+    const signedPropertyNames = keys(toSignAnswer);
     //@ts-expect-error
     if (includeExtraPropsInChallengeSignedPropertyNames) signedPropertyNames.push(...Object.keys(extraProps));
 
@@ -1407,7 +1407,7 @@ export async function publishChallengeMessageWithExtraProps({
         protocolVersion: env.PROTOCOL_VERSION,
         timestamp: timestamp()
     });
-    const signedPropertyNames = remeda.keys.strict(toSignChallenge);
+    const signedPropertyNames = keys(toSignChallenge);
     //@ts-expect-error
     if (includeExtraPropsInChallengeSignedPropertyNames) signedPropertyNames.push(...Object.keys(extraProps));
 
@@ -1445,7 +1445,7 @@ export async function publishChallengeVerificationMessageWithExtraProps({
         protocolVersion: env.PROTOCOL_VERSION,
         timestamp: timestamp()
     });
-    const signedPropertyNames = remeda.keys.strict(toSignChallengeVerification);
+    const signedPropertyNames = keys(toSignChallengeVerification);
     //@ts-expect-error
     if (includeExtraPropsInChallengeSignedPropertyNames) signedPropertyNames.push(...Object.keys(extraProps));
 
@@ -1625,9 +1625,9 @@ export function getAvailablePKCConfigsToTestAgainst(opts?: {
             ? ["remote-kubo-rpc", "remote-libp2pjs", "remote-ipfs-gateway"]
             : ["local-kubo-rpc", "remote-kubo-rpc", "remote-libp2pjs", "remote-ipfs-gateway"];
         if (!isBrowser && isRpcFlagOn()) pkcConfigCodes.push("remote-pkc-rpc");
-        const availableConfigs = remeda.pick(testConfigCodeToPKCInstanceWithHumanName, pkcConfigCodes);
+        const availableConfigs = pick(testConfigCodeToPKCInstanceWithHumanName, pkcConfigCodes);
         if (opts.includeOnlyTheseTests?.length) {
-            return Object.values(remeda.pick(availableConfigs, opts.includeOnlyTheseTests));
+            return Object.values(pick(availableConfigs, opts.includeOnlyTheseTests));
         }
         return Object.values(availableConfigs);
     }
@@ -1653,13 +1653,11 @@ export function getAvailablePKCConfigsToTestAgainst(opts?: {
                     `Config "${config}" does not exist in the mapper. Available configs are: ${pkcConfigs.map((c) => c.name).join(", ")}`
                 );
         });
-        const filteredKeys = remeda.keys
-            .strict(testConfigCodeToPKCInstanceWithHumanName)
-            .filter(
-                (config) =>
-                    opts.includeOnlyTheseTests!.includes(config) &&
-                    pkcConfigs.find((c) => c.name === testConfigCodeToPKCInstanceWithHumanName[config].name)
-            );
+        const filteredKeys = keys(testConfigCodeToPKCInstanceWithHumanName).filter(
+            (config) =>
+                opts.includeOnlyTheseTests!.includes(config) &&
+                pkcConfigs.find((c) => c.name === testConfigCodeToPKCInstanceWithHumanName[config].name)
+        );
         const configs = filteredKeys.map((config) => testConfigCodeToPKCInstanceWithHumanName[config]);
         return configs;
     }
@@ -1954,34 +1952,24 @@ export function jsonifyCommunityAndRemoveInternalProps(community: RemoteCommunit
     // rather than resolves) and a not-yet-resolved instance legitimately have none. It is a runtime
     // resolution artifact (a CommunityIpfs reserved field, like nameResolved), so strip it before
     // comparing community content/identity. See docs/protocol/delegated-ipns.md.
-    return remeda.omit(jsonfied, [
-        "ipnsHops",
-        "startedState",
-        "started",
-        "signer",
-        "settings",
-        "editable",
-        "clients",
-        "updatingState",
-        "state"
-    ]);
+    return omit(jsonfied, ["ipnsHops", "startedState", "started", "signer", "settings", "editable", "clients", "updatingState", "state"]);
 }
 
 export function jsonifyLocalCommunityWithNoInternalProps(community: LocalCommunity) {
     const localJson = <LocalCommunityJson>JSON.parse(JSON.stringify(community));
     //@ts-expect-error
     delete localJson["posts"]["clients"];
-    return remeda.omit(localJson, ["startedState", "started", "clients", "state", "updatingState"]);
+    return omit(localJson, ["startedState", "started", "clients", "state", "updatingState"]);
 }
 
 export function jsonifyCommentAndRemoveInstanceProps(comment: Comment) {
     const jsonfied = cleanUpBeforePublishing(JSON.parse(JSON.stringify(comment)));
     if ("replies" in jsonfied) delete jsonfied["replies"]["clients"];
-    if ("replies" in jsonfied && remeda.isEmpty(jsonfied.replies)) delete jsonfied["replies"];
+    if ("replies" in jsonfied && isEmpty(jsonfied.replies)) delete jsonfied["replies"];
     // nameResolved is runtime-only — strip it like jsonifyCommunityAndRemoveInternalProps does
     if (jsonfied.author?.nameResolved !== undefined) delete jsonfied.author.nameResolved;
     _stripNameResolvedFromPages(jsonfied["replies"]);
-    return remeda.omit(jsonfied, ["clients", "state", "updatingState", "state", "publishingState", "raw"]);
+    return omit(jsonfied, ["clients", "state", "updatingState", "state", "publishingState", "raw"]);
 }
 
 export async function waitUntilPKCCommunitiesIncludeCommunityAddress(pkc: PKC, communityAddress: string) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ import type { Multiaddr } from "@multiformats/multiaddr";
 import * as Digest from "multiformats/hashes/digest";
 import { Buffer } from "buffer";
 import { base58btc } from "multiformats/bases/base58";
-import * as remeda from "remeda";
+import { isEmpty, isNonNullish, isPlainObject, keys, mapKeys, omitBy, pickBy } from "remeda";
 import type { KuboRpcClient } from "./types.js";
 import type {
     AddOptions,
@@ -120,14 +120,14 @@ export async function raceAgainstAbort<T>(promise: Promise<T>, signal?: AbortSig
 
 export function replaceXWithY(obj: Record<string, any>, x: any, y: any): any {
     // obj is a JS object
-    if (!remeda.isPlainObject(obj)) return obj;
+    if (!isPlainObject(obj)) return obj;
     const newObj: Record<string, any> = {};
     Object.entries(obj).forEach(([key, value]) => {
         if (obj[key] === x) newObj[key] = y;
         // `typeof`` gives browser transpiling error "Uncaught ReferenceError: exports is not defined"
         // don't know why but it can be fixed by replacing with `instanceof`
         // else if (typeof value === "object" && value !== null) newObj[key] = replaceXWithY(value, x, y);
-        else if (remeda.isPlainObject(value)) newObj[key] = replaceXWithY(value, x, y);
+        else if (isPlainObject(value)) newObj[key] = replaceXWithY(value, x, y);
         else if (Array.isArray(value)) newObj[key] = value.map((iterValue) => replaceXWithY(iterValue, x, y));
         else newObj[key] = value;
     });
@@ -135,37 +135,39 @@ export function replaceXWithY(obj: Record<string, any>, x: any, y: any): any {
 }
 
 export function removeNullUndefinedValues<T extends Object>(obj: T): T {
-    return remeda.pickBy(obj, remeda.isNonNullish) as T;
+    // remeda v2 types pickBy's result as EnumeratedPartialNarrowed<T, ...>, which no longer
+    // overlaps T for a direct cast; go through unknown. Runtime: same object minus null/undefined.
+    return pickBy(obj, isNonNullish) as unknown as T;
 }
 
 function removeUndefinedValues<T extends Object>(obj: T) {
-    return remeda.pickBy(obj, remeda.isDefined.strict);
+    return pickBy(obj, isNonNullish);
 }
 
 function removeNullUndefinedEmptyObjectValues<T extends Object>(obj: T) {
     const firstStep = removeNullUndefinedValues(obj); // remove undefined and null values
-    const secondStep = remeda.omitBy(firstStep, (value) => remeda.isPlainObject(value) && remeda.isEmpty(value)); // remove empty {} values
+    const secondStep = omitBy(firstStep, (value) => isPlainObject(value) && isEmpty(value)); // remove empty {} values
     return secondStep;
 }
 
 // A safe function that you can use that will not modify a JSON by removing null or empty objects
 export function removeUndefinedValuesRecursively<T>(obj: T): T {
     if (Array.isArray(obj)) return <T>obj.map(removeUndefinedValuesRecursively);
-    if (!remeda.isPlainObject(obj)) return obj;
+    if (!isPlainObject(obj)) return obj;
     const cleanedObj: any = removeUndefinedValues(obj);
     for (const [key, value] of Object.entries(cleanedObj))
-        if (remeda.isPlainObject(value) || Array.isArray(value)) cleanedObj[key] = removeUndefinedValuesRecursively(value);
+        if (isPlainObject(value) || Array.isArray(value)) cleanedObj[key] = removeUndefinedValuesRecursively(value);
     return cleanedObj;
 }
 
 export function removeNullUndefinedEmptyObjectsValuesRecursively<T>(obj: T): T {
     if (Array.isArray(obj)) return <T>obj.map(removeNullUndefinedEmptyObjectsValuesRecursively);
-    if (!remeda.isPlainObject(obj)) return obj;
+    if (!isPlainObject(obj)) return obj;
     const cleanedObj: any = removeNullUndefinedEmptyObjectValues(obj);
     for (const key of Object.keys(cleanedObj)) {
-        if (remeda.isPlainObject(cleanedObj[key]) || Array.isArray(cleanedObj[key]))
+        if (isPlainObject(cleanedObj[key]) || Array.isArray(cleanedObj[key]))
             cleanedObj[key] = removeNullUndefinedEmptyObjectsValuesRecursively(cleanedObj[key]);
-        if (remeda.isPlainObject(cleanedObj[key]) && remeda.isEmpty(cleanedObj[key])) delete cleanedObj[key];
+        if (isPlainObject(cleanedObj[key]) && isEmpty(cleanedObj[key])) delete cleanedObj[key];
     }
 
     return cleanedObj;
@@ -186,7 +188,7 @@ export const parseDbResponses = (obj: any): any => {
     if (obj === "[object Object]") throw Error(`Object shouldn't be [object Object]`);
     if (Array.isArray(obj)) return obj.map((o) => parseDbResponses(o));
     const parsedJsonString = parseIfJsonString(obj);
-    if (!remeda.isPlainObject(obj) && !parsedJsonString) return obj;
+    if (!isPlainObject(obj) && !parsedJsonString) return obj;
 
     const newObj = removeNullUndefinedValues(parsedJsonString || obj); // we may need clone here, not sure
     const booleanFields = [
@@ -223,7 +225,7 @@ export const parseDbResponses = (obj: any): any => {
     if (newObj.extraProps) return { ...newObj, ...newObj.extraProps };
     else if (newObj["commentIpfs_extraProps"]) {
         // needed when creating pages
-        const mappedExtraPropsOnCommentIpfs = remeda.mapKeys(newObj["commentIpfs_extraProps"], (key) => `commentIpfs_${String(key)}`);
+        const mappedExtraPropsOnCommentIpfs = mapKeys(newObj["commentIpfs_extraProps"], (key) => `commentIpfs_${String(key)}`);
         return { ...newObj, ...mappedExtraPropsOnCommentIpfs };
     }
 
@@ -254,7 +256,7 @@ export function firstResolve<T>(promises: Promise<T>[]) {
 }
 
 export function getErrorCodeFromMessage(message: string): keyof typeof messages {
-    const codes = remeda.keys.strict(messages);
+    const codes = keys(messages);
     for (const code of codes) if (messages[code] === message) return code;
     throw Error(`No error code was found for message (${message})`);
 }
@@ -268,8 +270,7 @@ export function getPostUpdateTimestampRange(postUpdates: CommunityIpfsType["post
     if (!postUpdates) throw Error("community has no post updates");
     if (!postTimestamp) throw Error("post has no timestamp");
     return (
-        remeda.keys
-            .strict(postUpdates)
+        keys(postUpdates)
             // sort from smallest to biggest
             .sort((a, b) => Number(a) - Number(b))
             // find the smallest timestamp range where comment.timestamp is newer
@@ -560,7 +561,7 @@ export function derivePublicationFromChallengeRequest<
 ): T extends DecryptedChallengeRequestMessageTypeWithCommunityAuthor
     ? PublicationWithCommunityAuthorFromDecryptedChallengeRequest
     : PublicationFromDecryptedChallengeRequest {
-    const publicationFieldNames = remeda.keys.strict(DecryptedChallengeRequestPublicationSchema.shape) as (keyof T)[];
+    const publicationFieldNames = keys(DecryptedChallengeRequestPublicationSchema.shape) as (keyof T)[];
     for (const pubName of publicationFieldNames) {
         const publication = request[pubName];
         if (publication)

--- a/test/challenges/challenges.test.ts
+++ b/test/challenges/challenges.test.ts
@@ -10,7 +10,7 @@ import {
 import type { GetChallengeAnswers } from "../../dist/node/runtime/node/community/challenges/index.js";
 import type { DecryptedChallengeRequestMessageTypeWithCommunityAuthor } from "../../dist/node/pubsub-messages/types.js";
 import type { LocalCommunity } from "../../dist/node/runtime/node/community/local-community.js";
-import * as remeda from "remeda";
+import { isPlainObject } from "remeda";
 import { PKC, communities, authors, communityAuthors, challengeAnswers, challengeCommentCids, results } from "./fixtures/fixtures.ts";
 
 // Type for challenge verification results (union of success, pending, failure)
@@ -24,9 +24,9 @@ const parsePubsubMsgFixture = (json: Record<string, unknown>): Record<string, un
     const isBuffer = (obj: Record<string, unknown>): boolean => Object.keys(obj).every((key) => /\d/.test(key));
     const parsed: Record<string, unknown> = {};
     for (const key of Object.keys(json)) {
-        if (remeda.isPlainObject(json[key]) && isBuffer(json[key] as Record<string, unknown>))
+        if (isPlainObject(json[key]) && isBuffer(json[key] as Record<string, unknown>))
             parsed[key] = Uint8Array.from(Object.values(json[key] as Record<string, number>));
-        else if (remeda.isPlainObject(json[key])) parsed[key] = parsePubsubMsgFixture(json[key] as Record<string, unknown>);
+        else if (isPlainObject(json[key])) parsed[key] = parsePubsubMsgFixture(json[key] as Record<string, unknown>);
         else parsed[key] = json[key];
     }
     return parsed;

--- a/test/challenges/exclude.test.ts
+++ b/test/challenges/exclude.test.ts
@@ -7,7 +7,7 @@ import {
 import { addToRateLimiter } from "../../dist/node/runtime/node/community/challenges/exclude/rate-limiter.js";
 import type { DecryptedChallengeRequestMessageTypeWithCommunityAuthor } from "../../dist/node/pubsub-messages/types.js";
 import type { LocalCommunity } from "../../dist/node/runtime/node/community/local-community.js";
-import * as remeda from "remeda";
+import { clone } from "remeda";
 import { PKC, authors } from "./fixtures/fixtures.ts";
 import validCommentEditFixture from "../fixtures/signatures/commentEdit/valid_comment_edit.json" with { type: "json" };
 import validCommentFixture from "..//fixtures/signatures/comment/commentUpdate/valid_comment_ipfs.json" with { type: "json" };
@@ -362,17 +362,17 @@ describe("shouldExcludePublication", () => {
         // high-karma.bso is a mod
         const modAuthor = { address: "high-karma.bso", displayName: "Mod User" };
 
-        const commentEditOfMod = remeda.clone(validCommentEditFixture);
+        const commentEditOfMod = clone(validCommentEditFixture);
         commentEditOfMod.author = modAuthor;
 
-        const postOfMod = remeda.clone(validCommentFixture);
+        const postOfMod = clone(validCommentFixture);
         postOfMod.author = modAuthor;
 
         const replyOfMod = {
             ...postOfMod,
             parentCid: "Qm..."
         };
-        const voteOfMod = remeda.clone(validVoteFixture);
+        const voteOfMod = clone(validVoteFixture);
         voteOfMod.author = modAuthor;
 
         // Mock community with roles - high-karma.bso is a moderator

--- a/test/challenges/publication-match.test.ts
+++ b/test/challenges/publication-match.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../dist/node/runtime/node/community/challenges/index.js";
 import type { DecryptedChallengeRequestMessageTypeWithCommunityAuthor } from "../../dist/node/pubsub-messages/types.js";
 import type { LocalCommunity } from "../../dist/node/runtime/node/community/local-community.js";
-import * as remeda from "remeda";
+import { omit } from "remeda";
 
 import type { ChallengeVerificationMessageType } from "../../dist/node/pubsub-messages/types.js";
 import type { Challenge } from "../../dist/node/community/types.js";
@@ -63,7 +63,7 @@ describe("publication-match challenge", () => {
                 ...defaultPublication,
                 ...(overrides.publication || {})
             },
-            ...(remeda.omit(overrides, ["publication"]) || {})
+            ...(omit(overrides, ["publication"]) || {})
         };
     };
 

--- a/test/challenges/voucher.test.ts
+++ b/test/challenges/voucher.test.ts
@@ -4,7 +4,7 @@ import type { DecryptedChallengeRequestMessageTypeWithCommunityAuthor } from "..
 import type { LocalCommunity } from "../../dist/node/runtime/node/community/local-community.js";
 import type { ChallengeVerificationMessageType } from "../../dist/node/pubsub-messages/types.js";
 import type { Challenge, ChallengeResult } from "../../dist/node/community/types.js";
-import * as remeda from "remeda";
+import { omit } from "remeda";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { tmpdir } from "node:os";
@@ -71,7 +71,7 @@ describe.skip("voucher challenge", () => {
                 ...defaultPublication,
                 ...(overrides.publication || {})
             },
-            ...(remeda.omit(overrides, ["publication"]) || {})
+            ...(omit(overrides, ["publication"]) || {})
         };
     };
 

--- a/test/node-and-browser/community/createcommunity.pkc.test.ts
+++ b/test/node-and-browser/community/createcommunity.pkc.test.ts
@@ -13,7 +13,7 @@ import { describeIfRpc } from "../../helpers/conditional-tests.js";
 
 import { stringify as deterministicStringify } from "safe-stable-stringify";
 
-import * as remeda from "remeda";
+import { clone } from "remeda";
 import validCommunityJsonfiedFixture from "../../fixtures/signatures/community/valid_community_jsonfied.json" with { type: "json" };
 import validCommunityJsonfiedOldWireFormatFixture from "../../fixtures/signatures/community/valid_community_jsonfied_old_wire_format.json" with { type: "json" };
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
@@ -148,7 +148,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) =>
         );
 
         it("createCommunity preserves runtime-only author.nameResolved in preloaded fixture pages", async () => {
-            const communityJson = remeda.clone(validCommunityJsonfiedFixture);
+            const communityJson = clone(validCommunityJsonfiedFixture);
             const sourceComment = communityJson.posts.pages.hot.comments[0];
             const sourceRawComment = (communityJson.raw.subplebbitIpfs || (communityJson.raw as Record<string, any>).communityIpfs).posts
                 .pages.hot.comments[0];
@@ -169,7 +169,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) =>
         });
 
         it("createCommunity preserves runtime-only author.nameResolved in preloaded OLD-wire-format fixture pages", async () => {
-            const communityJson = remeda.clone(validCommunityJsonfiedOldWireFormatFixture);
+            const communityJson = clone(validCommunityJsonfiedOldWireFormatFixture);
             const sourceComment = communityJson.posts.pages.hot.comments[0];
             const sourceRawComment = (communityJson.raw.subplebbitIpfs || (communityJson.raw as Record<string, any>).communityIpfs).posts
                 .pages.hot.comments[0];
@@ -190,8 +190,8 @@ getAvailablePKCConfigsToTestAgainst().map((config) =>
         });
 
         it(`Community JSON props does not change by creating a Community object via pkc.createCommunity`, async () => {
-            const communityJson = remeda.clone(validCommunityJsonfiedFixture);
-            const communityObj = await pkc.createCommunity(remeda.clone(validCommunityJsonfiedFixture));
+            const communityJson = clone(validCommunityJsonfiedFixture);
+            const communityObj = await pkc.createCommunity(clone(validCommunityJsonfiedFixture));
             expect(communityJson.lastPostCid).to.equal(communityObj.lastPostCid).and.to.be.a("string");
             expect(communityJson.pubsubTopic).to.equal(communityObj.pubsubTopic).and.to.be.a("string");
             expect(communityJson.address).to.equal(communityObj.address).and.to.be.a("string");
@@ -217,8 +217,8 @@ getAvailablePKCConfigsToTestAgainst().map((config) =>
         });
 
         it("createCommunity with old-wire-format fixture correctly derives communityAddress in pages", async () => {
-            const communityJson = remeda.clone(validCommunityJsonfiedOldWireFormatFixture);
-            const communityObj = await pkc.createCommunity(remeda.clone(validCommunityJsonfiedOldWireFormatFixture));
+            const communityJson = clone(validCommunityJsonfiedOldWireFormatFixture);
+            const communityObj = await pkc.createCommunity(clone(validCommunityJsonfiedOldWireFormatFixture));
 
             // Top-level fields unaffected by wire format change
             expect(communityJson.lastPostCid).to.equal(communityObj.lastPostCid).and.to.be.a("string");

--- a/test/node-and-browser/community/posts/pages.posts.test.ts
+++ b/test/node-and-browser/community/posts/pages.posts.test.ts
@@ -12,7 +12,7 @@ import {
 import { itSkipIfRpc } from "../../../helpers/conditional-tests.js";
 import { testCommentFieldsInPageJson, testPageCommentsIfSortedCorrectly } from "../../pages/pages-test-util.js";
 import signers from "../../../fixtures/signers.js";
-import * as remeda from "remeda";
+import { clone } from "remeda";
 import { of as calculateIpfsHash } from "typestub-ipfs-only-hash";
 import { Buffer } from "buffer";
 import { messages } from "../../../../dist/node/errors.js";
@@ -132,7 +132,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
         it(`.getPage will throw if the first page is over 1mb`, async () => {
             const community = await pkc.getCommunity({ address: communityAddress });
-            const page = remeda.clone(community.raw.communityIpfs.posts.pages.hot);
+            const page = clone(community.raw.communityIpfs.posts.pages.hot);
 
             // Make sure the page is over 1MB
             // Keep adding comments until the page exceeds 1MB
@@ -170,7 +170,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
                 await publishRandomReply({ parentComment: newPost as CommentIpfsWithCidDefined, pkc: pkc });
                 await waitTillPostInCommunityPages(newPost as Comment & { cid: string }, pkc);
                 community = await pkc.getCommunity({ address: communityAddress });
-                validPageJson = remeda.clone(community.posts.pages.hot); // PageTypeJson, not PageIpfs
+                validPageJson = clone(community.posts.pages.hot); // PageTypeJson, not PageIpfs
             });
 
             afterAll(async () => {
@@ -304,7 +304,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
                 await post.stop();
 
                 // Get a replies page
-                const repliesPage = remeda.clone(post.replies.pages.best);
+                const repliesPage = clone(post.replies.pages.best);
 
                 // This should fail because we're using a replies page with posts.validatePage
                 try {

--- a/test/node-and-browser/community/update.community.test.ts
+++ b/test/node-and-browser/community/update.community.test.ts
@@ -13,7 +13,7 @@ import {
 import { itSkipIfRpc } from "../../helpers/conditional-tests.js";
 import { convertBase58IpnsNameToBase36Cid } from "../../../dist/node/signer/util.js";
 
-import * as remeda from "remeda";
+import { clone } from "remeda";
 import { _signJson } from "../../../dist/node/signer/signatures.js";
 import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 
@@ -99,7 +99,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         it(`community.update() works correctly with community.address as domain`, async () => {
             const community = await pkc.getCommunity({ address: "plebbit.bso" }); // 'plebbit.eth' is part of test-server.js
             expect(community.address).to.equal("plebbit.bso");
-            const oldUpdatedAt = remeda.clone(community.updatedAt);
+            const oldUpdatedAt = clone(community.updatedAt);
             await community.update();
             await publishRandomPost({ communityAddress: community.address, pkc: pkc }); // Invoke an update
             await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => oldUpdatedAt !== community.updatedAt });

--- a/test/node-and-browser/community/wire-format-migration.test.ts
+++ b/test/node-and-browser/community/wire-format-migration.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, afterAll, expect } from "vitest";
 import signers from "../../fixtures/signers.js";
 import { getAvailablePKCConfigsToTestAgainst } from "../../../dist/node/test/test-util.js";
-import * as remeda from "remeda";
+import { clone } from "remeda";
 import validCommunityFixture from "../../fixtures/signatures/community/valid_community_ipfs.json" with { type: "json" };
 import newFormatFixture from "../../fixtures/signatures/community/valid_community_ipfs_new_format.json" with { type: "json" };
 import newFormatWithNameFixture from "../../fixtures/signatures/community/valid_community_ipfs_new_format_with_name.json" with { type: "json" };
@@ -30,14 +30,14 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
         it(`address stays immutable when loading new-format record with name`, async () => {
             const community = await pkc.createCommunity({ address: signers[0].address });
-            community.initCommunityIpfsPropsNoMerge(remeda.clone(newFormatWithNameFixture) as CommunityIpfsType);
+            community.initCommunityIpfsPropsNoMerge(clone(newFormatWithNameFixture) as CommunityIpfsType);
             expect(community.name).to.equal("test-sub.eth");
             expect(community.address).to.equal(signers[0].address); // address is immutable
         });
 
         it(`address falls back to publicKey when no name is present`, async () => {
             const community = await pkc.createCommunity({ address: signers[0].address });
-            community.initCommunityIpfsPropsNoMerge(remeda.clone(newFormatFixture) as CommunityIpfsType);
+            community.initCommunityIpfsPropsNoMerge(clone(newFormatFixture) as CommunityIpfsType);
             // No name, so address should be the IPNS key derived from signature.publicKey
             expect(community.address).to.equal(signers[0].address);
         });
@@ -45,19 +45,19 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         it(`address is computed correctly when loading old-format record with IPNS address`, async () => {
             const community = await pkc.createCommunity({ address: signers[0].address });
             // Old fixture has address = signers[0].address (IPNS key)
-            community.initCommunityIpfsPropsNoMerge(remeda.clone(validCommunityFixture) as CommunityIpfsType);
+            community.initCommunityIpfsPropsNoMerge(clone(validCommunityFixture) as CommunityIpfsType);
             expect(community.address).to.equal(signers[0].address);
         });
 
         it(`publicKey is derived from signature.publicKey`, async () => {
             const community = await pkc.createCommunity({ address: signers[0].address });
-            community.initCommunityIpfsPropsNoMerge(remeda.clone(newFormatFixture) as CommunityIpfsType);
+            community.initCommunityIpfsPropsNoMerge(clone(newFormatFixture) as CommunityIpfsType);
             expect(community.publicKey).to.equal(signers[0].address);
         });
 
         it(`address and publicKey appear in JSON.stringify output`, async () => {
             const community = await pkc.createCommunity({ address: signers[0].address });
-            community.initCommunityIpfsPropsNoMerge(remeda.clone(newFormatFixture) as CommunityIpfsType);
+            community.initCommunityIpfsPropsNoMerge(clone(newFormatFixture) as CommunityIpfsType);
             const json = JSON.parse(JSON.stringify(community));
             expect(json.address).to.be.a("string");
             expect(json.publicKey).to.be.a("string");
@@ -179,7 +179,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
 describe.concurrent("Wire format migration — backward compat parsing", async () => {
     it(`parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails accepts old record with address`, () => {
-        const result = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(remeda.clone(validCommunityFixture) as CommunityIpfsType);
+        const result = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(clone(validCommunityFixture) as CommunityIpfsType);
         // Old record with address should parse successfully
         expect(result).to.have.property("signature");
         // Address is preserved as a passthrough field
@@ -187,15 +187,13 @@ describe.concurrent("Wire format migration — backward compat parsing", async (
     });
 
     it(`parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails accepts new record without address`, () => {
-        const result = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(remeda.clone(newFormatFixture) as CommunityIpfsType);
+        const result = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(clone(newFormatFixture) as CommunityIpfsType);
         expect(result).to.have.property("signature");
         expect((result as Record<string, unknown>).address).to.be.undefined;
     });
 
     it(`parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails accepts new record with name`, () => {
-        const result = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(
-            remeda.clone(newFormatWithNameFixture) as CommunityIpfsType
-        );
+        const result = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(clone(newFormatWithNameFixture) as CommunityIpfsType);
         expect(result).to.have.property("signature");
         expect(result.name).to.equal("test-sub.eth");
     });

--- a/test/node-and-browser/publications/comment-edit/content.edit.test.ts
+++ b/test/node-and-browser/publications/comment-edit/content.edit.test.ts
@@ -7,7 +7,7 @@ import {
     resolveWhenConditionIsTrue
 } from "../../../../dist/node/test/test-util.js";
 import { messages } from "../../../../dist/node/errors.js";
-import * as remeda from "remeda";
+import { clone } from "remeda";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import type { PKC } from "../../../../dist/node/pkc/pkc.js";
 import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
@@ -31,7 +31,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
                 pkc: pkc,
                 postProps: { content: "original content" }
             });
-            originalContent = remeda.clone(commentToBeEdited.content);
+            originalContent = clone(commentToBeEdited.content);
             await commentToBeEdited.update();
         });
 
@@ -215,7 +215,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
                     pkc: pkc,
                     postProps: { signer: roleTest.signer }
                 });
-                const originalContent = remeda.clone(commentToEdit.content);
+                const originalContent = clone(commentToEdit.content);
                 await commentToEdit.update();
                 const editedText = `${roleTest.role} role testing CommentEdit`;
                 const editReason = `For ${roleTest.role} role to test editing a comment`;

--- a/test/node-and-browser/publications/comment-edit/delete.edit.test.ts
+++ b/test/node-and-browser/publications/comment-edit/delete.edit.test.ts
@@ -11,7 +11,7 @@ import {
     iterateThroughPagesToFindCommentInParentPagesInstance
 } from "../../../../dist/node/test/test-util.js";
 import { messages } from "../../../../dist/node/errors.js";
-import * as remeda from "remeda";
+import { sample } from "remeda";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import type { PKC } from "../../../../dist/node/pkc/pkc.js";
 import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
@@ -116,12 +116,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it(`Can't publish vote on deleted post`, async () => {
-            const voteUnderDeletedPost = await generateMockVote(
-                postToDelete as CommentIpfsWithCidDefined,
-                1,
-                pkc,
-                remeda.sample(signers, 1)[0]
-            );
+            const voteUnderDeletedPost = await generateMockVote(postToDelete as CommentIpfsWithCidDefined, 1, pkc, sample(signers, 1)[0]);
             await publishWithExpectedResult({
                 publication: voteUnderDeletedPost,
                 expectedChallengeSuccess: false,
@@ -131,7 +126,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
         it(`Can't publish reply under deleted post`, async () => {
             const replyUnderDeletedPost = await generateMockComment(postToDelete as CommentIpfsWithCidDefined, pkc, false, {
-                signer: remeda.sample(signers, 1)[0]
+                signer: sample(signers, 1)[0]
             });
             await publishWithExpectedResult({
                 publication: replyUnderDeletedPost,
@@ -142,7 +137,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
         it(`Can't publish a reply under a reply of a deleted post`, async () => {
             const reply = await generateMockComment(postReply as CommentIpfsWithCidDefined, pkc, false, {
-                signer: remeda.sample(signers, 1)[0]
+                signer: sample(signers, 1)[0]
             });
             await publishWithExpectedResult({
                 publication: reply,
@@ -152,7 +147,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it(`Can't publish a vote under a reply of a deleted post`, async () => {
-            const vote = await generateMockVote(postReply as CommentIpfsWithCidDefined, 1, pkc, remeda.sample(signers, 1)[0]);
+            const vote = await generateMockVote(postReply as CommentIpfsWithCidDefined, 1, pkc, sample(signers, 1)[0]);
             await publishWithExpectedResult({
                 publication: vote,
                 expectedChallengeSuccess: false,

--- a/test/node-and-browser/publications/comment-moderation/pin.test.ts
+++ b/test/node-and-browser/publications/comment-moderation/pin.test.ts
@@ -11,7 +11,7 @@ import {
     getAvailablePKCConfigsToTestAgainst
 } from "../../../../dist/node/test/test-util.js";
 import { messages } from "../../../../dist/node/errors.js";
-import * as remeda from "remeda";
+import { firstBy, unique } from "remeda";
 import { POSTS_SORT_TYPES } from "../../../../dist/node/pages/util.js";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import type { CommentIpfsWithCidDefined, CommentWithinRepliesPostsPageJson } from "../../../../dist/node/publications/comment/types.js";
@@ -334,7 +334,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             const allPosts = community.posts.pageCids.new
                 ? await loadAllPages(community.posts.pageCids.new, community.posts)
                 : community.posts.pages.hot.comments;
-            post = await pkc.createComment(remeda.maxBy(allPosts, (c) => c.replyCount));
+            post = await pkc.createComment(firstBy(allPosts, [(c) => c.replyCount, "desc"]));
             await post.update();
             await populatePost();
             expect(post.replyCount).to.be.greaterThan(5); // Arbitary number
@@ -375,10 +375,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
             await postToRecreate.stop();
 
-            const postsPagesNames = remeda.unique([
-                ...Object.keys(postToRecreate.replies.pageCids),
-                ...Object.keys(postToRecreate.replies.pages)
-            ]);
+            const postsPagesNames = unique([...Object.keys(postToRecreate.replies.pageCids), ...Object.keys(postToRecreate.replies.pages)]);
             expect(postsPagesNames.length).to.be.greaterThan(0);
 
             for (const pageSortName of postsPagesNames) {

--- a/test/node-and-browser/publications/comment-moderation/purged.test.ts
+++ b/test/node-and-browser/publications/comment-moderation/purged.test.ts
@@ -17,7 +17,7 @@ import { itSkipIfRpc } from "../../../helpers/conditional-tests.js";
 import { messages } from "../../../../dist/node/errors.js";
 import { CID } from "kubo-rpc-client";
 
-import * as remeda from "remeda";
+import { sample, uniqueBy } from "remeda";
 import { findCommentInPageInstanceRecursively } from "../../../../dist/node/pages/util.js";
 import { of as calculateIpfsHash } from "typestub-ipfs-only-hash";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
@@ -174,7 +174,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             }
 
             it(`Sub rejects votes on purged comment with depth ${commentDepth}`, async () => {
-                const vote = await generateMockVote(commentToPurge as CommentIpfsWithCidDefined, 1, pkc, remeda.sample(signers, 1)[0]);
+                const vote = await generateMockVote(commentToPurge as CommentIpfsWithCidDefined, 1, pkc, sample(signers, 1)[0]);
                 await publishWithExpectedResult({
                     publication: vote,
                     expectedChallengeSuccess: false,
@@ -350,7 +350,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
                         }))
                     ];
 
-                    const labeledCids = remeda.uniqueBy(cidEntries, (entry) => entry.cid);
+                    const labeledCids = uniqueBy(cidEntries, (entry) => entry.cid);
                     const labeledCidsV1 = labeledCids.map((entry) => ({
                         label: `${entry.label} (v1)`,
                         cid: CID.parse(entry.cid).toV1().toString()

--- a/test/node-and-browser/publications/comment-moderation/remove.test.ts
+++ b/test/node-and-browser/publications/comment-moderation/remove.test.ts
@@ -11,7 +11,7 @@ import {
     iterateThroughPageCidToFindComment
 } from "../../../../dist/node/test/test-util.js";
 import { messages } from "../../../../dist/node/errors.js";
-import * as remeda from "remeda";
+import { sample } from "remeda";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import type { PKC } from "../../../../dist/node/pkc/pkc.js";
 import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
@@ -91,7 +91,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it(`Sub rejects votes on removed post`, async () => {
-            const vote = await generateMockVote(postToRemove as CommentIpfsWithCidDefined, 1, pkc, remeda.sample(signers, 1)[0]);
+            const vote = await generateMockVote(postToRemove as CommentIpfsWithCidDefined, 1, pkc, sample(signers, 1)[0]);
             await publishWithExpectedResult({
                 publication: vote,
                 expectedChallengeSuccess: false,
@@ -101,7 +101,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
         it(`Sub rejects replies on removed post`, async () => {
             const reply = await generateMockComment(postToRemove as CommentIpfsWithCidDefined, pkc, false, {
-                signer: remeda.sample(signers, 1)[0]
+                signer: sample(signers, 1)[0]
             });
             await publishWithExpectedResult({
                 publication: reply,
@@ -111,7 +111,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it(`Sub rejects votes on a reply of a removed post`, async () => {
-            const vote = await generateMockVote(postReply as CommentIpfsWithCidDefined, 1, pkc, remeda.sample(signers, 1)[0]);
+            const vote = await generateMockVote(postReply as CommentIpfsWithCidDefined, 1, pkc, sample(signers, 1)[0]);
             await publishWithExpectedResult({
                 publication: vote,
                 expectedChallengeSuccess: false,
@@ -121,7 +121,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
         it(`Sub rejects replies on a reply of a removed post`, async () => {
             const reply = await generateMockComment(postReply as CommentIpfsWithCidDefined, pkc, false, {
-                signer: remeda.sample(signers, 1)[0]
+                signer: sample(signers, 1)[0]
             });
             await publishWithExpectedResult({
                 publication: reply,
@@ -312,9 +312,9 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             // We're testing publishing under replyUnderRemovedReply
             const [reply, vote] = [
                 await generateMockComment(replyUnderRemovedReply as CommentIpfsWithCidDefined, pkc, false, {
-                    signer: remeda.sample(signers, 1)[0]
+                    signer: sample(signers, 1)[0]
                 }),
-                await generateMockVote(replyUnderRemovedReply as CommentIpfsWithCidDefined, 1, pkc, remeda.sample(signers, 1)[0])
+                await generateMockVote(replyUnderRemovedReply as CommentIpfsWithCidDefined, 1, pkc, sample(signers, 1)[0])
             ];
             await Promise.all([reply, vote].map((pub) => publishWithExpectedResult({ publication: pub, expectedChallengeSuccess: true })));
         });

--- a/test/node-and-browser/publications/comment/backward.compatibility.commentupdate.test.ts
+++ b/test/node-and-browser/publications/comment/backward.compatibility.commentupdate.test.ts
@@ -13,7 +13,7 @@ import { itSkipIfRpc } from "../../../helpers/conditional-tests.js";
 import { messages } from "../../../../dist/node/errors.js";
 import { _signJson } from "../../../../dist/node/signer/signatures.js";
 import validCommentUpdateFixture from "../../../fixtures/signatures/comment/commentUpdate/valid_comment_update.json" with { type: "json" };
-import * as remeda from "remeda";
+import { clone, keys, omit } from "remeda";
 import { of as calculateIpfsHash } from "typestub-ipfs-only-hash";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import Logger from "@pkcprotocol/pkc-logger";
@@ -54,7 +54,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         itSkipIfRpc(`Loading CommentUpdate whose extra props are not in signedPropertyNames should throw`, async () => {
-            const invalidCommentUpdate = remeda.clone(post.raw.commentUpdate);
+            const invalidCommentUpdate = clone(post.raw.commentUpdate);
             Object.assign(invalidCommentUpdate, extraProps);
 
             const postToUpdate = await pkc.getComment({ cid: post.cid });
@@ -96,7 +96,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             }
         });
         itSkipIfRpc(`Can load CommentUpdate with extra props if they're included in signedPropertyNames`, async () => {
-            const commentUpdateWithExtraProps = remeda.clone(post.raw.commentUpdate);
+            const commentUpdateWithExtraProps = clone(post.raw.commentUpdate);
             Object.assign(commentUpdateWithExtraProps, extraProps);
 
             commentUpdateWithExtraProps.signature = await _signJson(
@@ -130,7 +130,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         itSkipIfRpc(`Can load CommentUpdate with extra props in commentUpdate.author`, async () => {
-            const commentUpdateWithExtraProps = remeda.clone(post.raw.commentUpdate);
+            const commentUpdateWithExtraProps = clone(post.raw.commentUpdate);
             Object.assign(commentUpdateWithExtraProps.author, extraProps);
 
             commentUpdateWithExtraProps.signature = await _signJson(
@@ -284,7 +284,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             Object.assign(commentUpdate, extraProps);
 
             commentUpdate.signature = await _signJson(
-                remeda.keys.strict(remeda.omit(commentUpdate, ["signature"])),
+                keys(omit(commentUpdate, ["signature"])),
                 commentUpdate,
                 subWithNoResponseSigner,
                 log
@@ -321,7 +321,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             Object.assign(commentUpdate.author, extraProps);
 
             commentUpdate.signature = await _signJson(
-                remeda.keys.strict(remeda.omit(commentUpdate, ["signature"])),
+                keys(omit(commentUpdate, ["signature"])),
                 commentUpdate,
                 subWithNoResponseSigner,
                 log

--- a/test/node-and-browser/publications/comment/publish/publish.verification.test.ts
+++ b/test/node-and-browser/publications/comment/publish/publish.verification.test.ts
@@ -12,7 +12,7 @@ import {
     ensurePublicationIsSigned
 } from "../../../../../dist/node/test/test-util.js";
 import { itSkipIfRpc } from "../../../../helpers/conditional-tests.js";
-import * as remeda from "remeda";
+import { sample } from "remeda";
 import { messages } from "../../../../../dist/node/errors.js";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import type { PKCError } from "../../../../../dist/node/pkc-error.js";
@@ -91,7 +91,7 @@ describe.concurrent("Community rejection of incorrect values of fields", async (
         const comment = await pkc.createComment({
             parentCid: "QmV8Q8tWqbLTPYdrvSXHjXgrgWUR1fZ9Ctj56ETPi58FDY", // random cid that's not related to this sub,
             postCid: "QmV8Q8tWqbLTPYdrvSXHjXgrgWUR1fZ9Ctj56ETPi58FDY",
-            signer: remeda.sample(signers, 1)[0],
+            signer: sample(signers, 1)[0],
             content: `Random Content` + Date.now(),
             communityAddress: communityAddress
         });

--- a/test/node-and-browser/publications/comment/stop.comment.test.ts
+++ b/test/node-and-browser/publications/comment/stop.comment.test.ts
@@ -12,8 +12,18 @@ import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
 import { sha256 } from "js-sha256";
 
 import type { PKC } from "../../../../dist/node/pkc/pkc.js";
+import type { PKCError } from "../../../../dist/node/pkc-error.js";
 
 const communityAddress = signers[0].address;
+
+// The comment update loop legitimately emits a retriable "failed to fetch CommentUpdate" error while it
+// polls the community's post-updates for the freshly-published comment, whose CommentUpdate may not have
+// propagated to the remote gateway yet. That transient error is orthogonal to the abort behaviour these
+// tests verify, and on slow configs (e.g. firefox + remote-ipfs-gateway) it lands in the window between
+// update() and stop(), so exclude it before asserting the abort itself surfaced no error.
+function errorsExcludingTransientUpdateFetchFailures(errors: Error[]) {
+    return errors.filter((e) => (e as PKCError).code !== "ERR_FAILED_TO_FETCH_COMMENT_UPDATE_FROM_ALL_POST_UPDATES_RANGES");
+}
 
 function createAbortError(message: string) {
     const error = new Error(message);
@@ -140,7 +150,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     expect(blockedResolver.getReceivedSignal()!.aborted).to.equal(true);
                     expect(reader._memCaches.nameResolvedCache.get(sha256("plebbit.bso" + publishedComment.signature.publicKey))).to.be
                         .undefined;
-                    expect(errors).to.have.length(0);
+                    expect(errorsExcludingTransientUpdateFetchFailures(errors)).to.have.length(0);
                 } finally {
                     await Promise.allSettled([reader.destroy(), publisher.destroy()]);
                 }
@@ -183,7 +193,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     expect(blockedResolver.getReceivedSignal()!.aborted).to.equal(true);
                     expect(reader._memCaches.nameResolvedCache.get(sha256("plebbit.bso" + publishedComment.signature.publicKey))).to.be
                         .undefined;
-                    expect(errors).to.have.length(0);
+                    expect(errorsExcludingTransientUpdateFetchFailures(errors)).to.have.length(0);
                 } finally {
                     await Promise.allSettled([reader.destroy(), publisher.destroy()]);
                 }

--- a/test/node-and-browser/publications/community-edit/community.edit.publication.test.ts
+++ b/test/node-and-browser/publications/community-edit/community.edit.publication.test.ts
@@ -5,7 +5,7 @@ import {
     resolveWhenConditionIsTrue
 } from "../../../../dist/node/test/test-util.js";
 import signers from "../../../fixtures/signers.js";
-import * as remeda from "remeda";
+import { omit } from "remeda";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import type { PKC } from "../../../../dist/node/pkc/pkc.js";
 
@@ -61,11 +61,8 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             const communityEditPubFromStringified = await pkc.createCommunityEdit(JSON.parse(JSON.stringify(communityEditPub)));
             const jsonPropsToOmit = ["clients"];
 
-            const communityEditPubJson = remeda.omit(JSON.parse(JSON.stringify(communityEditPub)), jsonPropsToOmit) as Record<
-                string,
-                unknown
-            >;
-            const stringifiedCommunityEditJson = remeda.omit(
+            const communityEditPubJson = omit(JSON.parse(JSON.stringify(communityEditPub)), jsonPropsToOmit) as Record<string, unknown>;
+            const stringifiedCommunityEditJson = omit(
                 JSON.parse(JSON.stringify(communityEditPubFromStringified)),
                 jsonPropsToOmit
             ) as Record<string, unknown>;

--- a/test/node-and-browser/publications/vote/downvote.test.ts
+++ b/test/node-and-browser/publications/vote/downvote.test.ts
@@ -7,7 +7,7 @@ import {
     resolveWhenConditionIsTrue,
     getAvailablePKCConfigsToTestAgainst
 } from "../../../../dist/node/test/test-util.js";
-import * as remeda from "remeda";
+import { clone } from "remeda";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import type { PKC } from "../../../../dist/node/pkc/pkc.js";
 import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
@@ -40,7 +40,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it.sequential("Can downvote a post", async () => {
-            const originalDownvote = remeda.clone(postToVote.downvoteCount);
+            const originalDownvote = clone(postToVote.downvoteCount);
             const vote = await generateMockVote(postToVote as unknown as CommentIpfsWithCidDefined, -1, pkc);
             await publishWithExpectedResult({ publication: vote, expectedChallengeSuccess: true });
 
@@ -58,7 +58,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it.sequential(`Can downvote a reply`, async () => {
-            const originalDownvote = remeda.clone(replyToVote.downvoteCount);
+            const originalDownvote = clone(replyToVote.downvoteCount);
             const vote = await generateMockVote(replyToVote as unknown as CommentIpfsWithCidDefined, -1, pkc);
             await publishWithExpectedResult({ publication: vote, expectedChallengeSuccess: true });
 
@@ -77,8 +77,8 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it.sequential("Can change post downvote to upvote", async () => {
-            const originalUpvote = remeda.clone(postToVote.upvoteCount);
-            const originalDownvote = remeda.clone(postToVote.downvoteCount);
+            const originalUpvote = clone(postToVote.upvoteCount);
+            const originalDownvote = clone(postToVote.downvoteCount);
             const vote = await pkc.createVote({
                 commentCid: previousVotes[0].commentCid,
                 communityAddress: previousVotes[0].communityAddress,
@@ -100,8 +100,8 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it.sequential("Can change reply downvote to upvote", async () => {
-            const originalUpvote = remeda.clone(replyToVote.upvoteCount);
-            const originalDownvote = remeda.clone(replyToVote.downvoteCount);
+            const originalUpvote = clone(replyToVote.upvoteCount);
+            const originalDownvote = clone(replyToVote.downvoteCount);
             const vote = await pkc.createVote({
                 commentCid: previousVotes[1].commentCid,
                 communityAddress: previousVotes[1].communityAddress,

--- a/test/node-and-browser/publications/vote/upvote.test.ts
+++ b/test/node-and-browser/publications/vote/upvote.test.ts
@@ -7,7 +7,7 @@ import {
     resolveWhenConditionIsTrue,
     getAvailablePKCConfigsToTestAgainst
 } from "../../../../dist/node/test/test-util.js";
-import * as remeda from "remeda";
+import { clone, omit, sample } from "remeda";
 import { messages } from "../../../../dist/node/errors.js";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import type { PKC } from "../../../../dist/node/pkc/pkc.js";
@@ -48,12 +48,12 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it(`(vote: Vote) === pkc.createVote(JSON.parse(JSON.stringify(vote)))`, async () => {
-            const vote = await generateMockVote(postToVote as unknown as CommentIpfsWithCidDefined, 1, pkc, remeda.sample(signers, 1)[0]);
+            const vote = await generateMockVote(postToVote as unknown as CommentIpfsWithCidDefined, 1, pkc, sample(signers, 1)[0]);
             const voteFromStringifiedVote = await pkc.createVote(JSON.parse(JSON.stringify(vote)));
             const jsonPropsToOmit = ["clients"];
 
-            const voteJson = remeda.omit(JSON.parse(JSON.stringify(vote)), jsonPropsToOmit) as Record<string, unknown>;
-            const stringifiedVoteJson = remeda.omit(JSON.parse(JSON.stringify(voteFromStringifiedVote)), jsonPropsToOmit) as Record<
+            const voteJson = omit(JSON.parse(JSON.stringify(vote)), jsonPropsToOmit) as Record<string, unknown>;
+            const stringifiedVoteJson = omit(JSON.parse(JSON.stringify(voteFromStringifiedVote)), jsonPropsToOmit) as Record<
                 string,
                 unknown
             >;
@@ -62,7 +62,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it.sequential("Can upvote a post", async () => {
-            const originalUpvote = remeda.clone(postToVote.upvoteCount);
+            const originalUpvote = clone(postToVote.upvoteCount);
             const vote = await generateMockVote(postToVote as unknown as CommentIpfsWithCidDefined, 1, pkc);
             await publishWithExpectedResult({ publication: vote, expectedChallengeSuccess: true });
             await resolveWhenConditionIsTrue({
@@ -78,7 +78,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it(`Can upvote a reply`, async () => {
-            const originalUpvote = remeda.clone(replyToVote.upvoteCount);
+            const originalUpvote = clone(replyToVote.upvoteCount);
             const vote = await generateMockVote(replyToVote as unknown as CommentIpfsWithCidDefined, 1, pkc);
             await publishWithExpectedResult({ publication: vote, expectedChallengeSuccess: true });
             await resolveWhenConditionIsTrue({
@@ -95,8 +95,8 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it.sequential("Can change post upvote to downvote", async () => {
-            const originalUpvote = remeda.clone(postToVote.upvoteCount);
-            const originalDownvote = remeda.clone(postToVote.downvoteCount);
+            const originalUpvote = clone(postToVote.upvoteCount);
+            const originalDownvote = clone(postToVote.downvoteCount);
             const vote = await pkc.createVote({
                 commentCid: previousVotes[0].commentCid,
                 signer: previousVotes[0].signer,
@@ -117,8 +117,8 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it.sequential("Can change reply upvote to downvote", async () => {
-            const originalUpvote = remeda.clone(replyToVote.upvoteCount);
-            const originalDownvote = remeda.clone(replyToVote.downvoteCount);
+            const originalUpvote = clone(replyToVote.upvoteCount);
+            const originalDownvote = clone(replyToVote.downvoteCount);
             const vote = await pkc.createVote({
                 commentCid: previousVotes[1].commentCid,
                 signer: previousVotes[1].signer,
@@ -149,7 +149,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         });
 
         it(`Can publish a vote that was created from jsonfied vote instance`, async () => {
-            const vote = await generateMockVote(postToVote as unknown as CommentIpfsWithCidDefined, 1, pkc, remeda.sample(signers, 1)[0]);
+            const vote = await generateMockVote(postToVote as unknown as CommentIpfsWithCidDefined, 1, pkc, sample(signers, 1)[0]);
             const voteFromStringifiedVote = await pkc.createVote(JSON.parse(JSON.stringify(vote)));
             const challengeRequestPromise = new Promise<ChallengeRequestWithVote>((resolve) =>
                 voteFromStringifiedVote.once("challengerequest", resolve)

--- a/test/node-and-browser/pubsub-msgs/backward.compatibility.pubsub.test.ts
+++ b/test/node-and-browser/pubsub-msgs/backward.compatibility.pubsub.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../dist/node/test/test-util.js";
 import validCommentUpdateFixture from "../../fixtures/signatures/comment/commentUpdate/valid_comment_update.json" with { type: "json" };
 import { of as calculateIpfsHash } from "typestub-ipfs-only-hash";
-import * as remeda from "remeda";
+import { keys, omit } from "remeda";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 
 import { _signJson, _signPubsubMsg } from "../../../dist/node/signer/signatures.js";
@@ -325,12 +325,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                 const extraPropsInEncrypted = { extraProp: 1234 };
 
                 const log = Logger("pkc-js:test:backward-compat-pubsub");
-                commentUpdate.signature = await _signJson(
-                    remeda.keys.strict(remeda.omit(commentUpdate, ["signature"])),
-                    commentUpdate,
-                    pubsubSigner,
-                    log
-                );
+                commentUpdate.signature = await _signJson(keys(omit(commentUpdate, ["signature"])), commentUpdate, pubsubSigner, log);
 
                 await post.publish();
 

--- a/test/node-and-browser/signatures/comment.test.ts
+++ b/test/node-and-browser/signatures/comment.test.ts
@@ -12,7 +12,7 @@ import {
 import { messages } from "../../../dist/node/errors.js";
 import signers from "../../fixtures/signers.js";
 import { timestamp } from "../../../dist/node/util.js";
-import * as remeda from "remeda";
+import { clone, omit } from "remeda";
 import validCommentFixture from "../../fixtures/signatures/comment/commentUpdate/valid_comment_ipfs.json" with { type: "json" };
 import validCommentAvatarFixture from "../../fixtures/signatures/comment/valid_comment_avatar_fixture.json" with { type: "json" };
 import validCommentAuthorAddressDomainFixture from "../../fixtures/signatures/comment/valid_comment_author_address_as_domain.json" with { type: "json" };
@@ -87,14 +87,14 @@ describe("sign comment", async () => {
         });
         const signature = await signComment({ comment, pkc: pkc });
         expect(signature.publicKey).to.equal(signer.publicKey);
-        const signedComment: CommentPubsubMessagePublication = { signature, ...remeda.omit(comment, ["signer", "communityAddress"]) };
+        const signedComment: CommentPubsubMessagePublication = { signature, ...omit(comment, ["signer", "communityAddress"]) };
         const verificaiton = await verifyCommentPubsubMessage({
             comment: signedComment,
             resolveAuthorNames: pkc.resolveAuthorNames,
             clientsManager: pkc._clientsManager
         });
         expect(verificaiton).to.deep.equal({ valid: true });
-        signedCommentClone = remeda.clone(signedComment);
+        signedCommentClone = clone(signedComment);
     });
 
     it("Can sign a comment with an imported key", async () => {
@@ -104,7 +104,7 @@ describe("sign comment", async () => {
             signer
         });
         const signature = await signComment({ comment, pkc: pkc });
-        const signedComment: CommentPubsubMessagePublication = { signature, ...remeda.omit(comment, ["signer", "communityAddress"]) };
+        const signedComment: CommentPubsubMessagePublication = { signature, ...omit(comment, ["signer", "communityAddress"]) };
         expect(signedComment.signature.publicKey).to.be.equal(signers[1].publicKey, "Generated public key should be same as provided");
         const verificaiton = await verifyCommentPubsubMessage({
             comment: signedComment,
@@ -131,7 +131,7 @@ describe("sign comment", async () => {
     });
 
     it(`signComment throws with author.name not being a domain`, async () => {
-        const cloneComment = remeda.clone(signedCommentClone) as CommentPubsubMessagePublication;
+        const cloneComment = clone(signedCommentClone) as CommentPubsubMessagePublication;
         delete (cloneComment as { signature?: unknown }).signature;
         cloneComment.author = { name: "gibbreish" };
         try {
@@ -156,7 +156,7 @@ describe("sign comment", async () => {
             content: "comment content"
         });
         const signature = await signComment({ comment, pkc: pkc });
-        const signedComment: CommentPubsubMessagePublication = { signature, ...remeda.omit(comment, ["signer", "communityAddress"]) };
+        const signedComment: CommentPubsubMessagePublication = { signature, ...omit(comment, ["signer", "communityAddress"]) };
         const res = await verifyCommentPubsubMessage({
             comment: signedComment,
             resolveAuthorNames: pkc.resolveAuthorNames,
@@ -175,7 +175,7 @@ describe("sign comment", async () => {
             content: "comment content"
         });
         const signature = await signComment({ comment, pkc: pkc });
-        const signedComment: CommentPubsubMessagePublication = { signature, ...remeda.omit(comment, ["signer", "communityAddress"]) };
+        const signedComment: CommentPubsubMessagePublication = { signature, ...omit(comment, ["signer", "communityAddress"]) };
         const res = await verifyCommentPubsubMessage({
             comment: signedComment,
             resolveAuthorNames: false,
@@ -195,7 +195,7 @@ describe("sign comment", async () => {
         // Override timestamp for deterministic test
         (comment as { timestamp: number }).timestamp = 12345678;
         const signature = await signComment({ comment, pkc: pkc });
-        const signedComment: CommentPubsubMessagePublication = { signature, ...remeda.omit(comment, ["signer", "communityAddress"]) };
+        const signedComment: CommentPubsubMessagePublication = { signature, ...omit(comment, ["signer", "communityAddress"]) };
         const res = await verifyCommentPubsubMessage({
             comment: signedComment,
             resolveAuthorNames: pkc.resolveAuthorNames,
@@ -221,7 +221,7 @@ describeSkipIfRpc("verify Comment", async () => {
         const commentToSign = { ...fixtureComment, signer: signers[1] } as unknown as CommentOptionsToSign;
         const freshSignature = await signComment({ comment: commentToSign, pkc: pkc });
         const fixtureWithSignature = {
-            ...remeda.omit(commentToSign, ["signer", "communityAddress"]),
+            ...omit(commentToSign, ["signer", "communityAddress"]),
             signature: freshSignature
         } as unknown as CommentPubsubMessagePublication;
         const verification = await verifyCommentPubsubMessage({
@@ -233,7 +233,7 @@ describeSkipIfRpc("verify Comment", async () => {
     });
 
     it("verifyCommentPubsubMessage failure with wrong signature", async () => {
-        const invalidSignature = remeda.clone(fixtureSignature);
+        const invalidSignature = clone(fixtureSignature);
         invalidSignature.signature += "1";
 
         // Note: fixtureComment doesn't have protocolVersion
@@ -247,7 +247,7 @@ describeSkipIfRpc("verify Comment", async () => {
     });
 
     it(`Valid Comment fixture from previous pkc-js version is validated correctly`, async () => {
-        const comment = remeda.clone(validCommentFixture) as CommentIpfsType;
+        const comment = clone(validCommentFixture) as CommentIpfsType;
 
         const verification = await verifyCommentIpfs({
             comment,
@@ -259,7 +259,7 @@ describeSkipIfRpc("verify Comment", async () => {
     });
 
     it(`A comment with avatar fixture is validated correctly`, async () => {
-        const comment = remeda.clone(validCommentAvatarFixture) as CommentIpfsType;
+        const comment = clone(validCommentAvatarFixture) as CommentIpfsType;
         const verification = await verifyCommentIpfs({
             comment,
             clientsManager: pkc._clientsManager,
@@ -270,7 +270,7 @@ describeSkipIfRpc("verify Comment", async () => {
     });
 
     it(`verifyCommentPubsubMessage invalidates a comment with tampered author.name`, async () => {
-        const comment = remeda.clone({ ...fixtureComment, signature: fixtureSignature }) as unknown as LegacyCommentPublication;
+        const comment = clone({ ...fixtureComment, signature: fixtureSignature }) as unknown as LegacyCommentPublication;
         comment.author.name = "gibbresish";
         const verification = await verifyCommentPubsubMessage({
             comment: comment as unknown as CommentPubsubMessagePublication,
@@ -289,7 +289,7 @@ describeSkipIfRpc("verify Comment", async () => {
             content: "some content"
         });
         const comment: CommentPubsubMessagePublication = {
-            ...remeda.omit(commentToSign, ["signer", "communityAddress"]),
+            ...omit(commentToSign, ["signer", "communityAddress"]),
             signature: await signComment({ comment: commentToSign, pkc: pkc })
         };
         const verification = await verifyCommentPubsubMessage({
@@ -312,7 +312,7 @@ describeSkipIfRpc("verify Comment", async () => {
             signer
         };
         const signature = await signComment({ comment: commentToSign, pkc: pkc });
-        const signedComment: CommentPubsubMessagePublication = { signature, ...remeda.omit(commentToSign, ["signer", "communityAddress"]) };
+        const signedComment: CommentPubsubMessagePublication = { signature, ...omit(commentToSign, ["signer", "communityAddress"]) };
         const verification = await verifyCommentPubsubMessage({
             comment: signedComment,
             resolveAuthorNames: pkc.resolveAuthorNames,
@@ -334,7 +334,7 @@ describeSkipIfRpc("verify Comment", async () => {
             signer
         };
         const signature = await signComment({ comment: commentToSign, pkc: pkc });
-        const signedComment: CommentPubsubMessagePublication = { signature, ...remeda.omit(commentToSign, ["signer", "communityAddress"]) };
+        const signedComment: CommentPubsubMessagePublication = { signature, ...omit(commentToSign, ["signer", "communityAddress"]) };
 
         // Tamper with author.flairs
         signedComment.author.flairs = [{ text: "Tampered" }];
@@ -359,7 +359,7 @@ describeSkipIfRpc("verify Comment", async () => {
             signer
         };
         const signature = await signComment({ comment: commentToSign, pkc: pkc });
-        const signedComment: CommentPubsubMessagePublication = { signature, ...remeda.omit(commentToSign, ["signer", "communityAddress"]) };
+        const signedComment: CommentPubsubMessagePublication = { signature, ...omit(commentToSign, ["signer", "communityAddress"]) };
 
         // Tamper with flairs as if a mod changed them
         signedComment.flairs = [{ text: "Mod Changed" }];
@@ -372,7 +372,7 @@ describeSkipIfRpc("verify Comment", async () => {
     });
 
     it(`verifyCommentIpfs rejects a tampered signature even after the same CID was previously verified as valid`, async () => {
-        const validComment = remeda.clone(validCommentFixture) as CommentIpfsType;
+        const validComment = clone(validCommentFixture) as CommentIpfsType;
         const calculatedCommentCid = "QmCacheBugTest";
 
         // First call: valid signature, populates the cache
@@ -385,7 +385,7 @@ describeSkipIfRpc("verify Comment", async () => {
         expect(validVerification).to.deep.equal({ valid: true });
 
         // Second call: same CID but tampered signature — must NOT return cached { valid: true }
-        const tamperedComment = remeda.clone(validCommentFixture) as CommentIpfsType;
+        const tamperedComment = clone(validCommentFixture) as CommentIpfsType;
         tamperedComment.signature.signature += "invalid";
         const tamperedVerification = await verifyCommentIpfs({
             comment: tamperedComment,
@@ -397,7 +397,7 @@ describeSkipIfRpc("verify Comment", async () => {
     });
 
     it(`verifyCommentIpfs passes when communityPublicKey differs from community but communityName matches (key rotation)`, async () => {
-        const comment = remeda.clone(validCommentFixture) as CommentIpfsType;
+        const comment = clone(validCommentFixture) as CommentIpfsType;
         // Simulate key rotation: comment was published under old key, community now has new key.
         // Add new-format fields; old communityAddress stays for signature validity since it's in signedPropertyNames.
         // getCommunityAddressFromRecord returns communityName first, so the address check uses the domain, not the key.
@@ -415,7 +415,7 @@ describeSkipIfRpc("verify Comment", async () => {
     });
 
     it(`verifyCommentIpfs returns invalid when communityName from record mismatches communityNameFromInstance`, async () => {
-        const comment = remeda.clone(validCommentFixture) as CommentIpfsType;
+        const comment = clone(validCommentFixture) as CommentIpfsType;
         (comment as Record<string, unknown>).communityName = "real.eth";
 
         const verification = await verifyCommentIpfs({
@@ -429,7 +429,7 @@ describeSkipIfRpc("verify Comment", async () => {
     });
 
     it(`verifyCommentIpfs passes when communityName aliases match (.eth vs .bso)`, async () => {
-        const comment = remeda.clone(validCommentFixture) as CommentIpfsType;
+        const comment = clone(validCommentFixture) as CommentIpfsType;
         (comment as Record<string, unknown>).communityName = "example.eth";
 
         const verification = await verifyCommentIpfs({
@@ -443,7 +443,7 @@ describeSkipIfRpc("verify Comment", async () => {
     });
 
     it(`verifyCommentIpfs passes when communityPublicKeyFromInstance differs from record`, async () => {
-        const comment = remeda.clone(validCommentFixture) as CommentIpfsType;
+        const comment = clone(validCommentFixture) as CommentIpfsType;
 
         const verification = await verifyCommentIpfs({
             comment,
@@ -456,7 +456,7 @@ describeSkipIfRpc("verify Comment", async () => {
     });
 
     it(`verifyCommentIpfs passes when communityNameFromInstance is set but record has no communityName`, async () => {
-        const comment = remeda.clone(validCommentFixture) as CommentIpfsType;
+        const comment = clone(validCommentFixture) as CommentIpfsType;
         // validCommentFixture has subplebbitAddress (IPNS key), no communityName
 
         const verification = await verifyCommentIpfs({
@@ -490,7 +490,7 @@ describeSkipIfRpc(`Comment with author.name as domain`, async () => {
             content: "domain identity claim"
         });
         const signedPublication = {
-            ...remeda.omit(commentToSign, ["signer", "communityAddress"]),
+            ...omit(commentToSign, ["signer", "communityAddress"]),
             signature: await signComment({ comment: commentToSign, pkc: tempPKC })
         } satisfies CommentPubsubMessagePublication;
 
@@ -504,7 +504,7 @@ describeSkipIfRpc(`Comment with author.name as domain`, async () => {
         await tempPKC.destroy();
     });
     it(`verifyCommentIpfs returns valid when author domain resolves to different address (nameResolved handles display)`, async () => {
-        const comment = remeda.clone(validCommentAuthorAddressDomainFixture) as CommentIpfsType;
+        const comment = clone(validCommentAuthorAddressDomainFixture) as CommentIpfsType;
         const tempPKC = await mockRemotePKC({
             mockResolve: false,
             pkcOptions: {
@@ -571,7 +571,7 @@ describeSkipIfRpc(`commentupdate`, async () => {
     });
 
     it(`Fixture CommentUpdate can be signed by community and validated correctly`, async () => {
-        const update = remeda.clone(validCommentUpdateFixture) as CommentUpdateType;
+        const update = clone(validCommentUpdateFixture) as CommentUpdateType;
         const commentForVerify: Pick<CommentIpfsWithCidPostCidDefined, "signature" | "postCid" | "depth" | "cid"> = {
             cid: update.cid,
             postCid: undefined as unknown as string, // Post has no postCid
@@ -592,7 +592,7 @@ describeSkipIfRpc(`commentupdate`, async () => {
     });
 
     it(`CommentUpdate from previous pkc-js versions can be verified`, async () => {
-        const update = remeda.clone(validCommentUpdateFixture) as CommentUpdateType;
+        const update = clone(validCommentUpdateFixture) as CommentUpdateType;
         const commentForVerify: Pick<CommentIpfsWithCidPostCidDefined, "signature" | "postCid" | "depth" | "cid"> = {
             cid: update.cid,
             postCid: undefined as unknown as string,
@@ -612,7 +612,7 @@ describeSkipIfRpc(`commentupdate`, async () => {
     });
 
     it(`verifyCommentUpdate invalidate commentUpdate if it was signed by other than community key`, async () => {
-        const update = remeda.clone(validCommentUpdateFixture) as CommentUpdateType;
+        const update = clone(validCommentUpdateFixture) as CommentUpdateType;
         const commentForVerify: Pick<CommentIpfsWithCidPostCidDefined, "signature" | "postCid" | "depth" | "cid"> = {
             cid: update.cid,
             postCid: undefined as unknown as string,
@@ -633,7 +633,7 @@ describeSkipIfRpc(`commentupdate`, async () => {
     });
 
     it(`A commentUpdate with an edit signed by other than original author will be rejected`, async () => {
-        const update = remeda.clone(validCommentUpdateWithAuthorEditFixture) as CommentUpdateType & {
+        const update = clone(validCommentUpdateWithAuthorEditFixture) as CommentUpdateType & {
             edit: { author?: { name?: string }; signature?: unknown; signer?: unknown };
         };
         const commentForVerify: Pick<CommentIpfsWithCidPostCidDefined, "signature" | "postCid" | "depth" | "cid"> = {
@@ -675,7 +675,7 @@ describeSkipIfRpc(`commentupdate`, async () => {
     });
 
     it(`commentUpdate.edit is invalidated if any prop is changed and not signed by original author`, async () => {
-        const update = remeda.clone(validCommentUpdateWithAuthorEditFixture) as CommentUpdateType & { edit: { content: string } };
+        const update = clone(validCommentUpdateWithAuthorEditFixture) as CommentUpdateType & { edit: { content: string } };
         const commentForVerify: Pick<CommentIpfsWithCidPostCidDefined, "signature" | "postCid" | "depth" | "cid"> = {
             cid: update.cid,
             postCid: undefined as unknown as string,

--- a/test/node-and-browser/signatures/community.test.ts
+++ b/test/node-and-browser/signatures/community.test.ts
@@ -4,7 +4,7 @@ import { createMockNameResolver, mockRemotePKC, resolveWhenConditionIsTrue, mock
 import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
 import { messages } from "../../../dist/node/errors.js";
 import { verifyCommunity, signCommunity, cleanUpBeforePublishing, _signJson } from "../../../dist/node/signer/signatures.js";
-import * as remeda from "remeda";
+import { clone } from "remeda";
 import validCommunityFixture from "../../fixtures/signatures/community/valid_community_ipfs.json" with { type: "json" };
 import newFormatFixture from "../../fixtures/signatures/community/valid_community_ipfs_new_format.json" with { type: "json" };
 import newFormatWithNameFixture from "../../fixtures/signatures/community/valid_community_ipfs_new_format_with_name.json" with { type: "json" };
@@ -27,8 +27,8 @@ describeSkipIfRpc.concurrent("Sign community", async () => {
     });
 
     it(`Can sign and validate fixture community correctly`, async () => {
-        const subFixture = remeda.clone(validCommunityFixture) as CommunityIpfsType;
-        const subFixtureClone = remeda.clone(subFixture) as Record<string, unknown>;
+        const subFixture = clone(validCommunityFixture) as CommunityIpfsType;
+        const subFixtureClone = clone(subFixture) as Record<string, unknown>;
         delete subFixtureClone["signature"];
         const signature = await signCommunity({
             community: subFixtureClone as Omit<CommunityIpfsType, "signature">,
@@ -68,8 +68,8 @@ describeSkipIfRpc.concurrent("Sign community", async () => {
     });
 
     it(`Can sign new-format record without address`, async () => {
-        const subFixture = remeda.clone(newFormatFixture) as CommunityIpfsType;
-        const subFixtureClone = remeda.clone(subFixture) as Record<string, unknown>;
+        const subFixture = clone(newFormatFixture) as CommunityIpfsType;
+        const subFixtureClone = clone(subFixture) as Record<string, unknown>;
         delete subFixtureClone["signature"];
         const signature = await signCommunity({
             community: subFixtureClone as Omit<CommunityIpfsType, "signature">,
@@ -80,8 +80,8 @@ describeSkipIfRpc.concurrent("Sign community", async () => {
     });
 
     it(`Can sign new-format record with name`, async () => {
-        const subFixture = remeda.clone(newFormatWithNameFixture) as CommunityIpfsType;
-        const subFixtureClone = remeda.clone(subFixture) as Record<string, unknown>;
+        const subFixture = clone(newFormatWithNameFixture) as CommunityIpfsType;
+        const subFixtureClone = clone(subFixture) as Record<string, unknown>;
         delete subFixtureClone["signature"];
         const signature = await signCommunity({
             community: subFixtureClone as Omit<CommunityIpfsType, "signature">,
@@ -125,7 +125,7 @@ describeSkipIfRpc.concurrent("Verify community", async () => {
         ).to.deep.equal({ valid: true });
     });
     it(`Valid community fixture is validated correctly`, async () => {
-        const community = remeda.clone(validCommunityFixture) as CommunityIpfsType;
+        const community = clone(validCommunityFixture) as CommunityIpfsType;
         expect(
             await verifyCommunity({
                 community: community,
@@ -139,7 +139,7 @@ describeSkipIfRpc.concurrent("Verify community", async () => {
     });
 
     it(`Old-format fixture with address in signedPropertyNames still verifies`, async () => {
-        const community = remeda.clone(validCommunityFixture) as CommunityIpfsType;
+        const community = clone(validCommunityFixture) as CommunityIpfsType;
         expect(community.signature.signedPropertyNames).to.include("address");
         expect(
             await verifyCommunity({
@@ -154,7 +154,7 @@ describeSkipIfRpc.concurrent("Verify community", async () => {
     });
 
     it(`New-format fixture without address verifies`, async () => {
-        const community = remeda.clone(newFormatFixture) as CommunityIpfsType;
+        const community = clone(newFormatFixture) as CommunityIpfsType;
         expect(community.signature.signedPropertyNames).to.not.include("address");
         expect((community as Record<string, unknown>).address).to.be.undefined;
         expect(
@@ -170,7 +170,7 @@ describeSkipIfRpc.concurrent("Verify community", async () => {
     });
 
     it(`New-format fixture with name verifies`, async () => {
-        const community = remeda.clone(newFormatWithNameFixture) as CommunityIpfsType;
+        const community = clone(newFormatWithNameFixture) as CommunityIpfsType;
         expect(community.signature.signedPropertyNames).to.include("name");
         expect(community.signature.signedPropertyNames).to.not.include("address");
         expect(community.name).to.equal("test-sub.eth");
@@ -220,7 +220,7 @@ describeSkipIfRpc.concurrent("Verify community", async () => {
         });
 
         await loadedCommunity.stop();
-        const communityJson = remeda.clone(loadedCommunity.raw.communityIpfs!);
+        const communityJson = clone(loadedCommunity.raw.communityIpfs!);
         expect(
             await verifyCommunity({
                 community: communityJson,
@@ -251,7 +251,7 @@ describeSkipIfRpc.concurrent("Verify community", async () => {
     it(`community signature is valid if community.posts has a comment.author.address who resolves to an invalid address`, async () => {
         // Publish a comment with ENS domain here
 
-        const subIpfs = remeda.clone(validCommunityFixture) as CommunityIpfsType; // This json has only one comment with plebbit.eth
+        const subIpfs = clone(validCommunityFixture) as CommunityIpfsType; // This json has only one comment with plebbit.eth
         const commentWithEnsCid = subIpfs.posts.pages.hot.comments.find(
             (commentPage) => commentPage.comment.author.address === "plebbit.eth"
         )!.commentUpdate.cid;
@@ -293,8 +293,8 @@ describeSkipIfRpc.concurrent("Verify community", async () => {
         const tempPKC: PKCType = await mockRemotePKC();
 
         // Use new-format fixture (no address) to avoid signature mismatch due to format change
-        const subFixture = remeda.clone(newFormatFixture) as CommunityIpfsType;
-        const subFixtureClone = remeda.clone(subFixture) as CommunityIpfsType & { extraProp?: string };
+        const subFixture = clone(newFormatFixture) as CommunityIpfsType;
+        const subFixtureClone = clone(subFixture) as CommunityIpfsType & { extraProp?: string };
         subFixtureClone.extraProp = "1234";
         const signature = await signCommunity({
             community: subFixtureClone as Omit<CommunityIpfsType, "signature">,
@@ -323,8 +323,8 @@ describeSkipIfRpc.concurrent("Verify community", async () => {
     it(`A community record is accepted if it includes an extra prop as long as it's in signature.signedPropertyNames`, async () => {
         const tempPKC: PKCType = await mockRemotePKC();
 
-        const subFixture = remeda.clone(validCommunityFixture) as CommunityIpfsType;
-        const subFixtureClone = remeda.clone(subFixture) as CommunityIpfsType & { extraProp?: string };
+        const subFixture = clone(validCommunityFixture) as CommunityIpfsType;
+        const subFixtureClone = clone(subFixture) as CommunityIpfsType & { extraProp?: string };
         subFixtureClone.extraProp = "1234";
         const signature = await _signJson([...subFixture.signature.signedPropertyNames, "extraProp"], subFixtureClone, signers[0], log);
         expect(signature.signedPropertyNames).to.include("extraProp");
@@ -347,8 +347,8 @@ describeSkipIfRpc.concurrent("Verify community", async () => {
     it(`A community record is rejected if it includes runtime-only nameResolved even when signed`, async () => {
         const tempPKC: PKCType = await mockRemotePKC();
 
-        const subFixture = remeda.clone(newFormatFixture) as CommunityIpfsType;
-        const subFixtureClone = remeda.clone(subFixture) as CommunityIpfsType & { nameResolved?: boolean };
+        const subFixture = clone(newFormatFixture) as CommunityIpfsType;
+        const subFixtureClone = clone(subFixture) as CommunityIpfsType & { nameResolved?: boolean };
         subFixtureClone.nameResolved = true;
         const signature = await _signJson([...subFixture.signature.signedPropertyNames, "nameResolved"], subFixtureClone, signers[0], log);
 

--- a/test/node-and-browser/signatures/edit.comment.test.ts
+++ b/test/node-and-browser/signatures/edit.comment.test.ts
@@ -3,7 +3,7 @@ import { mockRemotePKC } from "../../../dist/node/test/test-util.js";
 import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
 import signers from "../../fixtures/signers.js";
 import { timestamp } from "../../../dist/node/util.js";
-import * as remeda from "remeda";
+import { clone, omit } from "remeda";
 import { messages } from "../../../dist/node/errors.js";
 import { verifyCommentEdit, signCommentEdit } from "../../../dist/node/signer/signatures.js";
 import validCommentEditFixture from "../../fixtures/signatures/commentEdit/valid_comment_edit.json" with { type: "json" };
@@ -50,7 +50,7 @@ describe("Sign commentedit", async () => {
     });
 
     it(`signCommentEdit throws with author.name not being a domain`, async () => {
-        const cloneEdit = remeda.clone(editProps);
+        const cloneEdit = clone(editProps);
         cloneEdit.author = { name: "gibbreish" };
         try {
             await signCommentEdit({ edit: { ...cloneEdit, signer: signers[7] }, pkc: pkc });
@@ -61,7 +61,7 @@ describe("Sign commentedit", async () => {
     });
     it(`signCommentEdit allows author to be omitted`, async () => {
         const signature = await signCommentEdit({
-            edit: { ...remeda.omit(editProps, ["author"]), signer: signers[7] } as CommentEditOptionsToSign,
+            edit: { ...omit(editProps, ["author"]), signer: signers[7] } as CommentEditOptionsToSign,
             pkc: pkc
         });
         expect(signature.publicKey).to.equal(signers[7].publicKey);
@@ -76,7 +76,7 @@ describeSkipIfRpc("Verify CommentEdit", async () => {
         await pkc.createCommentEdit(validCommentEditFixture as unknown as CommentEditPubsubMessagePublication); // should throw if it has an invalid schema
     });
     it(`Valid CommentEdit signature fixture is validated correctly`, async () => {
-        const edit = remeda.clone(validCommentEditFixture) as CommentEditPubsubMessagePublication;
+        const edit = clone(validCommentEditFixture) as CommentEditPubsubMessagePublication;
         const verification = await verifyCommentEdit({
             edit,
             resolveAuthorNames: pkc.resolveAuthorNames,
@@ -86,7 +86,7 @@ describeSkipIfRpc("Verify CommentEdit", async () => {
     });
 
     it(`Invalid CommentEdit signature gets invalidated correctly`, async () => {
-        const edit = remeda.clone(validCommentEditFixture) as CommentEditPubsubMessagePublication & { reason: string };
+        const edit = clone(validCommentEditFixture) as CommentEditPubsubMessagePublication & { reason: string };
         edit.reason += "1234"; // Should invalidate comment edit
         const verification = await verifyCommentEdit({
             edit,
@@ -97,7 +97,7 @@ describeSkipIfRpc("Verify CommentEdit", async () => {
     });
 
     it(`verifyCommentEdit invalidates a commentEdit with tampered author.name`, async () => {
-        const edit = remeda.clone(validCommentEditFixture) as CommentEditPubsubMessagePublication;
+        const edit = clone(validCommentEditFixture) as CommentEditPubsubMessagePublication;
         edit.author = { ...(edit.author || {}), name: "gibbresish" };
         const verification = await verifyCommentEdit({
             edit,
@@ -108,7 +108,7 @@ describeSkipIfRpc("Verify CommentEdit", async () => {
         expect(verification).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });
     });
     it("verifyCommentEdit invalidates a legacy commentEdit with author removed because the signature changes", async () => {
-        const edit = remeda.clone(validCommentEditFixture) as CommentEditPubsubMessagePublication;
+        const edit = clone(validCommentEditFixture) as CommentEditPubsubMessagePublication;
         delete edit.author;
         const verification = await verifyCommentEdit({
             edit,

--- a/test/node-and-browser/signatures/pages.test.ts
+++ b/test/node-and-browser/signatures/pages.test.ts
@@ -4,7 +4,7 @@ import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
 import { verifyPage } from "../../../dist/node/signer/signatures.js";
 import { messages } from "../../../dist/node/errors.js";
 import signers from "../../fixtures/signers.js";
-import * as remeda from "remeda";
+import { clone } from "remeda";
 import { v4 as uuidV4 } from "uuid";
 
 import validPageIpfsFixture from "../../fixtures/valid_page.json" with { type: "json" };
@@ -81,14 +81,14 @@ describeSkipIfRpc(`verify pages`, async () => {
     });
 
     it(`Page from previous pkc-js versions can be validated`, async () => {
-        const page = remeda.clone(legacyPageIpfsFixture) as PageIpfs;
+        const page = clone(legacyPageIpfsFixture) as PageIpfs;
         const verification = await verifyPageJsonAlongWithObject(page, pkc, community, undefined);
         expect(verification).to.deep.equal({ valid: true });
     });
 
     it(`verifyPage will return valid when comment.author.name (domain) resolves to address different than the signer's`, async () => {
         // verifyPage would override the incorrect domain
-        const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+        const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
         // New wire format uses author.name for domains
         const commentWithDomainIndex = invalidPage.comments.findIndex(
             (pageComment) => typeof pageComment.comment.author?.name === "string"
@@ -116,13 +116,13 @@ describeSkipIfRpc(`verify pages`, async () => {
 
     describe(`A community owner changing any of comment fields in page will invalidate`, async () => {
         beforeAll(async () => {
-            const page = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const page = clone(validPageIpfsFixture) as PageIpfs;
             const verificaiton = await verifyPageJsonAlongWithObject(page, pkc, community, undefined);
             expect(verificaiton).to.deep.equal({ valid: true });
         });
 
         it(`comment.flairs (original)`, async () => {
-            const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
             // Add flairs to a comment that had none — changing the comment object changes its CID hash,
             // so the commentUpdate.cid no longer matches
             invalidPage.comments[0].comment.flairs = [{ text: "Injected Flair" }];
@@ -130,7 +130,7 @@ describeSkipIfRpc(`verify pages`, async () => {
             expect(verification).to.deep.equal({ valid: false, reason: messages.ERR_COMMENT_UPDATE_DIFFERENT_CID_THAN_COMMENT });
         });
         it("comment.content (author has never modified comment.content before))", async () => {
-            const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
             const commentWithNoEditIndex = invalidPage.comments.findIndex((pageComment) => !pageComment.commentUpdate.edit?.content);
             invalidPage.comments[commentWithNoEditIndex].comment.content = "Content modified by community illegally";
             const verification = await verifyPageJsonAlongWithObject(invalidPage, pkc, community, undefined);
@@ -139,7 +139,7 @@ describeSkipIfRpc(`verify pages`, async () => {
 
         it(`comment.content (when author has modified comment.content before)`, async () => {
             // Use legacy fixture which has comments with commentUpdate.edit.content
-            const invalidPage = remeda.clone(legacyPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(legacyPageIpfsFixture) as PageIpfs;
             const commentWithEditIndex = invalidPage.comments.findIndex((pageComment) => pageComment.commentUpdate.edit?.content);
             expect(commentWithEditIndex).to.be.greaterThanOrEqual(0);
             invalidPage.comments[commentWithEditIndex].comment.content = "Content modified by community illegally";
@@ -149,7 +149,7 @@ describeSkipIfRpc(`verify pages`, async () => {
 
         it(`commentUpdate.edit.content`, async () => {
             // Use legacy fixture which has comments with commentUpdate.edit.content
-            const invalidPage = remeda.clone(legacyPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(legacyPageIpfsFixture) as PageIpfs;
             const commentWithEditIndex = invalidPage.comments.findIndex((pageComment) => pageComment.commentUpdate.edit?.content);
             invalidPage.comments[commentWithEditIndex].commentUpdate.edit!.content = "Content modified by community illegally";
             const verification = await verifyPageJsonAlongWithObject(invalidPage, pkc, community, undefined);
@@ -158,7 +158,7 @@ describeSkipIfRpc(`verify pages`, async () => {
 
         it(`commentUpdate.edit.spoiler`, async () => {
             // Use legacy fixture which has comments with commentUpdate.edit.spoiler
-            const invalidPage = remeda.clone(legacyPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(legacyPageIpfsFixture) as PageIpfs;
             const commentWithSpoilerIndex = invalidPage.comments.findIndex((pageComment) => pageComment.commentUpdate.edit?.spoiler);
             expect(commentWithSpoilerIndex).to.be.greaterThanOrEqual(0);
             invalidPage.comments[commentWithSpoilerIndex].commentUpdate.edit!.spoiler =
@@ -169,7 +169,7 @@ describeSkipIfRpc(`verify pages`, async () => {
 
         it(`commentUpdate.edit.deleted`, async () => {
             // Use legacy fixture which has comments with commentUpdate.edit
-            const invalidPage = remeda.clone(legacyPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(legacyPageIpfsFixture) as PageIpfs;
             const commentWithDeletedIndex = invalidPage.comments.findIndex((pageComment) => pageComment.commentUpdate.edit);
             expect(commentWithDeletedIndex).to.be.greaterThanOrEqual(0);
             invalidPage.comments[commentWithDeletedIndex].commentUpdate.edit!.deleted = !Boolean(
@@ -180,7 +180,7 @@ describeSkipIfRpc(`verify pages`, async () => {
         });
 
         it(`comment.link`, async () => {
-            const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
             const commentWithLinkIndex = invalidPage.comments.findIndex((pageComment) => pageComment.comment.link);
             expect(commentWithLinkIndex).to.be.greaterThanOrEqual(0);
             invalidPage.comments[commentWithLinkIndex].comment.link = "https://differentLinkzz.com";
@@ -188,7 +188,7 @@ describeSkipIfRpc(`verify pages`, async () => {
             expect(verification).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });
         });
         it(`comment.parentCid`, async () => {
-            const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
             const commentWithRepliesIndex = invalidPage.comments.findIndex(
                 (pageComment) => pageComment.commentUpdate.replyCount > 0 && pageComment.commentUpdate.replies?.pages
             );
@@ -201,14 +201,14 @@ describeSkipIfRpc(`verify pages`, async () => {
             expect(verification).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });
         });
         it(`comment.communityPublicKey (tampered signed field)`, async () => {
-            const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
             (invalidPage.comments[0].comment as Record<string, unknown>).communityPublicKey += "1234";
             const verification = await verifyPageJsonAlongWithObject(invalidPage, pkc, community, undefined);
             expect(verification).to.deep.equal({ valid: false, reason: messages.ERR_COMMENT_IN_PAGE_BELONG_TO_DIFFERENT_COMMUNITY });
         });
         it(`comment.communityName (tampered signed field)`, async () => {
             // Use fixture with communityName in signedPropertyNames (domain-based community)
-            const invalidPage = remeda.clone(validPageWithNameFixture) as PageIpfs;
+            const invalidPage = clone(validPageWithNameFixture) as PageIpfs;
             (invalidPage.comments[0].comment as Record<string, unknown>).communityName = "fake.eth";
             const domainCommunity = {
                 publicKey: "12D3KooWN5rLmRJ8fWMwTtkDN7w2RgPPGRM4mtWTnfbjpi1Sh7zR",
@@ -230,32 +230,32 @@ describeSkipIfRpc(`verify pages`, async () => {
             expect(verification).to.deep.equal({ valid: false, reason: messages.ERR_COMMENT_IN_PAGE_BELONG_TO_DIFFERENT_COMMUNITY });
         });
         it("comment.timestamp", async () => {
-            const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
             invalidPage.comments[0].comment.timestamp += 1;
             const verification = await verifyPageJsonAlongWithObject(invalidPage, pkc, community, undefined);
             expect(verification).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });
         });
         it(`comment.author.address (ed25519)`, async () => {
-            const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
             (invalidPage.comments[0].comment.author as { address: string }).address =
                 "12D3KooWJJcSwMHrFvsFL7YCNDLD93kBczEfkHpPNdxcjZwR2X2Y"; // Random address
             const verification = await verifyPageJsonAlongWithObject(invalidPage, pkc, community, undefined);
             expect(verification).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });
         });
         it(`comment.author.previousCommentCid`, async () => {
-            const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
             invalidPage.comments[0].comment.author.previousCommentCid! += "1";
             const verification = await verifyPageJsonAlongWithObject(invalidPage, pkc, community, undefined);
             expect(verification).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });
         });
         it(`comment.author.displayName`, async () => {
-            const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
             invalidPage.comments[0].comment.author.displayName! += "1";
             const verification = await verifyPageJsonAlongWithObject(invalidPage, pkc, community, undefined);
             expect(verification).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });
         });
         it("comment.author.wallets", async () => {
-            const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
             const commentWithWalletsIndex = invalidPage.comments.findIndex((comment) => comment.comment.author.wallets);
             expect(commentWithWalletsIndex).to.be.greaterThanOrEqual(0);
             // Corrupt the wallets by converting to string (this is intentional to test signature validation)
@@ -265,7 +265,7 @@ describeSkipIfRpc(`verify pages`, async () => {
             expect(verification).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });
         });
         it("comment.author.avatar", async () => {
-            const invalidPage = remeda.clone(validPageIpfsFixture) as PageIpfs;
+            const invalidPage = clone(validPageIpfsFixture) as PageIpfs;
             const commentWithAvatarIndex = invalidPage.comments.findIndex((comment) => comment.comment.author.avatar);
             expect(commentWithAvatarIndex).to.be.greaterThanOrEqual(0);
             invalidPage.comments[commentWithAvatarIndex].comment.author.avatar!.id += "12234";
@@ -275,7 +275,7 @@ describeSkipIfRpc(`verify pages`, async () => {
     });
 
     it(`Page is invalid when verifying key-only community has different publicKey`, async () => {
-        const page = remeda.clone(validPageIpfsFixture) as PageIpfs;
+        const page = clone(validPageIpfsFixture) as PageIpfs;
         const verification = await verifyPage({
             pageCid: uuidV4(),
             pageSortName: "hot",
@@ -291,7 +291,7 @@ describeSkipIfRpc(`verify pages`, async () => {
     });
 
     it(`Page is invalid when verifying community has different name than comment's communityName`, async () => {
-        const page = remeda.clone(validPageIpfsFixture) as PageIpfs;
+        const page = clone(validPageIpfsFixture) as PageIpfs;
         // Add communityName to the record — name check in verifyCommentIpfs fires before signature check
         (page.comments[0].comment as Record<string, unknown>).communityName = "real.eth";
         const verification = await verifyPage({
@@ -309,7 +309,7 @@ describeSkipIfRpc(`verify pages`, async () => {
     });
 
     it(`Domain fixture is valid when verified against matching domain community`, async () => {
-        const page = remeda.clone(validPageWithNameFixture) as PageIpfs;
+        const page = clone(validPageWithNameFixture) as PageIpfs;
         const domainCommunity = {
             publicKey: "12D3KooWN5rLmRJ8fWMwTtkDN7w2RgPPGRM4mtWTnfbjpi1Sh7zR",
             name: "testcommunity.eth",
@@ -332,7 +332,7 @@ describeSkipIfRpc(`verify pages`, async () => {
     it(`Key rotation is allowed for domain communities (different publicKey, same name)`, async () => {
         // Domain fixture has communityName: "testcommunity.eth" and communityPublicKey: "12D3KooWN5..."
         // Verify with a community that has the same name but a DIFFERENT publicKey
-        const page = remeda.clone(validPageWithNameFixture) as PageIpfs;
+        const page = clone(validPageWithNameFixture) as PageIpfs;
         const rotatedKeyCommunity = {
             publicKey: "12D3KooWJJcSwMHrFvsFL7YCNDLD93kBczEfkHpPNdxcjZwR2X2Y", // different key
             name: "testcommunity.eth", // same name
@@ -354,7 +354,7 @@ describeSkipIfRpc(`verify pages`, async () => {
 
     it(`Legacy subplebbitAddress page is invalid when community has different publicKey`, async () => {
         // Legacy fixture uses subplebbitAddress: "12D3KooWN5..." (non-domain = publicKey)
-        const page = remeda.clone(legacyPageIpfsFixture) as PageIpfs;
+        const page = clone(legacyPageIpfsFixture) as PageIpfs;
         const verification = await verifyPage({
             pageCid: uuidV4(),
             pageSortName: "hot",
@@ -372,7 +372,7 @@ describeSkipIfRpc(`verify pages`, async () => {
     it(`Domain community: tampered communityPublicKey with matching name is caught by CID mismatch`, async () => {
         // When a domain community checks pages, it only validates name (key rotation allowed).
         // Tampering communityPublicKey passes the community check, but changes the CID since it's signed.
-        const page = remeda.clone(validPageWithNameFixture) as PageIpfs;
+        const page = clone(validPageWithNameFixture) as PageIpfs;
         (page.comments[0].comment as Record<string, unknown>).communityPublicKey = "12D3KooWJJcSwMHrFvsFL7YCNDLD93kBczEfkHpPNdxcjZwR2X2Y";
         const domainCommunity = {
             publicKey: "12D3KooWN5rLmRJ8fWMwTtkDN7w2RgPPGRM4mtWTnfbjpi1Sh7zR",

--- a/test/node-and-browser/signatures/pubsub.messages.test.ts
+++ b/test/node-and-browser/signatures/pubsub.messages.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../dist/node/signer/signatures.js";
 import signers from "../../fixtures/signers.js";
 import { messages } from "../../../dist/node/errors.js";
-import * as remeda from "remeda";
+import { clone, isPlainObject, omit } from "remeda";
 import { default as PKCJsVersion } from "../../../dist/node/version.js";
 import { encode as cborgEncode, decode as cborgDecode } from "cborg";
 import { getBufferedPKCAddressFromPublicKey } from "../../../dist/node/signer/util.js";
@@ -45,9 +45,9 @@ const parsePubsubMsgFixture = <T extends Record<string, unknown>>(json: T): T =>
     const isBuffer = (obj: Record<string, unknown>) => Object.keys(obj).every((key) => /\d/.test(key));
     const parsed: Record<string, unknown> = {};
     for (const key of Object.keys(json)) {
-        if (remeda.isPlainObject(json[key]) && isBuffer(json[key] as Record<string, unknown>))
+        if (isPlainObject(json[key]) && isBuffer(json[key] as Record<string, unknown>))
             parsed[key] = Uint8Array.from(Object.values(json[key] as Record<string, unknown>) as number[]);
-        else if (remeda.isPlainObject(json[key])) parsed[key] = parsePubsubMsgFixture(json[key] as Record<string, unknown>);
+        else if (isPlainObject(json[key])) parsed[key] = parsePubsubMsgFixture(json[key] as Record<string, unknown>);
         else parsed[key] = json[key];
     }
     return parsed as T;
@@ -67,13 +67,13 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
         });
 
         it(`valid challengerequest fixture from previous version can be validated`, async () => {
-            const request = parsePubsubMsgFixture(remeda.clone(validChallengeRequestFixture)) as unknown as ChallengeRequestMessageType;
+            const request = parsePubsubMsgFixture(clone(validChallengeRequestFixture)) as unknown as ChallengeRequestMessageType;
             const verificaiton = await verifyChallengeRequest({ request, validateTimestampRange: false });
             expect(verificaiton).to.deep.equal({ valid: true });
         });
 
         it(`challenge request with challengeRequestId that is not derived from signer is invalidated`, async () => {
-            const request = parsePubsubMsgFixture(remeda.clone(validChallengeRequestFixture)) as unknown as ChallengeRequestMessageType;
+            const request = parsePubsubMsgFixture(clone(validChallengeRequestFixture)) as unknown as ChallengeRequestMessageType;
             request.challengeRequestId[0] += 1; // Invalidate challengeRequestId
             const verificaiton = await verifyChallengeRequest({ request, validateTimestampRange: false });
             expect(verificaiton).to.deep.equal({ valid: false, reason: messages.ERR_CHALLENGE_REQUEST_ID_NOT_DERIVED_FROM_SIGNATURE });
@@ -90,11 +90,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             );
             await comment.publish();
             const challengeRequest = await challengeRequestPromise;
-            const challengeRequestToEdit = remeda.omit(remeda.clone(challengeRequest), [
-                "comment",
-                "challengeAnswers",
-                "challengeCommentCids"
-            ]);
+            const challengeRequestToEdit = omit(clone(challengeRequest), ["comment", "challengeAnswers", "challengeCommentCids"]);
             challengeRequestToEdit.timestamp = timestamp() - 6 * 60; // Should be invalidated now
             const signer = Object.values(comment._challengeExchanges)[0].signer!;
             challengeRequestToEdit.signature = await signChallengeRequest({ request: challengeRequestToEdit, signer });
@@ -114,7 +110,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
 
             await comment.publish();
             const challengeRequest = await challengeRequestPromise;
-            const requestToValidate = remeda.omit(challengeRequest, ["comment", "challengeAnswers", "challengeCommentCids"]);
+            const requestToValidate = omit(challengeRequest, ["comment", "challengeAnswers", "challengeCommentCids"]);
             const verificaiton = await verifyChallengeRequest({ request: requestToValidate, validateTimestampRange: false });
             expect(verificaiton).to.deep.equal({ valid: true });
         });
@@ -135,7 +131,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             await comment.publish();
             const challengeRequest = await challengeRequestPromise;
 
-            const challengeRequestToModify = remeda.omit(challengeRequest, ["comment", "challengeCommentCids", "challengeAnswers"]);
+            const challengeRequestToModify = omit(challengeRequest, ["comment", "challengeCommentCids", "challengeAnswers"]);
             const pubsubSigner = Object.values(comment._challengeExchanges)[0].signer!;
             challengeRequestToModify.encrypted = await encryptEd25519AesGcm(
                 JSON.stringify(comment.toJSONPubsubRequestToEncrypt()),
@@ -204,7 +200,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                 reason: messages.ERR_SIGNATURE_IS_INVALID
             });
 
-            const challengeRequestToModify = remeda.omit(challengeRequest, ["comment", "challengeCommentCids", "challengeAnswers"]);
+            const challengeRequestToModify = omit(challengeRequest, ["comment", "challengeCommentCids", "challengeAnswers"]);
             const pubsubSigner = Object.values(comment._challengeExchanges)[0].signer!;
 
             challengeRequestToModify.encrypted = await encryptEd25519AesGcm(
@@ -241,11 +237,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             await Promise.all([new Promise((resolve) => comment.once("challengeverification", resolve)), comment.publish()]);
 
             const challengeRequest = await challengeRequestPromise;
-            const requestWithInvalidSignature = remeda.omit(remeda.clone(challengeRequest), [
-                "comment",
-                "challengeCommentCids",
-                "challengeAnswers"
-            ]);
+            const requestWithInvalidSignature = omit(clone(challengeRequest), ["comment", "challengeCommentCids", "challengeAnswers"]);
             requestWithInvalidSignature.acceptedChallengeTypes.push("test"); // Signature should be invalid after
             const verificaiton = await verifyChallengeRequest({ request: requestWithInvalidSignature, validateTimestampRange: false });
             expect(verificaiton).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });
@@ -281,7 +273,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
         });
 
         it(`valid challengemessage fixture from previous version can be validated`, async () => {
-            const challenge = parsePubsubMsgFixture(remeda.clone(validChallengeFixture)) as unknown as ChallengeMessageType;
+            const challenge = parsePubsubMsgFixture(clone(validChallengeFixture)) as unknown as ChallengeMessageType;
             const verificaiton = await verifyChallengeMessage({
                 challenge,
                 pubsubTopic: "12D3KooWANwdyPERMQaCgiMnTT1t3Lr4XLFbK1z4ptFVhW2ozg1z",
@@ -291,7 +283,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
         });
 
         it(`Invalid ChallengeMessage gets invalidated correctly`, async () => {
-            const challenge = parsePubsubMsgFixture(remeda.clone(validChallengeFixture)) as unknown as ChallengeMessageType;
+            const challenge = parsePubsubMsgFixture(clone(validChallengeFixture)) as unknown as ChallengeMessageType;
             challenge.timestamp -= 1234; // Should invalidate signature
             const verificaiton = await verifyChallengeMessage({
                 challenge,
@@ -302,7 +294,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
         });
 
         it(`challenge message signed by other than community.pubsubTopic is invalidated`, async () => {
-            const challenge = parsePubsubMsgFixture(remeda.clone(validChallengeFixture)) as unknown as ChallengeMessageType;
+            const challenge = parsePubsubMsgFixture(clone(validChallengeFixture)) as unknown as ChallengeMessageType;
             const verificaiton = await verifyChallengeMessage({
                 challenge,
                 pubsubTopic: (await pkc.createSigner()).address,
@@ -322,7 +314,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
 
             const challengePubsubMsg = await new Promise<DecryptedChallengeMessageType>((resolve) => comment.once("challenge", resolve));
 
-            const challengePubsubMsgNoExtraProps = remeda.omit(challengePubsubMsg, ["challenges"]);
+            const challengePubsubMsgNoExtraProps = omit(challengePubsubMsg, ["challenges"]);
 
             const verification = await verifyChallengeMessage({
                 challenge: challengePubsubMsgNoExtraProps,
@@ -345,13 +337,13 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
         });
 
         it(`valid challengeanswer fixture from previous version can be validated`, async () => {
-            const answer = parsePubsubMsgFixture(remeda.clone(validChallengeAnswerFixture)) as unknown as ChallengeAnswerMessageType;
+            const answer = parsePubsubMsgFixture(clone(validChallengeAnswerFixture)) as unknown as ChallengeAnswerMessageType;
             const verificaiton = await verifyChallengeAnswer({ answer, validateTimestampRange: false });
             expect(verificaiton).to.deep.equal({ valid: true });
         });
 
         it(`challenge answer with challengeRequestId that is not derived from signer is invalidated`, async () => {
-            const answer = parsePubsubMsgFixture(remeda.clone(validChallengeAnswerFixture)) as unknown as ChallengeAnswerMessageType;
+            const answer = parsePubsubMsgFixture(clone(validChallengeAnswerFixture)) as unknown as ChallengeAnswerMessageType;
             answer.challengeRequestId[0] += 1; // Invalidate challenge request id
             const verificaiton = await verifyChallengeAnswer({ answer, validateTimestampRange: false });
             expect(verificaiton).to.deep.equal({ valid: false, reason: messages.ERR_CHALLENGE_REQUEST_ID_NOT_DERIVED_FROM_SIGNATURE });
@@ -371,7 +363,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             const challengeAnswerPubsubMsg = await new Promise<DecryptedChallengeAnswerMessageType>((resolve) =>
                 comment.once("challengeanswer", resolve)
             );
-            const challengeAnswerPubsubMsgNoExtraProps = remeda.omit(challengeAnswerPubsubMsg, ["challengeAnswers"]);
+            const challengeAnswerPubsubMsgNoExtraProps = omit(challengeAnswerPubsubMsg, ["challengeAnswers"]);
             const verificaiton = await verifyChallengeAnswer({
                 answer: challengeAnswerPubsubMsgNoExtraProps,
                 validateTimestampRange: false
@@ -457,7 +449,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     (exchange) => exchange.challengeAnswer
                 )!.challengeAnswer!;
 
-                const challengeAnswerToModify = remeda.omit(challengeAnswersPubsubMessage, ["challengeAnswers"]);
+                const challengeAnswerToModify = omit(challengeAnswersPubsubMessage, ["challengeAnswers"]);
                 challengeAnswerToModify.encrypted = await encryptEd25519AesGcm(
                     JSON.stringify({}),
                     pubsubSigner.privateKey,
@@ -555,7 +547,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
 
         it(`valid challengeverification fixture from previous version can be validated`, async () => {
             const challengeVerification = parsePubsubMsgFixture(
-                remeda.clone(validChallengeVerificationFixture)
+                clone(validChallengeVerificationFixture)
             ) as unknown as ChallengeVerificationMessageType;
             const verificaiton = await verifyChallengeVerification({
                 verification: challengeVerification,
@@ -575,7 +567,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             const challengeVerification = await new Promise<DecryptedChallengeVerificationMessageType>((resolve) =>
                 comment.once("challengeverification", resolve)
             );
-            const challengeVerificationNoExtraProps = remeda.omit(challengeVerification, ["comment", "commentUpdate"]);
+            const challengeVerificationNoExtraProps = omit(challengeVerification, ["comment", "commentUpdate"]);
             const verification = await verifyChallengeVerification({
                 verification: challengeVerificationNoExtraProps,
                 pubsubTopic: signers[0].address,
@@ -585,7 +577,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
         });
         it(`Invalid challengeverification gets invalidated correctly`, async () => {
             const challengeVerification = parsePubsubMsgFixture(
-                remeda.clone(validChallengeVerificationFixture)
+                clone(validChallengeVerificationFixture)
             ) as unknown as ChallengeVerificationMessageType;
             challengeVerification.timestamp -= 1234; // Invalidate signature
             const verificaiton = await verifyChallengeVerification({

--- a/test/node-and-browser/signatures/vote.test.ts
+++ b/test/node-and-browser/signatures/vote.test.ts
@@ -4,7 +4,7 @@ import { mockPKCNoDataPathWithOnlyKuboClient } from "../../../dist/node/test/tes
 import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
 import { messages } from "../../../dist/node/errors.js";
 import { verifyVote, signVote } from "../../../dist/node/signer/signatures.js";
-import * as remeda from "remeda";
+import { clone, omit } from "remeda";
 import { timestamp } from "../../../dist/node/util.js";
 import validVoteFixture from "../../fixtures/valid_vote.json" with { type: "json" };
 
@@ -38,7 +38,7 @@ describe.concurrent("Sign Vote", async () => {
 
     it(`Can sign and validate Vote correctly`, async () => {
         const verification = await verifyVote({
-            vote: { ...remeda.omit(voteProps, ["communityAddress"]), signature: voteSignature } as VotePubsubMessagePublication,
+            vote: { ...omit(voteProps, ["communityAddress"]), signature: voteSignature } as VotePubsubMessagePublication,
             resolveAuthorNames: pkc.resolveAuthorNames,
             clientsManager: pkc._clientsManager
         });
@@ -46,7 +46,7 @@ describe.concurrent("Sign Vote", async () => {
     });
 
     it(`signVote throws with author.name not being a domain`, async () => {
-        const cloneVote = remeda.clone(voteProps);
+        const cloneVote = clone(voteProps);
         cloneVote.author = { name: "gibbreish" };
         try {
             await signVote({ vote: { ...cloneVote, signer: signers[7] }, pkc: pkc });
@@ -57,7 +57,7 @@ describe.concurrent("Sign Vote", async () => {
     });
     it(`signVote allows author to be omitted`, async () => {
         const signature = await signVote({
-            vote: { ...remeda.omit(voteProps, ["author"]), signer: signers[7] } as VoteOptionsToSign,
+            vote: { ...omit(voteProps, ["author"]), signer: signers[7] } as VoteOptionsToSign,
             pkc: pkc
         });
         expect(signature.publicKey).to.equal(signers[7].publicKey);
@@ -76,7 +76,7 @@ describeSkipIfRpc.concurrent("Verify vote", async () => {
     });
 
     it(`Valid vote signature fixture is validated correctly`, async () => {
-        const vote = remeda.clone(validVoteFixture) as unknown as VotePubsubMessagePublication;
+        const vote = clone(validVoteFixture) as unknown as VotePubsubMessagePublication;
         const verification = await verifyVote({
             vote,
             resolveAuthorNames: pkc.resolveAuthorNames,
@@ -86,7 +86,7 @@ describeSkipIfRpc.concurrent("Verify vote", async () => {
     });
 
     it(`Invalid vote signature gets invalidated correctly`, async () => {
-        const vote = remeda.clone(validVoteFixture) as unknown as VotePubsubMessagePublication;
+        const vote = clone(validVoteFixture) as unknown as VotePubsubMessagePublication;
         vote.commentCid += "1234"; // Should invalidate signature
         const verification = await verifyVote({
             vote,
@@ -97,7 +97,7 @@ describeSkipIfRpc.concurrent("Verify vote", async () => {
     });
 
     it(`verifyVote invalidates a vote with tampered author.name`, async () => {
-        const vote = remeda.clone(validVoteFixture) as unknown as VotePubsubMessagePublication;
+        const vote = clone(validVoteFixture) as unknown as VotePubsubMessagePublication;
         vote.author = { ...(vote.author || {}), name: "gibbresish" };
         const verification = await verifyVote({
             vote,
@@ -118,7 +118,7 @@ describeSkipIfRpc.concurrent("Verify vote", async () => {
             signer
         };
         const vote: VotePubsubMessagePublication = {
-            ...remeda.omit(voteToSign, ["signer", "communityAddress"]),
+            ...omit(voteToSign, ["signer", "communityAddress"]),
             signature: await signVote({ vote: voteToSign, pkc: pkc })
         };
         const verification = await verifyVote({

--- a/test/node/comment/post/pages.posts.test.ts
+++ b/test/node/comment/post/pages.posts.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../dist/node/test/test-util.js";
 import { POSTS_SORT_TYPES } from "../../../../dist/node/pages/util.js";
 import { testPageCommentsIfSortedCorrectly } from "../../../node-and-browser/pages/pages-test-util.js";
-import * as remeda from "remeda";
+import { groupBy } from "remeda";
 import { of as calculateIpfsHash } from "typestub-ipfs-only-hash";
 import { describe, it, beforeAll, afterAll } from "vitest";
 import type { PKC } from "../../../../dist/node/pkc/pkc.js";
@@ -120,7 +120,7 @@ describe("local community.posts pagination coverage", () => {
                     )) as CommentWithinRepliesPostsPageJson[];
                 }
                 expect(Object.keys(subPostsBySortName)).to.not.be.empty;
-                const pagesByTimeframe = remeda.groupBy(
+                const pagesByTimeframe = groupBy(
                     Object.entries(POSTS_SORT_TYPES),
                     ([_, sort]) => (sort as { timeframe?: string }).timeframe ?? "none"
                 );

--- a/test/node/community/create.community.test.ts
+++ b/test/node/community/create.community.test.ts
@@ -20,7 +20,7 @@ import type { CreatePKCWsServerOptions } from "../../../dist/node/rpc/src/types.
 
 import { stringify as deterministicStringify } from "safe-stable-stringify";
 
-import * as remeda from "remeda";
+import { omit, pick } from "remeda";
 
 import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
 import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
@@ -44,7 +44,7 @@ describe(`pkc.createCommunity (local)`, async () => {
         const newCommunity = (await pkc.createCommunity(communityArgs)) as LocalCommunity | RpcLocalCommunity;
         if (!("signer" in communityArgs))
             // signer shape changes after createCommunity
-            expect(remeda.pick(newCommunity, Object.keys(communityArgs) as (keyof typeof communityArgs)[])).to.deep.equal(communityArgs); // the args should exist after creating immedietely
+            expect(pick(newCommunity, Object.keys(communityArgs) as (keyof typeof communityArgs)[])).to.deep.equal(communityArgs); // the args should exist after creating immedietely
         await newCommunity.start();
         await resolveWhenConditionIsTrue({ toUpdate: newCommunity, predicate: async () => typeof newCommunity.updatedAt === "number" });
         await newCommunity.stop();
@@ -132,8 +132,8 @@ describe(`pkc.createCommunity (local)`, async () => {
         const clonedCommunity = (await pkc.createCommunity(community)) as LocalCommunity | RpcLocalCommunity;
         expect(clonedCommunity.posts).to.be.a("object");
         const internalProps = ["clients", "state", "startedState"] as const;
-        const clonedCommunityJson = JSON.parse(JSON.stringify(remeda.omit(clonedCommunity, internalProps)));
-        const localCommunityJson = JSON.parse(JSON.stringify(remeda.omit(community, internalProps)));
+        const clonedCommunityJson = JSON.parse(JSON.stringify(omit(clonedCommunity, internalProps)));
+        const localCommunityJson = JSON.parse(JSON.stringify(omit(community, internalProps)));
         delete clonedCommunityJson["raw"]["localCommunity"];
         delete localCommunityJson["raw"]["localCommunity"];
         expect(localCommunityJson).to.deep.equal(clonedCommunityJson);

--- a/test/node/community/edit.community.test.ts
+++ b/test/node/community/edit.community.test.ts
@@ -17,7 +17,7 @@ import { timestamp } from "../../../dist/node/util.js";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
 import fs from "fs";
 import path from "path";
-import * as remeda from "remeda";
+import { isDeepEqual, pick } from "remeda";
 
 import { v4 as uuidV4 } from "uuid";
 
@@ -364,12 +364,12 @@ describeSkipIfRpc(`Concurrency with community.edit`, async () => {
             const editKeys = Object.keys(editArgs) as (keyof CommunityEditOptions)[];
 
             const hasLatestEditProps = (community: LocalCommunity | RpcLocalCommunity): boolean => {
-                const picked = remeda.pick(community, editKeys);
-                return remeda.isDeepEqual(picked, editArgs as typeof picked);
+                const picked = pick(community, editKeys);
+                return isDeepEqual(picked, editArgs as typeof picked);
             };
 
             const expectSubToHaveLatestEditProps = (community: LocalCommunity | RpcLocalCommunity) => {
-                expect(remeda.pick(community, editKeys)).to.deep.equal(editArgs);
+                expect(pick(community, editKeys)).to.deep.equal(editArgs);
             };
 
             const updatingCommunity = (await pkc.createCommunity({ address: startedCommunity.address })) as
@@ -433,8 +433,8 @@ describeSkipIfRpc(`Concurrency with community.edit`, async () => {
                 | LocalCommunity
                 | RpcLocalCommunity;
             updatingCommunity.on("update", () => {
-                const picked = remeda.pick(updatingCommunity, editKeys);
-                if (remeda.isDeepEqual(picked, editArgs as typeof picked)) editIsFinished = true; // there's a case where the edit is finished and update is emitted before we get to update editIsFinished
+                const picked = pick(updatingCommunity, editKeys);
+                if (isDeepEqual(picked, editArgs as typeof picked)) editIsFinished = true; // there's a case where the edit is finished and update is emitted before we get to update editIsFinished
             });
 
             expect(updatingCommunity.signer).to.be.a("object");
@@ -448,8 +448,8 @@ describeSkipIfRpc(`Concurrency with community.edit`, async () => {
             await startedCommunity.start();
 
             startedCommunity.on("update", () => {
-                const picked = remeda.pick(startedCommunity, editKeys);
-                if (remeda.isDeepEqual(picked, editArgs as typeof picked)) editIsFinished = true; // there's a case where the edit is finished and update is emitted before we get to update editIsFinished
+                const picked = pick(startedCommunity, editKeys);
+                if (isDeepEqual(picked, editArgs as typeof picked)) editIsFinished = true; // there's a case where the edit is finished and update is emitted before we get to update editIsFinished
             });
 
             expect(startedCommunity.title).to.equal(communityTitle);
@@ -472,8 +472,8 @@ describeSkipIfRpc(`Concurrency with community.edit`, async () => {
                 | LocalCommunity
                 | RpcLocalCommunity;
             await editedCommunity.edit(editArgs); // it should be sent to the started community
-            expect(remeda.pick(editedCommunity, editKeys)).to.deep.equal(editArgs);
-            expect(remeda.pick(startedCommunity, editKeys)).to.deep.equal(editArgs);
+            expect(pick(editedCommunity, editKeys)).to.deep.equal(editArgs);
+            expect(pick(startedCommunity, editKeys)).to.deep.equal(editArgs);
 
             editIsFinished = true;
             expect(editedCommunity.title).to.equal(communityTitle);
@@ -487,8 +487,8 @@ describeSkipIfRpc(`Concurrency with community.edit`, async () => {
             console.log("wait for community update");
             await updateEventPromise;
 
-            expect(remeda.pick(editedCommunity, editKeys)).to.deep.equal(editArgs);
-            expect(remeda.pick(startedCommunity, editKeys)).to.deep.equal(editArgs); // this fails
+            expect(pick(editedCommunity, editKeys)).to.deep.equal(editArgs);
+            expect(pick(startedCommunity, editKeys)).to.deep.equal(editArgs); // this fails
 
             expect(updatingCommunity.title).to.equal(communityTitle);
             for (const [editKey, editValue] of Object.entries(editArgs))
@@ -510,9 +510,9 @@ describeSkipIfRpc(`Concurrency with community.edit`, async () => {
                 );
             }
 
-            expect(remeda.pick(startedCommunity, editKeys)).to.deep.equal(editArgs);
+            expect(pick(startedCommunity, editKeys)).to.deep.equal(editArgs);
             await startedCommunity.stop();
-            expect(remeda.pick(startedCommunity, editKeys)).to.deep.equal(editArgs);
+            expect(pick(startedCommunity, editKeys)).to.deep.equal(editArgs);
 
             expect(communityInstance.rules).to.equal(undefined); // community is not updating, started or editing so it has no way to get the rules
 

--- a/test/node/community/page-generation/edgecases.page.generation.community.test.ts
+++ b/test/node/community/page-generation/edgecases.page.generation.community.test.ts
@@ -3,7 +3,7 @@ import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
 import { it, vi } from "vitest";
 import { of as calculateIpfsCidV0Lib } from "typestub-ipfs-only-hash";
 import { randomUUID } from "node:crypto";
-import * as remeda from "remeda";
+import { omit } from "remeda";
 import { cleanUpBeforePublishing } from "../../../../dist/node/signer/signatures.js";
 import { calculateExpectedSignatureSize } from "../../../../dist/node/runtime/node/util.js";
 import { calculateStringSizeSameAsIpfsAddCidV0, timestamp } from "../../../../dist/node/util.js";
@@ -523,7 +523,7 @@ async function calculateAvailablePostsSizeForCommunity(community: LocalCommunity
     const updatedAt = timestamp();
 
     const baseCommunity = cleanUpBeforePublishing({
-        ...remeda.omit(community._toJSONIpfsBaseNoPosts(), ["signature"]),
+        ...omit(community._toJSONIpfsBaseNoPosts(), ["signature"]),
         lastPostCid: latestPost?.cid,
         lastCommentCid: latestComment?.cid,
         statsCid,

--- a/test/node/community/purge-reserved-fields.db.community.test.ts
+++ b/test/node/community/purge-reserved-fields.db.community.test.ts
@@ -6,7 +6,7 @@ import type { JsonSignature } from "../../../dist/node/signer/types.js";
 import type { CommentsTableRowInsert } from "../../../dist/node/publications/comment/types.js";
 import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
 import type { PurgedCommentTableRows } from "../../../dist/node/runtime/node/community/db-handler-types.js";
-import * as remeda from "remeda";
+import { intersection } from "remeda";
 
 interface FakeCommunity {
     address: string;
@@ -122,7 +122,7 @@ describe(`_purgeCommentsWithInvalidSchemaOrSignature constructs CommentIpfs corr
         // which includes DB-only fields that are in CommentIpfsReservedFields
         const buggyObject = { ...commentRecord, ...commentRecord.extraProps };
         const buggyKeys = Object.keys(buggyObject);
-        const reservedFieldsInBuggyObject = remeda.intersection(buggyKeys, [...CommentIpfsReservedFields]);
+        const reservedFieldsInBuggyObject = intersection(buggyKeys, [...CommentIpfsReservedFields]);
 
         // This SHOULD be empty but ISN'T due to the bug
         expect(
@@ -133,7 +133,7 @@ describe(`_purgeCommentsWithInvalidSchemaOrSignature constructs CommentIpfs corr
         // FIX: deriveCommentIpfsFromCommentTableRow correctly extracts only CommentIpfs fields
         const fixedObject = deriveCommentIpfsFromCommentTableRow(commentRecord);
         const fixedKeys = Object.keys(fixedObject);
-        const reservedFieldsInFixedObject = remeda.intersection(fixedKeys, [...CommentIpfsReservedFields]);
+        const reservedFieldsInFixedObject = intersection(fixedKeys, [...CommentIpfsReservedFields]);
 
         expect(reservedFieldsInFixedObject, `deriveCommentIpfsFromCommentTableRow should not include any reserved fields`).toEqual([]);
     });

--- a/test/node/pkc/validatecomment.pkc.test.ts
+++ b/test/node/pkc/validatecomment.pkc.test.ts
@@ -12,7 +12,7 @@ import type { CommentIpfsWithCidDefined } from "../../../dist/node/publications/
 import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
 import { PKCError } from "../../../dist/node/pkc-error.js";
 import signers from "../../fixtures/signers.js";
-import * as remeda from "remeda";
+import { clone as remedaClone } from "remeda";
 import pRetry from "p-retry";
 import { describe, beforeAll, afterAll, beforeEach, afterEach, it } from "vitest";
 import type { PKC } from "../../../dist/node/pkc/pkc.js";
@@ -36,7 +36,7 @@ const cloneCommentInstance = (source: Comment): Comment => {
     const clone = proto ? Object.assign(Object.create(proto), source) : { ...source };
     if (typeof clone.toJSON === "function") {
         // shallow clone for nested refs; tests mutate only top-level props
-        clone.raw = remeda.clone(source.raw);
+        clone.raw = remedaClone(source.raw);
     } else {
         clone.raw = JSON.parse(JSON.stringify(source.raw));
     }
@@ -164,7 +164,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
 
             it("should validate a valid Post pageComment object (validateReplies=false)", async () => {
                 try {
-                    await remotePKC.validateComment(remeda.clone(postPageComment), { validateReplies: false });
+                    await remotePKC.validateComment(remedaClone(postPageComment), { validateReplies: false });
                 } catch (e) {
                     expect.fail(`Expected promise to fulfill, but it rejected with: ${e}`);
                 }
@@ -172,7 +172,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
 
             it("should validate a valid Post pageComment object (validateReplies=true)", async () => {
                 try {
-                    await remotePKC.validateComment(remeda.clone(postPageComment), { validateReplies: true });
+                    await remotePKC.validateComment(remedaClone(postPageComment), { validateReplies: true });
                 } catch (e) {
                     expect.fail(`Expected promise to fulfill, but it rejected with: ${e}`);
                 }
@@ -181,7 +181,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
             // --- Tests for Reply Page Comment (from Flat Page) ---
             it("should validate a valid Reply pageComment object from flat page (validateReplies=undefined)", async () => {
                 try {
-                    await remotePKC.validateComment(remeda.clone(replyFromFlatPage));
+                    await remotePKC.validateComment(remedaClone(replyFromFlatPage));
                 } catch (e) {
                     expect.fail(`Expected promise to fulfill for replyFromFlatPage, but it rejected with: ${e}`);
                 }
@@ -189,7 +189,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
 
             it("should validate a valid Reply pageComment object from flat page (validateReplies=false)", async () => {
                 try {
-                    await remotePKC.validateComment(remeda.clone(replyFromFlatPage), { validateReplies: false });
+                    await remotePKC.validateComment(remedaClone(replyFromFlatPage), { validateReplies: false });
                 } catch (e) {
                     expect.fail(`Expected promise to fulfill for replyFromFlatPage, but it rejected with: ${e}`);
                 }
@@ -198,7 +198,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
             it("should validate a valid Reply pageComment object from flat page (validateReplies=true)", async () => {
                 // Since this reply might itself have replies (even though fetched via flat page), validating them is valid
                 try {
-                    await remotePKC.validateComment(remeda.clone(replyFromFlatPage), { validateReplies: true });
+                    await remotePKC.validateComment(remedaClone(replyFromFlatPage), { validateReplies: true });
                 } catch (e) {
                     expect.fail(`Expected promise to fulfill for replyFromFlatPage, but it rejected with: ${e}`);
                 }
@@ -207,7 +207,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
             // --- Tests for Reply Page Comment (from Best Page) ---
             it("should validate a valid Reply pageComment object from best page (validateReplies=undefined)", async () => {
                 try {
-                    await remotePKC.validateComment(remeda.clone(replyFromBestPage));
+                    await remotePKC.validateComment(remedaClone(replyFromBestPage));
                 } catch (e) {
                     expect.fail(`Expected promise to fulfill for replyFromBestPage, but it rejected with: ${e}`);
                 }
@@ -215,7 +215,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
 
             it("should validate a valid Reply pageComment object from best page (validateReplies=false)", async () => {
                 try {
-                    await remotePKC.validateComment(remeda.clone(replyFromBestPage), { validateReplies: false });
+                    await remotePKC.validateComment(remedaClone(replyFromBestPage), { validateReplies: false });
                 } catch (e) {
                     expect.fail(`Expected promise to fulfill for replyFromBestPage, but it rejected with: ${e}`);
                 }
@@ -224,7 +224,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
             it("should validate a valid Reply pageComment object from best page (validateReplies=true)", async () => {
                 // Since this reply might itself have replies, validating them is valid
                 try {
-                    await remotePKC.validateComment(remeda.clone(replyFromBestPage), { validateReplies: true });
+                    await remotePKC.validateComment(remedaClone(replyFromBestPage), { validateReplies: true });
                 } catch (e) {
                     expect.fail(`Expected promise to fulfill for replyFromBestPage, but it rejected with: ${e}`);
                 }
@@ -261,7 +261,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
                 let invalidComment: Comment | undefined;
                 try {
                     invalidComment = await pkc.createComment(sourcePostCommentInstance); // Use source
-                    invalidComment.raw.comment = remeda.clone(invalidComment.raw.comment);
+                    invalidComment.raw.comment = remedaClone(invalidComment.raw.comment);
                     invalidComment.raw.comment!.signature.signature += "invalid";
                     await pkc.validateComment(invalidComment);
                     expect.fail("Expected promise to reject, but it fulfilled.");
@@ -277,7 +277,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
                 let invalidComment: Comment | undefined;
                 try {
                     invalidComment = await pkc.createComment(sourcePostCommentInstance); // Use source
-                    const tamperedUpdate = remeda.clone(invalidComment.raw.commentUpdate);
+                    const tamperedUpdate = remedaClone(invalidComment.raw.commentUpdate);
                     tamperedUpdate!.signature.signature += "invalid"; // Tamper signature directly
                     invalidComment.raw.commentUpdate = tamperedUpdate;
                     await pkc.validateComment(invalidComment);
@@ -293,7 +293,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
             it("should reject Post instance if CommentIpfs data is missing", async () => {
                 let invalidComment: Comment | undefined;
                 try {
-                    invalidComment = await pkc.createComment(remeda.clone(sourcePostCommentInstance)); // Use source
+                    invalidComment = await pkc.createComment(remedaClone(sourcePostCommentInstance)); // Use source
                     invalidComment.raw.comment = undefined;
                     await pkc.validateComment(invalidComment);
                     expect.fail("Expected promise to reject, but it fulfilled.");
@@ -379,7 +379,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
             // --- Invalid Post Page Comment Tests ---
             it("should reject Post pageComment if comment signature is invalid", async () => {
                 try {
-                    const invalidPageComment = remeda.clone(postPageComment);
+                    const invalidPageComment = remedaClone(postPageComment);
                     invalidPageComment.raw.comment.signature.signature += "invalid";
                     await pkc.validateComment(invalidPageComment);
                     expect.fail("Expected promise to reject, but it fulfilled.");
@@ -391,8 +391,8 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
 
             it("should reject Post pageComment if commentUpdate signature is invalid", async () => {
                 try {
-                    const invalidPageComment = remeda.clone(postPageComment);
-                    invalidPageComment.raw.commentUpdate = remeda.clone(invalidPageComment.raw.commentUpdate);
+                    const invalidPageComment = remedaClone(postPageComment);
+                    invalidPageComment.raw.commentUpdate = remedaClone(invalidPageComment.raw.commentUpdate);
                     invalidPageComment.raw.commentUpdate.signature.signature += "invalid";
                     await pkc.validateComment(invalidPageComment);
                     expect.fail("Expected promise to reject, but it fulfilled.");
@@ -404,7 +404,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
 
             it("should reject Post pageComment if comment data is missing", async () => {
                 try {
-                    const invalidPageComment = remeda.clone(postPageComment);
+                    const invalidPageComment = remedaClone(postPageComment);
                     (invalidPageComment.raw as { comment: undefined }).comment = undefined;
                     await pkc.validateComment(invalidPageComment);
                     expect.fail("Expected promise to reject, but it fulfilled.");
@@ -416,7 +416,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
 
             it("should reject Post pageComment if commentUpdate data is missing", async () => {
                 try {
-                    const invalidPageComment = remeda.clone(postPageComment);
+                    const invalidPageComment = remedaClone(postPageComment);
                     (invalidPageComment.raw as { commentUpdate: undefined }).commentUpdate = undefined;
                     await pkc.validateComment(invalidPageComment);
                     expect.fail("Expected promise to reject, but it fulfilled.");
@@ -428,7 +428,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
 
             it("should reject Post pageComment if commentUpdate.cid is missing", async () => {
                 try {
-                    const invalidPageComment = remeda.clone(postPageComment);
+                    const invalidPageComment = remedaClone(postPageComment);
                     invalidPageComment.raw.commentUpdate.cid = undefined!;
                     invalidPageComment.cid = undefined!;
                     await pkc.validateComment(invalidPageComment);
@@ -441,7 +441,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
 
             it("should reject Post pageComment if postCid is missing", async () => {
                 try {
-                    const invalidPageComment = remeda.clone(postPageComment);
+                    const invalidPageComment = remedaClone(postPageComment);
                     invalidPageComment.postCid = undefined!;
                     await pkc.validateComment(invalidPageComment);
                     expect.fail("Expected promise to reject, but it fulfilled.");
@@ -468,7 +468,7 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
         });
 
         it("should validate a page comment parsed from an old-format wire record", async () => {
-            const pageJson = parsePageIpfs(remeda.clone(legacyPageIpfsFixture) as PageIpfs);
+            const pageJson = parsePageIpfs(remedaClone(legacyPageIpfsFixture) as PageIpfs);
             const firstComment = pageJson.comments[0];
             // The fixture uses an IPNS-key subplebbitAddress (not a domain), so the page parser
             // should derive communityPublicKey from it while communityName stays undefined

--- a/test/node/pkc/validatecomment.pkc.test.ts
+++ b/test/node/pkc/validatecomment.pkc.test.ts
@@ -293,7 +293,12 @@ getAvailablePKCConfigsToTestAgainst({ includeAllPossibleConfigOnEnv: true }).map
             it("should reject Post instance if CommentIpfs data is missing", async () => {
                 let invalidComment: Comment | undefined;
                 try {
-                    invalidComment = await pkc.createComment(remedaClone(sourcePostCommentInstance)); // Use source
+                    // Spread the source into a plain object rather than remeda-cloning the class instance:
+                    // remeda v2's clone() delegates to structuredClone() for class instances, which throws
+                    // DataCloneError on a Comment (it holds functions/EventEmitter internals). The spread keeps
+                    // the own enumerable props (incl. .raw), and createComment() builds a fresh instance from it,
+                    // so nulling raw.comment below cannot corrupt the shared sourcePostCommentInstance.
+                    invalidComment = await pkc.createComment({ ...sourcePostCommentInstance } as Comment);
                     invalidComment.raw.comment = undefined;
                     await pkc.validateComment(invalidComment);
                     expect.fail("Expected promise to reject, but it fulfilled.");


### PR DESCRIPTION
Follow-up to the import-performance work (#120 / #178). Tackles the remeda step written up in #178.

## Problem

Every module did `import * as remeda from "remeda"`, and a namespace import cannot be tree-shaken, so all **164** of remeda's per-function modules landed in every static import closure — ~53% of the slim `./client` entry's 309 modules (#178).

remeda **v1 does not tree-shake even with named imports**: its `export *` barrel plus the TypeScript namespace-merge `.strict` IIFE pattern defeat rolldown. Verified with a throwaway rolldown build — named imports of a handful of functions still pulled all 164 modules. (A re-export barrel was tried in #178 and also gave zero reduction.)

remeda **v2** tree-shakes cleanly (10 modules for a 5-function import in the throwaway build), so this bumps remeda to `^2.39.0` and converts every `import * as remeda` site in `src/` (49 files) and `test/` (31 files) to specific named imports (`remeda.pick` → `pick`).

## Result

- `./client` static closure: **309 → 167 modules** (remeda 164 → 22)
- `.` index static closure: remeda **164 → 32 modules**
- Wall-clock is modest (remeda's per-module link cost is tiny). On the slow prod host (Node v22.22.2, medians of 6 warm runs): `./client` import ~1274ms → ~1218ms (~4-5%); the full `.` index entry moved within noise (~2049ms → ~2021ms). The win is the much smaller module graph, a prerequisite for pushing `./client` toward sub-second.

## v2 API migration

- `.strict` variants removed (strict is the default): `keys.strict`/`fromEntries.strict`/`sortBy.strict`/`groupBy.strict` drop `.strict`; `isDefined.strict` (null+undefined) → `isNonNullish`
- `maxBy(a, fn)` → `firstBy(a, [fn, "desc"])`, `minBy(a, fn)` → `firstBy(a, fn)`
- `flatten`/`flattenDeep` → `flat`
- `unique<T>`/`difference<T>` type param is the container in v2 — dropped
- `keysToOmitFromSignedPropertyNames` is now an `as const` tuple: v2's `omit`/`pick` type key params as `const Keys extends readonly ...`, so a plain array leaked keys into the derived zod `.pick()` schema types
- explicit annotations/casts where v2's `PickFromArray`/`EnumeratedPartial` branded return types replaced clean `Pick`/`Omit` (remote-community, rpc-local-community, signatures, util)

### Runtime behavior change caught in testing (2nd commit)

**v2's `difference` is multiset** (removes each `other` element once) where v1's was set-based (removes all matches). The `*ReservedFields` lists concatenate keys from several schemas plus literals, so a field appearing twice in the candidate list **and** signed (present in the pubsub schema) survived as reserved — `CommentModerationReservedFields` regained commentModeration/communityPublicKey/communityName and `VotePubsubReservedFields` regained `vote`, which made every moderation and vote publication fail challenge verification with "has a reserved field". Fixed by wrapping the affected candidate lists in `unique()` (matching the guard comment-edit's list already had), plus the two runtime set-difference sites (cids-to-unpin, deleted-communities). `intersection` is also multiset in v2 but every call site is a `.length > 0` membership check, so it is unaffected.

Local-name collisions were handled by aliasing only the 3 genuine ones (pages/util `keys`, db-handler `entries`, validatecomment `clone`).

## Validation

- `npm run build` (tsc + rolldown bundle) and `config/verify-bundle.js` pass; `npx tsc --project test/tsconfig.json --noEmit` passes
- `scripts/smoke-pack-install.js` passes (pack + install + createCommunity lifecycle, incl. inlined-deps-hidden pass)
- Suites: `pkc` (local-kubo-rpc + remote-pkc-rpc), `rpc.errors` (USE_RPC), `pkc-ws-server` all 22 methods (comment/vote/moderation/edit publishing), `ban-then-purge` moderation, vote upvote + backward-compat, comment-edit backward-compat — all green
- Empirically diffed every `*ReservedFields`/`*SignedPropertyNames` export between the v1 and v2 builds; membership is identical after the `unique()` fix
- Prod-measured on new-plebbit (deployed to a scratch install, measured, restored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved import-time and startup performance by upgrading the utility library and reducing bundled module counts.
  * Reduced loaded code for core client and community workflows.

* **Bug Fixes**
  * Improved signed record field handling and reserved-field checks, including updates to key-set/deduplication behavior to avoid incorrect results when fields repeat.

* **Documentation**
  * Added performance and compatibility notes for the utility-library upgrade, including API/migration details and observed import-time improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->