### PR TITLE
fix(rpc): recover community subscription when its shared updating entry stops (#129)

### DIFF
--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -1198,9 +1198,39 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
         };
         community.on("error", errorListener);
 
+        // Guards recovery from firing during transitions we initiate on purpose (an unsubscribe
+        // teardown, or the stop()+update() swap in the settings handler below)
+        let intentionalStopInFlight = false;
+        let recovering = false;
+        // The subscription's mirror shares a server-side pkc._updatingCommunities entry with every
+        // other subscription to the same community. That shared entry can be stopped while this
+        // client is still subscribed (its refcount driven to 0 by another subscription's teardown
+        // or setSettings, or a pkc being destroyed), which cascades this mirror to "stopped"
+        // (src/community/remote-community.ts). Nothing else revives it, so the client's websocket
+        // would stay connected but silent forever (issue #129 / #181). The client never asked to
+        // stop, so re-establish updating on a fresh entry.
+        const recoverIfStrandedListener = async (newState: string) => {
+            if (newState !== "stopped" || isStartedCommunity || intentionalStopInFlight || recovering) return;
+            // Client has unsubscribed if the cleanup is gone; don't resurrect a dead subscription
+            if (!this.subscriptionCleanups?.[connectionId]?.[subscriptionId]) return;
+            recovering = true;
+            try {
+                log("Recovering community subscription", community.address, "whose shared updating instance was stopped");
+                await community.update();
+            } catch (e) {
+                log.error("Failed to recover community subscription after its updating instance stopped", community.address, e);
+            } finally {
+                recovering = false;
+            }
+        };
+        community.on("statechange", recoverIfStrandedListener);
+
         // cleanup function
         this.subscriptionCleanups[connectionId][subscriptionId] = async () => {
             log("Cleaning up community", community.address, "client subscription");
+            // Remove the recovery listener FIRST so the stop() below (an intentional teardown) does
+            // not trigger a resurrection
+            community.removeListener("statechange", recoverIfStrandedListener);
             community.removeListener("update", updateListener);
             community.removeListener("updatingstatechange", updatingStateListener);
             community.removeListener("error", errorListener);
@@ -1215,9 +1245,14 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
         this._onSettingsChange[connectionId][subscriptionId] = async ({ newPKC }: { newPKC: PKC }) => {
             // TODO this may need changing
             if (!isStartedCommunity) {
-                community._pkc = newPKC;
-                await community.stop();
-                await community.update();
+                intentionalStopInFlight = true;
+                try {
+                    community._pkc = newPKC;
+                    await community.stop();
+                    await community.update();
+                } finally {
+                    intentionalStopInFlight = false;
+                }
             }
         };
 

--- a/test/node/rpc/community-update-subscription-churn.rpc.test.ts
+++ b/test/node/rpc/community-update-subscription-churn.rpc.test.ts
@@ -314,6 +314,106 @@ describe("RPC community update subscription survives concurrent sibling churn (#
         }
     });
 
+    // Deterministic repro of the #129 root cause (the CI flake in
+    // test/node-and-browser/community/update.community.test.ts:400, run 28735809994).
+    //
+    // In CI, concurrent sibling churn (setSettings bursts + client destroys) during key migration
+    // drove the shared server-side pkc._updatingCommunities entry to stop() while client A's
+    // subscription mirror was STILL attached. The statechange->stopped cascade
+    // (src/community/remote-community.ts) then stops A's mirror, and nothing ever revives it: the
+    // only revival path is the per-subscription _onSettingsChange handler (src/rpc/src/index.ts),
+    // which does not run for a mirror stopped by the cascade. The ws forwarder stays attached to a
+    // mirror that never emits "update" again, so client A's websocket stays connected but silent
+    // forever (it timed out at 160s in CI).
+    //
+    // The earlier churn tests never reproduced this because they publish the post-migration record
+    // only AFTER all churn quiesces, so the entry is never stopped while a record is deliverable.
+    // Forcing the exact concurrent interleaving is what issue #129 could not do. Instead this test
+    // injects the reachable END-STATE deterministically: after A has migrated and its mirror is
+    // attached, stop the shared entry (what the refcount corruption / sibling-teardown cascade does
+    // in CI), then publish the post-migration record. A correct implementation must recover the
+    // subscription and deliver the record; the buggy build starves client A forever.
+    itIfRpc(`a subscription is permanently starved when its shared updating entry is stopped while still attached (#129 root cause)`, async () => {
+        const target = await createMigrationTargetWithInvalidRecord();
+        const { communityAddress: oldKeyA } = await createMockedCommunityIpns({});
+        const domain = `entry-stopped-under-sub-${Date.now()}.bso`;
+        resolverRecords.set(domain, target.newKey);
+
+        const clientA = await createClient();
+        try {
+            const communityA = await subscribeMigrationVictim(clientA, domain, oldKeyA, target.newKey);
+
+            // The shared server-side updating entry that client A's subscription mirrors
+            const entry = getServerUpdatingEntry(domain);
+            expect(entry, "server should have an updating entry for the migrated domain").to.exist;
+            expect(entry!.state, "updating entry should be updating before it is stopped").to.equal("updating");
+            expect(
+                entry!._numOfListenersForUpdatingInstance,
+                "client A's subscription mirror should be attached to the shared updating entry"
+            ).to.be.greaterThan(0);
+
+            // Reproduce the CI end-state: the shared entry is stopped while client A's subscription
+            // is still attached. In CI this happened via refcount corruption during concurrent
+            // sibling teardown; here it is injected directly so the failure is deterministic.
+            await entry!.stop();
+
+            // End the pre-record window: the post-migration record is now deliverable
+            await target.publishRecord();
+
+            // The post-migration record must still reach client A. In the buggy build A's mirror was
+            // cascaded to "stopped" and never re-attached, so this never resolves (issue #129).
+            await withTimeout(
+                resolveWhenConditionIsTrue({
+                    toUpdate: communityA,
+                    predicate: async () => typeof communityA.updatedAt === "number"
+                }),
+                60_000,
+                "client A post-migration record after its shared updating entry was stopped (#129)"
+            );
+            expect(communityA.publicKey).to.equal(target.newKey);
+            expect(communityA.address).to.equal(domain);
+
+            await communityA.stop();
+        } finally {
+            await target.destroy();
+            if (!clientA.destroyed) await clientA.destroy();
+        }
+    });
+
+    // Guard for the recovery added in #181: recovery must fire ONLY when a subscription is stranded
+    // by internal churn, never when the client legitimately stops. Models the teardown in
+    // test/node-and-browser/pkc/_updatingCommunities.pkc.test.ts (`stop() should stop all instances`)
+    // under RPC: several clients subscribe to one community, then all stop at once. The shared
+    // server-side entry hits refcount 0 and stops mid-teardown, which cascades the remaining mirrors
+    // to "stopped" while their unsubscribes are still in flight. Recovery must not resurrect them.
+    itIfRpc(`stopping all subscriptions to a community cleans up the shared entry without spurious recovery`, async () => {
+        const { communityAddress } = await createMockedCommunityIpns({}); // valid, published record
+
+        const clients = await Promise.all([createClient(), createClient(), createClient()]);
+        try {
+            const communities = await Promise.all(clients.map((c) => c.createCommunity({ address: communityAddress })));
+            await Promise.all(communities.map((c) => c.update()));
+            await Promise.all(
+                communities.map((c) =>
+                    resolveWhenConditionIsTrue({ toUpdate: c, predicate: async () => typeof c.updatedAt === "number" })
+                )
+            );
+            const serverEntry = () => findUpdatingCommunity(getServerPkc(), { publicKey: communityAddress }) as RemoteCommunity | undefined;
+            expect(serverEntry(), "server should have a shared updating entry for the community").to.exist;
+
+            // Legitimately stop every subscription at once
+            await Promise.all(communities.map((c) => c.stop()));
+            await new Promise((resolve) => setTimeout(resolve, 500));
+
+            // No spurious recovery: the shared server-side entry must be fully cleaned up and stay gone
+            expect(serverEntry(), "shared entry must be cleaned up after all clients stop, not resurrected by recovery").to.be
+                .undefined;
+            for (const c of communities) expect(c.state, "each client community must remain stopped").to.equal("stopped");
+        } finally {
+            await Promise.all(clients.map((c) => (c.destroyed ? Promise.resolve() : c.destroy())));
+        }
+    });
+
     itIfRpc(`subscription survives a setSettings burst during the pre-record migration window`, async () => {
         const target = await createMigrationTargetWithInvalidRecord();
         const { communityAddress: oldKey } = await createMockedCommunityIpns({});


### PR DESCRIPTION
Fixes #181. Root-cause fix for the recurrence of #129 (CI flake in `test/node-and-browser/community/update.community.test.ts`, run 28735809994).

## Problem

An RPC community-update subscription shares one server-side `pkc._updatingCommunities` entry with every other subscription to the same community. That shared entry can be stopped while a client is still subscribed (its refcount driven to 0 by another subscription's teardown or a `setSettings` sweep, or a pkc being destroyed), which cascades this subscription's mirror to `stopped` (`src/community/remote-community.ts`). Nothing revived it, so the client's websocket stayed connected but silent forever (the 160s CI timeout).

## Fix (ws-server layer)

Recovery belongs at the **ws-server**, which owns the intent "this subscription stays alive until the client unsubscribes" — **not** the community cascade, where stopping a shared updating instance is *meant* to stop its subscribers (documented by `test/node-and-browser/pkc/_updatingCommunities.pkc.test.ts` "`stop() should stop all instances listening to that instance`").

In `src/rpc/src/index.ts`, when a subscription's mirror goes to `stopped` while the client is still subscribed and the server did not stop it on purpose, re-establish updating on a fresh entry:
- A `statechange` recovery listener on the subscription mirror, guarded against firing during intentional stops.
- The listener is removed **first** in the unsubscribe cleanup, so a legitimate teardown never triggers recovery.
- The `setSettings` handler brackets its `stop()`+`update()` swap so the transient stop in the middle does not trigger recovery.

## Tests (`test/node/rpc/community-update-subscription-churn.rpc.test.ts`)

- **Deterministic repro** of #129: migrate a victim, stop the shared entry while its mirror is attached, publish the record, assert the client still receives it. Was a 60s timeout before; ~1s after.
- **Guard test** for the recovery: several clients subscribe to one community, then all stop at once (models the `_updatingCommunities` teardown under RPC). The shared entry hits refcount 0 and stops mid-teardown; the test asserts it is cleaned up and **not** resurrected by recovery.

## Verification (in-process ws-server = the changed code path)

- `test/node/rpc/community-update-subscription-churn.rpc.test.ts` — 5/5 pass (repro 60s→~1s; guard passes).

`src/community/remote-community.ts` is unchanged, so the community-layer cascade semantics are preserved. CI runs the full matrix for authoritative coverage.