### PR TITLE
fix(helia): don't count undialable providers toward maxPeers in direct IPNS fetch

### DIFF
--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -423,7 +423,8 @@ export async function directFetchIpnsRecordFromProviders({
     const subscriberTasks = pubsub.getSubscribers(pubsubTopic).map((peerId) => tryFetchFromPeer(peerId, "subscriber"));
 
     // Provider branch: discover providers of the topic CID from the HTTP routers, dial each, then
-    // fetch the moment the dial completes. Stop enqueueing at maxPeers attempts or on a winner.
+    // fetch the moment the dial completes. Stop enqueueing after maxPeers dialable providers or on
+    // a winner.
     const providerBranch = (async (): Promise<void> => {
         const findProvidersAbort = new AbortController();
         const findProvidersSignal = options?.signal
@@ -434,6 +435,16 @@ export async function directFetchIpnsRecordFromProviders({
         try {
             for await (const peer of helia.libp2p.contentRouting.findProviders(contentCid, { ...options, signal: findProvidersSignal })) {
                 if (resultController.signal.aborted) break;
+                // Providers whose announced addrs are all undialable must not consume one of the
+                // maxPeers attempt slots (issue #188): in a browser with a WSS-only connection
+                // gater, some routers consistently serve records with only tcp/quic addrs (or none)
+                // and answer fast, so their instantly-failing dials would otherwise burn every slot
+                // and force the caller back onto the ~10s legacy warmup path. We still dial them —
+                // the peerstore may know dialable addrs the record lacks — but only providers with
+                // at least one dialable announced addr count toward maxPeers. isDialable is a local
+                // check (gater + transport match), not a network round-trip.
+                const announcedAddrs = (peer as PeerInfo).multiaddrs ?? [];
+                const hasDialableAddr = announcedAddrs.length > 0 && (await helia.libp2p.isDialable(announcedAddrs));
                 dialFetchTasks.push(
                     (async () => {
                         try {
@@ -454,7 +465,7 @@ export async function directFetchIpnsRecordFromProviders({
                         }
                     })()
                 );
-                if (++attempted >= maxPeers) {
+                if (hasDialableAddr && ++attempted >= maxPeers) {
                     findProvidersAbort.abort();
                     break;
                 }

--- a/test/node/helia/ipns-direct-fetch.unit.test.ts
+++ b/test/node/helia/ipns-direct-fetch.unit.test.ts
@@ -12,6 +12,7 @@ import { ipnsValidator } from "ipns/validator";
 import { CID } from "multiformats/cid";
 import { equals as uint8ArrayEquals } from "uint8arrays/equals";
 import type { Libp2pJsClient } from "../../../dist/node/helia/libp2pjsClient.js";
+import type { Multiaddr } from "@multiformats/multiaddr";
 
 // Coverage for directFetchIpnsRecordFromProviders (src/helia/util.ts) — the IPNS resolution fast
 // path (issue #185). It fetches the record over libp2p/fetch, in parallel, directly from BOTH the
@@ -46,11 +47,20 @@ describeSkipIfRpc("directFetchIpnsRecordFromProviders (issue #185)", () => {
         }
     });
 
-    const createNode = async (opts: { listen?: boolean; routers?: string[] } = {}): Promise<Libp2pJsClient> => {
+    const createNode = async (
+        opts: {
+            listen?: boolean;
+            routers?: string[];
+            libp2pOptions?: Parameters<typeof createLibp2pJsClientOrUseExistingOne>[0]["libp2pOptions"];
+        } = {}
+    ): Promise<Libp2pJsClient> => {
         const client = (await createLibp2pJsClientOrUseExistingOne({
             key: `direct-fetch-${keyCounter++}`,
             httpRoutersOptions: opts.routers ?? ["http://localhost:1"],
-            libp2pOptions: opts.listen ? { addresses: { listen: ["/ip4/127.0.0.1/tcp/0/ws"] } } : {},
+            libp2pOptions: {
+                ...(opts.listen ? { addresses: { listen: ["/ip4/127.0.0.1/tcp/0/ws"] } } : {}),
+                ...opts.libp2pOptions
+            },
             heliaOptions: {}
         })) as Libp2pJsClient;
         clientsToStop.push(client);
@@ -133,6 +143,65 @@ describeSkipIfRpc("directFetchIpnsRecordFromProviders (issue #185)", () => {
         const elapsed = Date.now() - start;
 
         expect(result, "should have fetched a record from the provider").to.not.equal(undefined);
+        expect(result!.source).to.equal("provider");
+        expect(result!.peerId).to.equal(publisher.ID);
+        expect(uint8ArrayEquals(result!.recordBytes, marshalled), "served record bytes must match").to.equal(true);
+        expect(elapsed, `direct fetch took ${elapsed}ms, expected well under the 10s floor`).to.be.lessThan(FAST_FETCH_MAX_MS);
+    });
+
+    // Issue #188: undialable providers must not consume maxPeers attempt slots. In a browser with
+    // a WSS-only connection gater, some routers consistently serve provider records whose addrs
+    // are all tcp/quic (no WSS). Those dials fail instantly with DialDeniedError, but each one
+    // used to count toward maxPeers (4), so when the first 4 providers yielded were undialable
+    // the provider branch exhausted itself without a single real fetch attempt and resolution
+    // fell back to the ~10s legacy warmup path. Reproduce with a ws-only gater on the
+    // node-under-test and a router that yields maxPeers tcp-only providers BEFORE the one real
+    // ws publisher: the publisher must still be dialed and its record fetched.
+    it("does not count undialable (gater-denied) providers toward maxPeers (issue #188)", async () => {
+        const maxPeers = 4;
+        const { routingKey, marshalled, topic, cid } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled });
+
+        const router = new MockHttpRouter();
+        await router.start();
+        startedRouters.push(router);
+        // MockHttpRouter serves providers newest-first, so seed the dialable publisher FIRST and
+        // the undialable providers AFTER: the node-under-test then discovers all maxPeers
+        // undialable providers before the publisher, mirroring production where fast routers
+        // serving records without WSS addrs are yielded first.
+        router.addProviderForTesting(cid, publisher);
+        for (let i = 0; i < maxPeers; i++) {
+            const fakePeerId = peerIdFromPrivateKey(await generateKeyPair("Ed25519")).toString();
+            router.addProviderForTesting(cid, { ID: fakePeerId, Addrs: [`/ip4/127.0.0.1/tcp/${40100 + i}`] });
+        }
+
+        // Mirror the browser's WSS-only connection gater: deny any multiaddr without a ws/wss
+        // component, so the tcp-only providers fail instantly with DialDeniedError.
+        const node = await createNode({
+            routers: [router.url],
+            libp2pOptions: {
+                connectionGater: {
+                    denyDialMultiaddr: (multiaddr: Multiaddr) =>
+                        !multiaddr.getComponents().some((component) => component.name === "ws" || component.name === "wss")
+                }
+            }
+        });
+
+        const start = Date.now();
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers,
+            validate: ipnsValidator,
+            log
+        });
+        const elapsed = Date.now() - start;
+
+        expect(
+            result,
+            "the dialable publisher must still be fetched from even when maxPeers undialable providers are yielded first"
+        ).to.not.equal(undefined);
         expect(result!.source).to.equal("provider");
         expect(result!.peerId).to.equal(publisher.ID);
         expect(uint8ArrayEquals(result!.recordBytes, marshalled), "served record bytes must match").to.equal(true);


### PR DESCRIPTION
Fixes #188

## Problem

`directFetchIpnsRecordFromProviders` (`src/helia/util.ts`) counted every provider yielded by `findProviders` toward `maxPeers` (4) before knowing whether the provider had any dialable multiaddr. In a browser with a WSS-only connection gater, providers whose records carry only tcp/quic addrs fail instantly with `DialDeniedError` but still consumed an attempt slot. Some routers consistently serve records without WSS addrs and answer fast, so their undialable providers are often yielded first; if the first 4 providers were undialable, the provider branch exhausted itself without a single real fetch attempt and resolution fell back to the ~10s legacy warmup path that the direct-fetch fast path (#186) was built to skip. See the benchmark evidence in #188.

## Fix

Only providers with at least one dialable announced addr consume a `maxPeers` slot, checked via `libp2p.isDialable(announcedAddrs)` which runs the connection gater and transport-manager match locally (no network round-trip). Undialable providers are still dialed, since the peerstore may know dialable addrs the record lacks, but they can no longer starve the provider branch. In Node every announced addr is typically dialable, so behavior there is unchanged; the blast radius is the browser gater case.

The analogous filtering in `connectToPubsubPeers` is intentionally left out: it caps on successful connections rather than attempts, so undialable providers there are churn, not a correctness issue (noted as optional in #188).

## Regression test

`test/node/helia/ipns-direct-fetch.unit.test.ts`: a node-under-test with a ws-only connection gater (mirroring the browser WSS-only setup) discovers `maxPeers` tcp-only providers before the one real ws publisher, exploiting MockHttpRouter's newest-first ordering. Against unfixed code the test fails with `result === undefined` (all slots burned by gater-denied dials); with the fix the publisher is dialed and its record fetched. The test helper `createNode` was extended to accept `libp2pOptions` so tests can install a custom connection gater.

## Verification

- `npm run build` passes
- `npx tsc --project test/tsconfig.json --noEmit` passes
- Regression test fails on unfixed `src` (red), passes with the fix (green)
- All 4 suites under `test/node/helia/` pass (52 tests) under `--pkc-config "local-kubo-rpc"`