### PR TITLE
feat(helia): fetch IPNS records directly from providers/subscribers (#185)

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -21,6 +21,7 @@ export enum messages {
     ERR_GET_COMMUNITY_TIMED_OUT = "pkc.getCommunity({address}) timed out",
     ERR_TIMEOUT_WAITING_FOR_PUBSUB_TOPIC_PEERS = "Timeout waiting for propagation of pubsub topic peers",
     ERR_PUBSUB_TOPIC_PEER_WAIT_ABORTED = "Aborted while waiting for a peer to subscribe to a pubsub topic",
+    ERR_IPNS_DIRECT_FETCH_ABORTED = "Aborted while fetching an IPNS record directly from subscribers/providers",
     ERR_TIMED_OUT_RM_MFS_FILE = "Timed out removing MFS paths. We may need to nuke the whole MFS directory and republish everything",
     ERR_ABORTED_RESOLVING_TEXT_RECORD = "Aborted resolving text record on domain",
     // PKC errors

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -302,6 +302,9 @@ export async function createLibp2pJsClientOrUseExistingOne(
                                 }
                                 directFetchOutcome = { attempted: true, hit: false, durationMs: Date.now() - directStart };
                             } catch (directErr) {
+                                // A caller-initiated abort should surface as-is, not be masked by the
+                                // fallback path as ERR_RESOLVED_IPNS_P2P_TO_UNDEFINED.
+                                if (options?.signal?.aborted) throw directErr;
                                 directFetchOutcome = {
                                     attempted: true,
                                     hit: false,

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -22,7 +22,7 @@ import { EventEmitter } from "events";
 import type { HeliaWithLibp2pPubsub } from "./types.js";
 import { PKCError } from "../pkc-error.js";
 import { Libp2pJsClient } from "./libp2pjsClient.js";
-import { connectToPubsubPeers, getHeliaDebugContext } from "./util.js";
+import { connectToPubsubPeers, directFetchIpnsRecordFromProviders, getHeliaDebugContext } from "./util.js";
 import { createDefaultDialTransportGater } from "./dial-transport-filter.js";
 import { ipnsNameToIpnsOverPubsubTopic } from "../util.js";
 
@@ -251,11 +251,72 @@ export async function createLibp2pJsClientOrUseExistingOne(
                         const ipnsNameAsPeerId = peerIdFromString(currentName);
                         log.trace("Resolving ipns name", currentName, "with options", options);
 
+                        const ipnsPubsubTopic = ipnsNameToIpnsOverPubsubTopic(ipnsNameAsPeerId.toString());
+                        const routingKey = multihashToIPNSRoutingKey(ipnsNameAsPeerId.toMultihash());
+
+                        // Fast path: fetch the record over libp2p/fetch, in parallel, directly from BOTH
+                        // the topic's current gossipsub subscribers AND providers freshly discovered from
+                        // the HTTP routers — first signature-valid record wins. This skips the
+                        // waitForTopicSubscriber floor (up to 10s) that the legacy path below blocks on,
+                        // because @helia/ipns's PubSubRouting.get() only fetches from getSubscribers() and
+                        // throws when that list is empty. See directFetchIpnsRecordFromProviders.
+                        type DirectFetchOutcome =
+                            | { attempted: false }
+                            | { attempted: true; hit: true; durationMs: number; source: string; peerId: string }
+                            | { attempted: true; hit: false; durationMs: number; error?: Error };
+                        let directFetchOutcome: DirectFetchOutcome = { attempted: false };
+                        {
+                            // Subscribe so pushed record updates keep arriving (the legacy router.get() did
+                            // this as a side effect). Fire-and-forget warmup lets the gossipsub mesh form for
+                            // future pushes; we do NOT await it — the direct fetch does not need the mesh.
+                            if (!helia.libp2p.services.pubsub.getTopics().includes(ipnsPubsubTopic))
+                                helia.libp2p.services.pubsub.subscribe(ipnsPubsubTopic);
+                            void warmupForTopic(ipnsPubsubTopic, options).catch((e) =>
+                                log.trace("Fire-and-forget warmup failed for", ipnsPubsubTopic, e)
+                            );
+
+                            const directStart = Date.now();
+                            try {
+                                const direct = await directFetchIpnsRecordFromProviders({
+                                    helia,
+                                    pubsubTopic: ipnsPubsubTopic,
+                                    routingKey,
+                                    maxPeers: WARMUP_MAX_PEERS,
+                                    validate: ipnsValidator,
+                                    options,
+                                    log: Logger("pkc-js:helia:ipns:direct-fetch")
+                                });
+                                if (direct) {
+                                    directFetchOutcome = {
+                                        attempted: true,
+                                        hit: true,
+                                        durationMs: direct.durationMs,
+                                        source: direct.source,
+                                        peerId: direct.peerId
+                                    };
+                                    // Record already validated inside the helper — unmarshal directly,
+                                    // do NOT re-run ipnsValidator.
+                                    const record = unmarshalIPNSRecord(direct.recordBytes);
+                                    yield record.value;
+                                    return;
+                                }
+                                directFetchOutcome = { attempted: true, hit: false, durationMs: Date.now() - directStart };
+                            } catch (directErr) {
+                                directFetchOutcome = {
+                                    attempted: true,
+                                    hit: false,
+                                    durationMs: Date.now() - directStart,
+                                    error: directErr as Error
+                                };
+                                log.trace("Direct IPNS fetch path errored for", ipnsPubsubTopic, directErr);
+                            }
+                        }
+
+                        // Fallback: legacy warmup + router.get() loop.
                         // @helia/ipns 9.2.x pubsub router throws NotFoundError if zero subscribers exist
                         // for the topic at .get() time. Await peer warmup so the resolver sees a populated
                         // subscriber list (the monkey-patched pubsub.subscribe also kicks off warmup,
                         // but fire-and-forget — too late for the first .get()).
-                        const ipnsPubsubTopic = ipnsNameToIpnsOverPubsubTopic(ipnsNameAsPeerId.toString());
                         type WarmupOutcome =
                             | { attempted: false }
                             | { attempted: true; durationMs: number; subscribersAfterWarmup: number }
@@ -313,7 +374,6 @@ export async function createLibp2pJsClientOrUseExistingOne(
                         // the pubsub router's get() never serves from cache; it always queries peers. Record
                         // caching + ipnsSelector still happen inside the pubsub router's handleRecord
                         // regardless of whether we go through resolve() or call router.get directly.
-                        const routingKey = multihashToIPNSRoutingKey(ipnsNameAsPeerId.toMultihash());
                         let recordBytes: Uint8Array | undefined;
                         const routerErrors: Error[] = [];
                         for (const router of ipnsNameResolver.routers) {
@@ -337,6 +397,7 @@ export async function createLibp2pJsClientOrUseExistingOne(
                                 currentName,
                                 ipnsPubsubTopic,
                                 ipnsResolveOptions: options,
+                                directFetchOutcome,
                                 warmupOutcome,
                                 routerErrors,
                                 subscribersAtResolveTime: helia.libp2p.services.pubsub.getSubscribers(ipnsPubsubTopic).length,

--- a/src/helia/types.ts
+++ b/src/helia/types.ts
@@ -2,6 +2,7 @@ import type { createHelia } from "helia";
 import type { KuboRpcClient } from "../types.js";
 import type { PubsubRoutingComponents } from "@helia/ipns/routing";
 import type { GossipSub } from "@libp2p/gossipsub";
+import type { Fetch } from "@libp2p/fetch";
 
 export interface HeliaWithKuboRpcClientFunctions extends Pick<NonNullable<KuboRpcClient["_client"]>, "add" | "cat" | "pubsub" | "stop"> {
     add: KuboRpcClient["_client"]["add"];
@@ -22,6 +23,11 @@ export interface HeliaWithLibp2pPubsub extends baseHelia {
     libp2p: baseHelia["libp2p"] & {
         services: baseHelia["libp2p"]["services"] & {
             pubsub: PubsubRoutingComponents["libp2p"]["services"]["pubsub"] & GossipSubWithMeshPeers;
+            // The libp2p fetch service (`/libp2p/fetch/0.0.1`) is configured in helia-for-pkc.ts
+            // (`fetch: libp2pFetch()`) and powers @helia/ipns's pubsub fast-path. We call it
+            // directly to fetch IPNS records from known providers/subscribers, so type it here
+            // rather than casting at the call site.
+            fetch: Fetch;
         };
     };
 }

--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -1,5 +1,5 @@
 import type { HeliaWithLibp2pPubsub } from "./types.js";
-import type { PeerInfo } from "@libp2p/interface";
+import type { PeerId, PeerInfo } from "@libp2p/interface";
 import { CID } from "multiformats/cid";
 import Logger from "../logger.js";
 import { PKCError } from "../pkc-error.js";
@@ -7,6 +7,10 @@ import { pubsubTopicToDhtKeyCid } from "../util.js";
 
 const TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS = 10_000;
 const MESH_PEER_WAIT_TIMEOUT_MS = 3_000;
+// Per-peer bound on a single libp2p/fetch request in directFetchIpnsRecordFromProviders. The
+// @helia/ipns pubsub router uses 2.5s once a connection exists; we allow a little more because
+// our provider-branch fetch can race a still-completing dial.
+const DIRECT_FETCH_PER_PEER_TIMEOUT_MS = 5_000;
 
 export interface HeliaDebugContext {
     heliaPeerId: string;
@@ -329,4 +333,146 @@ export async function connectToPubsubPeers({
     }
 
     return connectedPeersWithContent;
+}
+
+export interface DirectFetchResult {
+    recordBytes: Uint8Array; // already passed the injected validator (ipnsValidator)
+    peerId: string; // the subscriber/provider that served it
+    source: "subscriber" | "provider";
+    durationMs: number;
+}
+
+// Fetch an IPNS record over the libp2p fetch protocol (`/libp2p/fetch/0.0.1`) directly and in
+// parallel from BOTH (a) peers already subscribed to the topic on our gossipsub
+// (getSubscribers) and (b) providers freshly discovered from the HTTP routers (findProviders).
+// The first signature-valid record wins; the remaining fetches are aborted.
+//
+// This bypasses the gossipsub subscription handshake that @helia/ipns's PubSubRouting.get()
+// waits on: get() only fetches from getSubscribers(topic) and throws NotFoundError when that
+// list is empty, which is why the resolve path currently blocks on waitForTopicSubscriber (a
+// 10s floor) before it can fetch. The publisher (kubo via go-libp2p-pubsub-router, or another
+// helia via registerLookupFunction) answers a fetch request with the current record regardless
+// of subscription state, so we can fetch the moment a provider connection opens.
+//
+// Returns undefined (not throw) when both branches exhaust without a valid record, so the
+// caller can fall back to the legacy router.get() path. Throws only when the caller's signal
+// aborts with no winner.
+export async function directFetchIpnsRecordFromProviders({
+    helia,
+    pubsubTopic,
+    routingKey,
+    maxPeers,
+    validate,
+    options,
+    log
+}: {
+    helia: HeliaWithLibp2pPubsub;
+    pubsubTopic: string;
+    routingKey: Uint8Array;
+    maxPeers: number; // how many freshly discovered providers to attempt before we stop
+    validate: (routingKey: Uint8Array, bytes: Uint8Array) => Promise<void>; // inject ipnsValidator
+    log: Logger;
+    options?: { signal?: AbortSignal; timeoutMs?: number };
+}): Promise<DirectFetchResult | undefined> {
+    if (options?.signal?.aborted) throw new PKCError("ERR_IPNS_DIRECT_FETCH_ABORTED", { pubsubTopic, ...getHeliaDebugContext(helia) });
+
+    const start = Date.now();
+    const fetchService = helia.libp2p.services.fetch;
+    const pubsub = helia.libp2p.services.pubsub;
+    const contentCid = pubsubTopicToDhtKeyCid(pubsubTopic);
+
+    // Aborted on the first valid record so every losing fetch (and the findProviders iterator)
+    // stops promptly rather than running to its own per-peer timeout.
+    const resultController = new AbortController();
+    let winner: DirectFetchResult | undefined;
+    const peerToError: Record<string, { errorName: string; errorMessage: string }> = {};
+
+    const recordErr = (peerId: PeerId, e: unknown) => {
+        const err = e as Error;
+        peerToError[peerId.toString()] = { errorName: err.name, errorMessage: err.message };
+        log.trace("Direct IPNS fetch failed from peer", peerId.toString(), "due to error", e);
+    };
+
+    // Fetch + validate from an already-connected peer. check-then-set of `winner` is safe on the
+    // single-threaded event loop because there is no await between the guard and the assignment.
+    const tryFetchFromPeer = async (peerId: PeerId, source: DirectFetchResult["source"]): Promise<void> => {
+        if (resultController.signal.aborted || winner) return;
+        // The fetch service's own timeout is fixed at construction, so bound each call via signal.
+        const timeoutSignal = AbortSignal.timeout(options?.timeoutMs ?? DIRECT_FETCH_PER_PEER_TIMEOUT_MS);
+        const signal = options?.signal
+            ? AbortSignal.any([options.signal, resultController.signal, timeoutSignal])
+            : AbortSignal.any([resultController.signal, timeoutSignal]);
+        try {
+            const bytes = await fetchService.fetch(peerId, routingKey, { signal });
+            if (bytes == null) {
+                log.trace("Peer", peerId.toString(), "did not have IPNS record for topic", pubsubTopic);
+                return;
+            }
+            await validate(routingKey, bytes); // throws on bad signature / wrong routing key
+            if (!resultController.signal.aborted && !winner) {
+                winner = { recordBytes: bytes, peerId: peerId.toString(), source, durationMs: Date.now() - start };
+                resultController.abort();
+            }
+        } catch (e) {
+            recordErr(peerId, e);
+        }
+    };
+
+    // Subscriber branch: fetch immediately from every peer gossipsub already reports as
+    // subscribed (they are connected, so no dial needed).
+    const subscriberTasks = pubsub.getSubscribers(pubsubTopic).map((peerId) => tryFetchFromPeer(peerId, "subscriber"));
+
+    // Provider branch: discover providers of the topic CID from the HTTP routers, dial each, then
+    // fetch the moment the dial completes. Stop enqueueing at maxPeers attempts or on a winner.
+    const providerBranch = (async (): Promise<void> => {
+        const findProvidersAbort = new AbortController();
+        const findProvidersSignal = options?.signal
+            ? AbortSignal.any([options.signal, findProvidersAbort.signal, resultController.signal])
+            : AbortSignal.any([findProvidersAbort.signal, resultController.signal]);
+        const dialFetchTasks: Promise<void>[] = [];
+        let attempted = 0;
+        try {
+            for await (const peer of helia.libp2p.contentRouting.findProviders(contentCid, { ...options, signal: findProvidersSignal })) {
+                if (resultController.signal.aborted) break;
+                dialFetchTasks.push(
+                    (async () => {
+                        try {
+                            // Not all routers merge discovered multiaddrs into the peerstore, so dial-by-id
+                            // could otherwise fail with "no addresses for peer" (mirrors connectToPubsubPeers).
+                            if ((peer as PeerInfo).multiaddrs?.length)
+                                await helia.libp2p.peerStore.merge(peer.id, { multiaddrs: (peer as PeerInfo).multiaddrs });
+                            await helia.libp2p.dial(peer.id, { signal: options?.signal }); // no-op if already connected
+                            await tryFetchFromPeer(peer.id, "provider");
+                        } catch (e) {
+                            recordErr(peer.id, e);
+                        }
+                    })()
+                );
+                if (++attempted >= maxPeers) {
+                    findProvidersAbort.abort();
+                    break;
+                }
+            }
+        } catch (e) {
+            // findProviders may throw the abort we caused ourselves (winner found / maxPeers). Any
+            // genuine error is non-fatal here: the subscriber branch may still win, and on total
+            // exhaustion we return undefined so the caller falls back to router.get().
+            if (!findProvidersSignal.aborted) log.trace("findProviders errored during direct IPNS fetch for topic", pubsubTopic, e);
+        }
+        await Promise.allSettled(dialFetchTasks);
+    })();
+
+    // Await both branches so no in-flight fetch/dial leaks past return.
+    await Promise.allSettled([...subscriberTasks, providerBranch]);
+
+    if (winner) {
+        log.trace("Direct IPNS fetch won from", winner.source, winner.peerId, "in", winner.durationMs, "ms for topic", pubsubTopic);
+        return winner;
+    }
+
+    // If the caller aborted us and nobody won, surface the abort rather than a silent miss.
+    if (options?.signal?.aborted)
+        throw new PKCError("ERR_IPNS_DIRECT_FETCH_ABORTED", { pubsubTopic, peerToError, ...getHeliaDebugContext(helia) });
+
+    return undefined;
 }

--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -441,7 +441,13 @@ export async function directFetchIpnsRecordFromProviders({
                             // could otherwise fail with "no addresses for peer" (mirrors connectToPubsubPeers).
                             if ((peer as PeerInfo).multiaddrs?.length)
                                 await helia.libp2p.peerStore.merge(peer.id, { multiaddrs: (peer as PeerInfo).multiaddrs });
-                            await helia.libp2p.dial(peer.id, { signal: options?.signal }); // no-op if already connected
+                            // Bind the dial to the winner signal too, so a losing dial is cancelled the
+                            // moment another peer wins rather than running to its own timeout and delaying
+                            // Promise.allSettled(dialFetchTasks) below.
+                            const dialSignal = options?.signal
+                                ? AbortSignal.any([options.signal, resultController.signal])
+                                : resultController.signal;
+                            await helia.libp2p.dial(peer.id, { signal: dialSignal }); // no-op if already connected
                             await tryFetchFromPeer(peer.id, "provider");
                         } catch (e) {
                             recordErr(peer.id, e);

--- a/test/node-and-browser/helia/helia.test.ts
+++ b/test/node-and-browser/helia/helia.test.ts
@@ -14,6 +14,8 @@ import type { Comment } from "../../../dist/node/publications/comment/comment.js
 import type { IpfsHttpClientPubsubMessage } from "../../../dist/node/types.js";
 import { ipnsNameToIpnsOverPubsubTopic } from "../../../dist/node/util.js";
 import { importer } from "ipfs-unixfs-importer";
+import { peerIdFromString } from "@libp2p/peer-id";
+import { multihashToIPNSRoutingKey } from "ipns";
 
 async function firstFromAsyncIterable<T>(iterable: AsyncIterable<T>): Promise<T> {
     for await (const value of iterable) return value;
@@ -254,7 +256,14 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             }
         });
 
-        it("name.resolve populates pubsub subscribers before @helia/ipns inspects them", async () => {
+        // The direct-fetch fast path (issue #185) resolves the record over libp2p/fetch without
+        // blocking on the gossipsub subscriber floor (TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS, up to 10s),
+        // so it intentionally does NOT wait for pubsub.getSubscribers(topic) to be populated before
+        // returning. It MUST, however, still subscribe to the IPNS-over-pubsub topic (and kick a
+        // fire-and-forget warmup) so future pushed record updates keep arriving. This asserts that
+        // the subscription survives the resolve — the guarantee that replaced the old
+        // warmup-before-first-get behavior.
+        it("name.resolve keeps the pubsub topic subscribed so pushed updates keep flowing", async () => {
             const { communityAddress } = await createMockedCommunityIpns({});
             const resolverPKC = await config.pkcInstancePromise();
             try {
@@ -263,25 +272,17 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 const pubsubSvc = heliaClient._helia.libp2p.services.pubsub;
                 const topic = ipnsNameToIpnsOverPubsubTopic(communityAddress);
 
-                expect(pubsubSvc.getSubscribers(topic).length).to.equal(0);
+                expect(pubsubSvc.getTopics(), "topic must not be subscribed before resolve").to.not.include(topic);
 
-                let lastReadCount: number | undefined;
-                const original = pubsubSvc.getSubscribers.bind(pubsubSvc);
-                pubsubSvc.getSubscribers = (t: string) => {
-                    const list = original(t);
-                    if (t === topic) lastReadCount = list.length;
-                    return list;
-                };
+                const resolved = await firstFromAsyncIterable(
+                    heliaShape.name.resolve(communityAddress, { nocache: true, recursive: true })
+                );
+                expect(resolved).to.be.a("string");
+                expect(resolved).to.match(/^\/ipfs\//);
 
-                try {
-                    await firstFromAsyncIterable(heliaShape.name.resolve(communityAddress, { nocache: true, recursive: true }));
-                } finally {
-                    pubsubSvc.getSubscribers = original;
-                }
-
-                // The @helia/ipns pubsub router's final read (the for-loop over peers) must see
-                // a populated subscriber list — that's what the warmup is for.
-                expect(lastReadCount, "subscribers must be populated by the time @helia/ipns reads them").to.be.greaterThan(0);
+                expect(pubsubSvc.getTopics(), "resolve must leave the IPNS pubsub topic subscribed for future pushed updates").to.include(
+                    topic
+                );
             } finally {
                 await resolverPKC.destroy();
             }
@@ -392,10 +393,6 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             const { communityAddress } = await createMockedCommunityIpns({});
             const pkc = await config.pkcInstancePromise();
             const heliaClient = Object.values(pkc.clients.libp2pJsClients)[0];
-            const heliaShape = heliaClient.heliaWithKuboRpcClientFunctions;
-
-            // Trigger an IPNS resolve so the pubsub router records a subscription internally.
-            await firstFromAsyncIterable(heliaShape.name.resolve(communityAddress, { nocache: true, recursive: true }));
 
             // Find the pubsub router by class name (matches the shape pinned in the
             // "IPNS router shape" suite above).
@@ -405,13 +402,28 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             expect(pubsubRouter, "expected to find a PubSubRouting in _heliaIpnsRouter.routers").to.exist;
 
             const routerWithLifecycle = pubsubRouter as {
+                get: (routingKey: Uint8Array, options?: { signal?: AbortSignal }) => Promise<unknown>;
                 getSubscriptions: () => string[];
                 stop: () => void | Promise<void>;
             };
+
+            // Seed a router-level subscription. name.resolve() no longer records one on its own:
+            // the direct-fetch fast path (issue #185) pre-subscribes the topic on gossipsub and
+            // returns before PubSubRouting.get() ever runs, and even the legacy fallback's get()
+            // skips adding the subscription because the topic is already in pubsub.getTopics().
+            // So we call the router's get() directly on a not-yet-subscribed topic to create the
+            // leak surface this test guards. get() subscribes and records the subscription before
+            // it awaits/fetches, so it is recorded even though get() then throws NotFoundError.
+            const routingKey = multihashToIPNSRoutingKey(peerIdFromString(communityAddress).toMultihash());
+            await routerWithLifecycle.get(routingKey, { signal: AbortSignal.timeout(2000) }).catch(() => {
+                // NotFoundError (no subscriber serves the record) or abort — the subscription is
+                // still recorded before get() rejects, which is all this test needs.
+            });
+
             const subsBeforeDestroy = routerWithLifecycle.getSubscriptions();
             expect(
                 subsBeforeDestroy.length,
-                `pubsub router should track at least one subscription after a successful resolve, got ${subsBeforeDestroy.length}`
+                `pubsub router should track at least one subscription after get(), got ${subsBeforeDestroy.length}`
             ).to.be.greaterThan(0);
 
             const stopSpy = vi.spyOn(routerWithLifecycle, "stop");

--- a/test/node/helia/ipns-direct-fetch.unit.test.ts
+++ b/test/node/helia/ipns-direct-fetch.unit.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createLibp2pJsClientOrUseExistingOne } from "../../../dist/node/helia/helia-for-pkc.js";
+import { directFetchIpnsRecordFromProviders } from "../../../dist/node/helia/util.js";
+import { MockHttpRouter } from "../../../dist/node/runtime/node/test/mock-http-router.js";
+import { ipnsNameToIpnsOverPubsubTopic, pubsubTopicToDhtKeyCid } from "../../../dist/node/util.js";
+import Logger from "../../../dist/node/logger.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { generateKeyPair } from "@libp2p/crypto/keys";
+import { peerIdFromPrivateKey } from "@libp2p/peer-id";
+import { createIPNSRecord, marshalIPNSRecord, multihashToIPNSRoutingKey } from "ipns";
+import { ipnsValidator } from "ipns/validator";
+import { CID } from "multiformats/cid";
+import { equals as uint8ArrayEquals } from "uint8arrays/equals";
+import type { Libp2pJsClient } from "../../../dist/node/helia/libp2pjsClient.js";
+
+// Coverage for directFetchIpnsRecordFromProviders (src/helia/util.ts) — the IPNS resolution fast
+// path (issue #185). It fetches the record over libp2p/fetch, in parallel, directly from BOTH the
+// topic's current gossipsub subscribers AND providers freshly discovered from the HTTP routers,
+// returning the first signature-valid record. This skips the waitForTopicSubscriber floor (up to
+// 10s) that @helia/ipns's PubSubRouting.get() forces because get() only fetches from
+// getSubscribers() and throws when that list is empty.
+//
+// Like the warmup suite, this stands up a STARTED node-under-test plus a real second libp2p node
+// that listens on /ws and serves the record over the fetch protocol. Client-side libp2p only and
+// config-independent (the helper never touches Kubo or the PKC RPC server — it operates purely on
+// the local helia/libp2p instance), so it runs once under non-RPC via describeSkipIfRpc.
+describeSkipIfRpc("directFetchIpnsRecordFromProviders (issue #185)", () => {
+    // A successful direct fetch (dialable provider/subscriber found) must finish far below the 10s
+    // waitForTopicSubscriber floor that the legacy path pays — this is the whole point of the fast
+    // path. Generous for CI jitter on a dial + fetch between two local nodes.
+    const FAST_FETCH_MAX_MS = 7_000;
+
+    const log = Logger("pkc-js:test:direct-fetch");
+    const clientsToStop: Libp2pJsClient[] = [];
+    const startedRouters: MockHttpRouter[] = [];
+    let keyCounter = 0;
+
+    afterEach(async () => {
+        while (clientsToStop.length) await clientsToStop.pop()!.heliaWithKuboRpcClientFunctions.stop();
+        while (startedRouters.length) {
+            try {
+                await startedRouters.pop()!.destroy();
+            } catch {
+                // already destroyed
+            }
+        }
+    });
+
+    const createNode = async (opts: { listen?: boolean; routers?: string[] } = {}): Promise<Libp2pJsClient> => {
+        const client = (await createLibp2pJsClientOrUseExistingOne({
+            key: `direct-fetch-${keyCounter++}`,
+            httpRoutersOptions: opts.routers ?? ["http://localhost:1"],
+            libp2pOptions: opts.listen ? { addresses: { listen: ["/ip4/127.0.0.1/tcp/0/ws"] } } : {},
+            heliaOptions: {}
+        })) as Libp2pJsClient;
+        clientsToStop.push(client);
+        return client;
+    };
+
+    // Build a fresh IPNS name + a validly-signed record for it, plus everything derived from it.
+    const makeRecord = async (valuePath = "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi") => {
+        const privateKey = await generateKeyPair("Ed25519");
+        const ipnsPeerId = peerIdFromPrivateKey(privateKey);
+        const record = await createIPNSRecord(privateKey, CID.parse(valuePath.replace("/ipfs/", "")), 1n, 60 * 60 * 1000);
+        const marshalled = marshalIPNSRecord(record);
+        const routingKey = multihashToIPNSRoutingKey(ipnsPeerId.toMultihash());
+        const topic = ipnsNameToIpnsOverPubsubTopic(ipnsPeerId.toString());
+        const cid = pubsubTopicToDhtKeyCid(topic).toString();
+        return { privateKey, ipnsPeerId, record, marshalled, routingKey, topic, cid };
+    };
+
+    // Stand up a real libp2p node that listens on /ws and serves `recordToServe` for `routingKey`
+    // over the fetch protocol. pkc nodes already register a `/ipns/` lookup (via @helia/ipns), so we
+    // unregister it and register our own that returns the pre-built record. If `subscribeTopic` is
+    // given, the node also subscribes to that topic (via the GossipSub PROTOTYPE method, bypassing
+    // helia-for-pkc's instance-level subscribe monkey-patch so it does not kick off its OWN warmup).
+    const startPublisherNode = async (args: {
+        routingKey: Uint8Array;
+        recordToServe: Uint8Array | undefined;
+        subscribeTopic?: string;
+    }): Promise<{ client: Libp2pJsClient; ID: string; Addrs: string[] }> => {
+        const client = await createNode({ listen: true });
+        const fetchService = client._helia.libp2p.services.fetch;
+        fetchService.unregisterLookupFunction("/ipns/");
+        fetchService.registerLookupFunction("/ipns/", async (key: Uint8Array) => {
+            if (args.recordToServe && uint8ArrayEquals(key, args.routingKey)) return args.recordToServe;
+            return undefined;
+        });
+
+        if (args.subscribeTopic) {
+            const pubsub = client._helia.libp2p.services.pubsub;
+            Object.getPrototypeOf(pubsub).subscribe.call(pubsub, args.subscribeTopic);
+        }
+
+        const wsAddrs = client._helia.libp2p
+            .getMultiaddrs()
+            .map((m) => m.toString())
+            .filter((a) => a.includes("/ws"))
+            .map((a) => a.replace(/\/p2p\/[^/]+$/, ""));
+        expect(wsAddrs.length, "publisher must expose at least one ws multiaddr").to.be.greaterThan(0);
+        return { client, ID: client._helia.libp2p.peerId.toString(), Addrs: wsAddrs };
+    };
+
+    const startRouterServing = async (cid: string, provider: { ID: string; Addrs: string[] }): Promise<string> => {
+        const router = new MockHttpRouter();
+        await router.start();
+        startedRouters.push(router);
+        router.addProviderForTesting(cid, provider);
+        return router.url;
+    };
+
+    // Provider fast path: the publisher is reachable ONLY via a router provider record and is NOT a
+    // gossipsub subscriber. The helper must dial it and fetch the record via libp2p/fetch, well under
+    // the 10s subscriber-wait floor — proving the subscription handshake is skipped.
+    it("fetches from a freshly discovered provider without waiting for a gossipsub subscription", async () => {
+        const { routingKey, marshalled, topic, cid } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled });
+        const routerUrl = await startRouterServing(cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        // Sanity: the publisher is NOT yet a subscriber from the node's view — this is the provider path.
+        expect(node._helia.libp2p.services.pubsub.getSubscribers(topic).map((p) => p.toString())).to.not.include(publisher.ID);
+
+        const start = Date.now();
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+        const elapsed = Date.now() - start;
+
+        expect(result, "should have fetched a record from the provider").to.not.equal(undefined);
+        expect(result!.source).to.equal("provider");
+        expect(result!.peerId).to.equal(publisher.ID);
+        expect(uint8ArrayEquals(result!.recordBytes, marshalled), "served record bytes must match").to.equal(true);
+        expect(elapsed, `direct fetch took ${elapsed}ms, expected well under the 10s floor`).to.be.lessThan(FAST_FETCH_MAX_MS);
+    });
+
+    // Subscriber branch: the publisher is already in getSubscribers(topic) and there is NO router
+    // record. The helper must still fetch from it — proving both sources are queried in parallel.
+    it("fetches from a peer already in getSubscribers when no router record exists", async () => {
+        const { routingKey, marshalled, topic } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled, subscribeTopic: topic });
+        // Dummy router (localhost:1) serves nothing, so the provider branch finds no providers.
+        const node = await createNode({ routers: ["http://localhost:1"] });
+
+        // Establish the connection so gossipsub exchanges subscriptions and reports the publisher as
+        // a subscriber. Dial by the publisher's full multiaddrs (they include the /p2p/<id> suffix).
+        await node._helia.libp2p.dial(publisher.client._helia.libp2p.getMultiaddrs());
+
+        const deadline = Date.now() + FAST_FETCH_MAX_MS;
+        while (
+            Date.now() < deadline &&
+            !node._helia.libp2p.services.pubsub.getSubscribers(topic).some((p) => p.toString() === publisher.ID)
+        )
+            await new Promise((r) => setTimeout(r, 100));
+        expect(
+            node._helia.libp2p.services.pubsub.getSubscribers(topic).map((p) => p.toString()),
+            "publisher should be a known subscriber before we fetch"
+        ).to.include(publisher.ID);
+
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+
+        expect(result, "should have fetched a record from the subscriber").to.not.equal(undefined);
+        expect(result!.source).to.equal("subscriber");
+        expect(result!.peerId).to.equal(publisher.ID);
+        expect(uint8ArrayEquals(result!.recordBytes, marshalled)).to.equal(true);
+    });
+
+    // A provider that serves a record whose signature does NOT match the requested routing key must
+    // be discarded by the validation gate — the helper must not return a poisoned value.
+    it("discards a record that fails signature validation and returns undefined", async () => {
+        const { routingKey, topic, cid } = await makeRecord();
+        // A validly-signed record, but for a DIFFERENT name — ipnsValidator(routingKey, ...) will reject it.
+        const foreign = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: foreign.marshalled });
+        const routerUrl = await startRouterServing(cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+
+        expect(result, "a bad-signature record must not win").to.equal(undefined);
+    });
+
+    // When no source has the record (provider dials but its fetch returns undefined), the helper
+    // returns undefined so the caller can fall back to the legacy router.get() path.
+    it("returns undefined when the discovered provider does not have the record", async () => {
+        const { routingKey, topic, cid } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: undefined }); // lookup always misses
+        const routerUrl = await startRouterServing(cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+
+        expect(result).to.equal(undefined);
+    });
+
+    // A pre-aborted caller signal must surface promptly as ERR_IPNS_DIRECT_FETCH_ABORTED, not hang.
+    it("throws ERR_IPNS_DIRECT_FETCH_ABORTED promptly when the caller signal is already aborted", async () => {
+        const { routingKey, topic, cid } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: (await makeRecord()).marshalled });
+        const routerUrl = await startRouterServing(cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        const start = Date.now();
+        let threw: (Error & { code?: string }) | null = null;
+        try {
+            await directFetchIpnsRecordFromProviders({
+                helia: node._helia,
+                pubsubTopic: topic,
+                routingKey,
+                maxPeers: 4,
+                validate: ipnsValidator,
+                log,
+                options: { signal: AbortSignal.abort() }
+            });
+        } catch (e) {
+            threw = e as Error & { code?: string };
+        }
+        const elapsed = Date.now() - start;
+
+        expect(threw, "should have thrown on a pre-aborted signal").to.not.equal(null);
+        expect(threw!.code ?? threw!.message).to.contain("ERR_IPNS_DIRECT_FETCH_ABORTED");
+        expect(elapsed, `abort should be prompt, took ${elapsed}ms`).to.be.lessThan(FAST_FETCH_MAX_MS);
+    });
+});


### PR DESCRIPTION
Closes #185.

## Problem

Cold IPNS-over-pubsub resolution waits longer than necessary. When resolving an IPNS name we already discover the exact provider peers for the name's pubsub topic from the HTTP routers (`findProviders`) and dial them, but we then **wait for those same peers to re-announce via gossipsub** (`subscription-change`, up to a 10s floor, `TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS`) before fetching the record.

Only after that wait does `@helia/ipns`'s `PubSubRouting.get()` run, and it fetches over the libp2p **fetch** protocol (`/libp2p/fetch/0.0.1`) but **only** from peers gossipsub has confirmed as subscribers (`getSubscribers(topic)`), throwing `NotFoundError` when that list is empty. The fetch protocol is a direct request/response: the publisher (kubo via go-libp2p-pubsub-router, or another helia via `registerLookupFunction`) answers with the current record regardless of the subscription handshake, so the wait is pure latency.

## Change

- New `directFetchIpnsRecordFromProviders` (`src/helia/util.ts`): fetch the record over libp2p/fetch, in parallel, directly from **both** the topic's current gossipsub subscribers **and** providers freshly discovered from the HTTP routers. First signature-valid record (`ipnsValidator`) wins; remaining fetches are aborted. Returns `undefined` on exhaustion so the caller can fall back; throws `ERR_IPNS_DIRECT_FETCH_ABORTED` only when the caller's signal aborts with no winner.
- Wired as the fast path in `name.resolve()` (`src/helia/helia-for-pkc.ts`): still subscribes + kicks a fire-and-forget warmup so pushed updates keep flowing, and on a miss/error falls back to the unchanged legacy warmup + `router.get()` loop. `directFetchOutcome` added to the `ERR_RESOLVED_IPNS_P2P_TO_UNDEFINED` diagnostics.
- `fetch: Fetch` added to the `HeliaWithLibp2pPubsub` services type; `ERR_IPNS_DIRECT_FETCH_ABORTED` error code added.

Per direction from the issue: fetch from both sources in parallel (provider-fetch is not the sole path), and no benchmark harness in this repo.

## Tests

New `test/node/helia/ipns-direct-fetch.unit.test.ts` (5 cases, modeled on the warmup suite with a real second libp2p node serving the record over fetch): provider fast path finishes far under the 10s floor; subscriber branch fetches when no router record exists; bad-signature record is discarded; miss returns `undefined`; pre-aborted signal throws promptly.

Regression: `helia-ipns-router-errors`, `helia-ipns-resolve-equivalence`, `warmup-connect-to-pubsub-peers`, `ipns-hops.community` (real resolve vs local Kubo), and the 12-case multi-hop `delegated-ipns` suite all pass. `npm run build` and the test type-check pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster IPNS record resolution that can fetch directly from pubsub subscribers and discovered providers before falling back to the existing lookup path.
  * Exposed direct-fetch results with source, peer, and timing details for better visibility.
  * Added a new error message for interrupted direct IPNS fetches.

* **Bug Fixes**
  * Improved handling of signature validation and aborted requests during direct fetches.
  * Added coverage for provider, subscriber, miss, and abort scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->