### PR TITLE
test: fix stale-read race on parent post's stored CommentUpdate in pseudonymityMode tests

### DIFF
--- a/test/node/community/features/per-author.pseudonymityMode.community.features.test.ts
+++ b/test/node/community/features/per-author.pseudonymityMode.community.features.test.ts
@@ -638,14 +638,18 @@ describeSkipIfRpc('community.features.pseudonymityMode="per-author"', () => {
                 const aggregatedAuthor = (localContext.community as LocalCommunity)._dbHandler.queryCommunityAuthor(localAuthor.address);
                 expect(aggregatedAuthor?.lastCommentCid).to.equal(followUpReply.cid);
 
-                const replyUpdate = (localContext.community as LocalCommunity)._dbHandler.queryStoredCommentUpdate({
-                    cid: followUpReply.cid
-                }) as StoredCommentUpdate;
+                const replyUpdate = await waitForStoredCommentUpdate(
+                    localContext.community as LocalCommunity,
+                    followUpReply.cid!,
+                    (stored) => stored.author?.community?.lastCommentCid === followUpReply.cid
+                );
                 expect(replyUpdate?.author?.community?.lastCommentCid).to.equal(followUpReply.cid);
 
-                const postUpdate = (localContext.community as LocalCommunity)._dbHandler.queryStoredCommentUpdate({
-                    cid: firstPost.cid
-                }) as StoredCommentUpdate;
+                const postUpdate = await waitForStoredCommentUpdate(
+                    localContext.community as LocalCommunity,
+                    firstPost.cid!,
+                    (stored) => stored.author?.community?.lastCommentCid === followUpReply.cid
+                );
                 expect(postUpdate?.author?.community?.lastCommentCid).to.equal(followUpReply.cid);
 
                 await firstPost.stop();
@@ -2037,12 +2041,19 @@ async function waitForStoredCommentUpdateWithAssertions(community: LocalCommunit
     return storedUpdate;
 }
 
-async function waitForStoredCommentUpdate(community: LocalCommunity, cid: string): Promise<StoredCommentUpdate> {
+// Comment updates are upserted per depth batch (replies before their ancestors), so waiting for one
+// comment's row to exist doesn't mean another comment's row has been regenerated yet. Pass a predicate
+// to wait until the stored update reflects the expected values instead of just existing.
+async function waitForStoredCommentUpdate(
+    community: LocalCommunity,
+    cid: string,
+    predicate?: (stored: StoredCommentUpdate) => boolean
+): Promise<StoredCommentUpdate> {
     const timeoutMs = 60000;
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {
         const stored = community._dbHandler.queryStoredCommentUpdate({ cid }) as StoredCommentUpdate | undefined;
-        if (stored) return stored;
+        if (stored && (!predicate || predicate(stored))) return stored;
         await new Promise((resolve) => setTimeout(resolve, 50));
     }
     throw new Error(`Timed out waiting for stored comment update for ${cid}`);

--- a/test/node/community/features/per-post.pseudonymityMode.community.features.test.ts
+++ b/test/node/community/features/per-post.pseudonymityMode.community.features.test.ts
@@ -848,12 +848,16 @@ describeSkipIfRpc('community.features.pseudonymityMode="per-post"', () => {
                 });
                 await waitForStoredCommentUpdateWithAssertions(localContext.community as LocalCommunity, reply);
 
-                const postUpdate = (localContext.community as LocalCommunity)._dbHandler.queryStoredCommentUpdate({
-                    cid: post.cid
-                }) as StoredCommentUpdate;
-                const replyUpdate = (localContext.community as LocalCommunity)._dbHandler.queryStoredCommentUpdate({
-                    cid: reply.cid
-                }) as StoredCommentUpdate;
+                const postUpdate = await waitForStoredCommentUpdate(
+                    localContext.community as LocalCommunity,
+                    post.cid!,
+                    (stored) => stored.author?.community?.lastCommentCid === reply.cid
+                );
+                const replyUpdate = await waitForStoredCommentUpdate(
+                    localContext.community as LocalCommunity,
+                    reply.cid!,
+                    (stored) => stored.author?.community?.lastCommentCid === reply.cid
+                );
                 expect(postUpdate?.author?.community?.lastCommentCid).to.equal(reply.cid);
                 expect(replyUpdate?.author?.community?.lastCommentCid).to.equal(reply.cid);
                 const aggregatedAuthor = (localContext.community as LocalCommunity)._dbHandler.queryCommunityAuthor(localAuthor.address);
@@ -2202,12 +2206,19 @@ async function waitForStoredCommentUpdateWithAssertions(community: LocalCommunit
     return storedUpdate;
 }
 
-async function waitForStoredCommentUpdate(community: LocalCommunity, cid: string): Promise<StoredCommentUpdate> {
+// Comment updates are upserted per depth batch (replies before their ancestors), so waiting for one
+// comment's row to exist doesn't mean another comment's row has been regenerated yet. Pass a predicate
+// to wait until the stored update reflects the expected values instead of just existing.
+async function waitForStoredCommentUpdate(
+    community: LocalCommunity,
+    cid: string,
+    predicate?: (stored: StoredCommentUpdate) => boolean
+): Promise<StoredCommentUpdate> {
     const timeoutMs = 60000;
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {
         const stored = community._dbHandler.queryStoredCommentUpdate({ cid }) as StoredCommentUpdate | undefined;
-        if (stored) return stored;
+        if (stored && (!predicate || predicate(stored))) return stored;
         await new Promise((resolve) => setTimeout(resolve, 50));
     }
     throw new Error(`Timed out waiting for stored comment update for ${cid}`);


### PR DESCRIPTION
Fixes #193.

## Problem

CI `test-pkc-js-node-local` (ubuntu + macos) started failing after #190 on:

- per-author: "Spec: author.community.lastCommentCid tracks the author's latest comment in the community for per-author mode"
- per-post: "Spec: author.community.lastCommentCid reflects the author's latest comment within the post when pseudonymityMode is per-post"

Both assert that the parent post's stored CommentUpdate carries `author.community.lastCommentCid === reply.cid`, but observed the stale value from the previous sync cycle.

## Root cause

`updateCommentsThatNeedToBeUpdated()` upserts comment updates per depth batch, highest depth first: the reply's row is written before the parent post's row is recalculated. The tests' `waitForStoredCommentUpdate` helper polls every 50ms and returns as soon as the reply's row *exists*, then the tests immediately read the post's row, which can still be the previous sync's update.

The race is latent since the tests were added. #190 made CommentUpdate signature verification genuinely async (WebCrypto `crypto.subtle.verify` yields to the event loop, where noble's sync verify did not), so the poll now reliably lands between the depth-1 and depth-0 upserts.

## Fix (test-only)

- `waitForStoredCommentUpdate` in both files accepts an optional predicate; the wait returns only when the stored update satisfies it.
- The two racy sites now wait until the parent post's (and reply's) stored update reflects the expected `lastCommentCid` before asserting.

## Verification

- Reproduced red deterministically by delaying the depth-0 upsert by 500ms in build output (`dist/` only, never committed): unmodified tests fail with the exact CI assertions on both files.
- With the fix, both files pass under the same artificial delay (108/108) and on clean build output (108/108).
- Audited every other `queryStoredCommentUpdate`-then-expect site across per-author, per-post, per-reply, pseudonymity-challenge-exclusion, and loading.update: all others either poll via `resolveWhenConditionIsTrue` (re-evaluated on the community `update` event, which fires after all depth batches are written), re-read the row they already waited on, or assert an absence that a stale row also satisfies. Only these two sites had the stale cross-row read.
- `npx tsc --project test/tsconfig.json --noEmit` passes.

Note: during detector runs with the artificial 500ms delay, the per-post `banExpiresAt` spec timed out once (1 of 3 runs); an instrumented rerun showed all injected delays completing normally and all tests passing, and the spec has never failed unpatched locally or in CI, so it is treated as an artifact of the artificial delay rather than a real race.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of community pseudonymity test coverage for per-author and per-post modes.
  * Updated comment update checks to wait until expected comment metadata is fully available before asserting results.
  * Added more flexible waiting logic so tests can validate specific stored values instead of only detecting that a record exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->