### PR TITLE
fix(rpc): add per-call timeout to PKCRpcClient so a lost response can't hang callers forever

### DIFF
--- a/src/clients/rpc-client/pkc-rpc-client.ts
+++ b/src/clients/rpc-client/pkc-rpc-client.ts
@@ -74,6 +74,7 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
     private _subscriptionEvents: Record<string, EventEmitter>; // subscription ID -> event emitter
     private _pendingSubscriptionMsgs: Record<string, any[]> = {};
     private _timeoutSeconds: number;
+    private _callTimeoutMs: number;
     private _openConnectionPromise?: Promise<any>;
     private _destroyRequested: boolean;
     constructor(rpcServerUrl: string) {
@@ -82,6 +83,11 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
 
         this._websocketServerUrl = rpcServerUrl; // default to first for now. Will change later
         this._timeoutSeconds = 20;
+        // Generous because some calls do unbounded server-side work (e.g. startCommunity repins a whole
+        // community). Its purpose is turning a lost RPC response into a diagnosable error instead of an
+        // infinite hang (issue #195), not bounding slow calls.
+        const envCallTimeoutMs = typeof process !== "undefined" ? Number(process.env?.["PKC_RPC_CALL_TIMEOUT_MS"]) : Number.NaN;
+        this._callTimeoutMs = envCallTimeoutMs > 0 ? envCallTimeoutMs : 300_000;
         this.communities = [];
         this._subscriptionEvents = {};
 
@@ -180,7 +186,15 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
             this._webSocketClient.call = async (...args) => {
                 try {
                     await this._init();
-                    return await originalWebsocketCall(...args);
+                    // A dropped/unmatched JSON-RPC response would otherwise leave this promise pending
+                    // forever (issue #195) — rpc-websockets applies no timeout of its own
+                    return await pTimeout(originalWebsocketCall(...args), {
+                        milliseconds: this._callTimeoutMs,
+                        message: new PKCError("ERR_RPC_CALL_TIMED_OUT", {
+                            rpcMethod: args[0],
+                            timeoutMs: this._callTimeoutMs
+                        })
+                    });
                 } catch (e) {
                     const typedError = <PKCError | { code: number; message: string } | Error | ZodError>e;
                     //e is an error json representation of PKCError

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -368,6 +368,7 @@ export enum messages {
     ERR_RPC_CLIENT_TRYING_TO_EDIT_REMOTE_COMMUNITY = "RPC client is attempting to edit remote community",
     ERR_RPC_CLIENT_TRYING_TO_DELETE_REMOTE_COMMUNITY = "RPC client is attempting to delete remote community",
     ERR_GENERIC_RPC_CLIENT_CALL_ERROR = "RPC client received an unknown error when executing call over websocket",
+    ERR_RPC_CALL_TIMED_OUT = "RPC client call timed out without receiving a response from the RPC server",
     ERR_RPC_CLIENT_CHALLENGE_NAME_NOT_AVAILABLE_ON_SERVER = "The challenge name is not available on the RPC server. Available challenges are listed in details.availableChallenges",
     ERR_ROLE_ADDRESS_NAME_COULD_NOT_BE_RESOLVED = "Role address name could not be resolved",
 

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -499,7 +499,11 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
     rpcWebsocketsRegister(method: string, callback: Function) {
         const callbackWithErrorHandled = async (params: any, connectionId: string) => {
             try {
+                // Trace receipt and response dispatch so a client hanging on a lost response (issue #195)
+                // can be attributed to either side: dispatched-but-never-matched vs never-dispatched
+                log.trace(`Received RPC call (${method}) from connection (${connectionId})`);
                 const res = await callback(params, connectionId);
+                log.trace(`Dispatching RPC response for call (${method}) to connection (${connectionId})`);
                 return res;
             } catch (e: any) {
                 const typedError = <PKCError | Error>e;

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -497,17 +497,19 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
 
     // util function to log errors of registered methods
     rpcWebsocketsRegister(method: string, callback: Function) {
+        let invocationCounter = 0; // correlates the two trace lines of one call under concurrent same-method calls
         const callbackWithErrorHandled = async (params: any, connectionId: string) => {
+            const invocationId = `${method}#${++invocationCounter}`;
             try {
                 // Trace receipt and response dispatch so a client hanging on a lost response (issue #195)
                 // can be attributed to either side: dispatched-but-never-matched vs never-dispatched
-                log.trace(`Received RPC call (${method}) from connection (${connectionId})`);
+                log.trace(`Received RPC call (${invocationId}) from connection (${connectionId})`);
                 const res = await callback(params, connectionId);
-                log.trace(`Dispatching RPC response for call (${method}) to connection (${connectionId})`);
+                log.trace(`Dispatching RPC response for call (${invocationId}) to connection (${connectionId})`);
                 return res;
             } catch (e: any) {
                 const typedError = <PKCError | Error>e;
-                log.error(`${callback.name} error`, { params, error: typedError });
+                log.error(`${callback.name} error (${invocationId})`, { params, error: typedError });
                 // We need to stringify the error here because rpc-websocket will remove props from PKCError
                 if (typedError instanceof PKCError) {
                     const seen = new WeakSet();

--- a/test/node/rpc/rpc-client-lost-response.test.ts
+++ b/test/node/rpc/rpc-client-lost-response.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { WebSocketServer, type WebSocket, type RawData } from "ws";
+import { EventEmitter } from "events";
+import PKCRpcClient from "../../../dist/node/clients/rpc-client/pkc-rpc-client.js";
+
+// Reproduces the CI hang from issue #195 (rpc.auto-start "rapid concurrent state updates" timing out on
+// windows-latest): the RPC server completed all 5 startCommunity calls, but one JSON-RPC response never
+// reached the awaiting client promise, and PKCRpcClient's call layer has no per-call timeout, so
+// Promise.all(starts) pended until the vitest timeout with zero diagnostics.
+//
+// The server below speaks just enough JSON-RPC to answer startCommunity, and drops the response for one
+// designated call. Without a per-call timeout in PKCRpcClient the affected call never settles.
+
+interface JsonRpcRequest {
+    jsonrpc: "2.0";
+    id?: number;
+    method: string;
+    params: unknown[];
+}
+
+class LossyRpcServer {
+    wss: WebSocketServer;
+    port: number;
+    callsReceived: JsonRpcRequest[] = [];
+    /** 1-based index of the call whose response gets dropped; 0 = drop nothing */
+    dropNthCall: number;
+    private subscriptionCounter = 0;
+
+    private constructor(wss: WebSocketServer, port: number, dropNthCall: number) {
+        this.wss = wss;
+        this.port = port;
+        this.dropNthCall = dropNthCall;
+        wss.on("connection", (socket: WebSocket) => {
+            socket.on("message", (raw: RawData) => this._handleMessage(socket, raw));
+        });
+    }
+
+    static async create(dropNthCall: number): Promise<LossyRpcServer> {
+        const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+        await EventEmitter.once(wss, "listening");
+        const address = wss.address();
+        if (address === null || typeof address === "string") throw Error("Expected WebSocketServer to listen on a TCP port");
+        return new LossyRpcServer(wss, address.port, dropNthCall);
+    }
+
+    private _handleMessage(socket: WebSocket, raw: RawData) {
+        const message = JSON.parse(raw.toString()) as JsonRpcRequest;
+        if (typeof message.id !== "number") return; // notification, nothing to respond to
+        this.callsReceived.push(message);
+        if (this.callsReceived.length === this.dropNthCall) return; // simulate the lost response
+        this.subscriptionCounter++;
+        socket.send(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { subscriptionId: this.subscriptionCounter } }));
+    }
+
+    async destroy() {
+        for (const client of this.wss.clients) client.terminate();
+        await new Promise<void>((resolve, reject) => this.wss.close((err) => (err ? reject(err) : resolve())));
+    }
+}
+
+const raceAgainstHang = async <T>(promise: Promise<T>, ms: number): Promise<"settled" | "hung"> => {
+    let sentinel: NodeJS.Timeout;
+    const hangSentinel = new Promise<"hung">((resolve) => {
+        sentinel = setTimeout(() => resolve("hung"), ms);
+    });
+    const outcome = await Promise.race([
+        promise.then(
+            () => "settled" as const,
+            () => "settled" as const
+        ),
+        hangSentinel
+    ]);
+    clearTimeout(sentinel!);
+    return outcome;
+};
+
+describe("PKCRpcClient calls whose response is lost", () => {
+    let server: LossyRpcServer;
+    let client: PKCRpcClient;
+
+    beforeAll(async () => {
+        server = await LossyRpcServer.create(3); // drop the response of the 3rd call, like the CI incident
+        client = new PKCRpcClient(`ws://127.0.0.1:${server.port}`);
+    });
+
+    afterAll(async () => {
+        await client.destroy();
+        await server.destroy();
+    });
+
+    it("concurrent startCommunity calls all settle even when the server drops one response", async () => {
+        // Lower the per-call timeout so the dropped call settles well within the hang sentinel
+        (client as unknown as { _callTimeoutMs: number })._callTimeoutMs = 8_000;
+
+        const communityCount = 5;
+        const starts = Array.from({ length: communityCount }, (_, i) =>
+            client.startCommunity({ publicKey: `12D3KooWFakePublicKeyForLostResponseRepro${i}` }).then(
+                (res) => ({ status: "resolved" as const, res, err: undefined as unknown }),
+                (err: unknown) => ({ status: "rejected" as const, res: undefined as { subscriptionId: number } | undefined, err })
+            )
+        );
+
+        const outcome = await raceAgainstHang(Promise.all(starts), 30_000);
+
+        // The server received and processed every call; only one response was dropped.
+        expect(server.callsReceived.filter((c) => c.method === "startCommunity").length).to.equal(communityCount);
+
+        // Without a per-call timeout this hangs forever (the CI symptom); with one it settles with an error.
+        expect(outcome).to.equal("settled");
+
+        const settledStarts = await Promise.all(starts);
+        const resolved = settledStarts.filter((s) => s.status === "resolved");
+        const rejected = settledStarts.filter((s) => s.status === "rejected");
+        expect(resolved.length).to.equal(communityCount - 1);
+        expect(rejected.length).to.equal(1);
+        for (const s of resolved) expect(s.res?.subscriptionId).to.be.a("number");
+
+        const timeoutError = rejected[0].err as { code?: string; details?: { rpcMethod?: string } };
+        expect(timeoutError.code).to.equal("ERR_RPC_CALL_TIMED_OUT");
+        expect(timeoutError.details?.rpcMethod).to.equal("startCommunity");
+    });
+});


### PR DESCRIPTION
Fixes #195.

## Problem

CI `test-pkc-js-node-local (windows-latest)` timed out (160s) on `rpc.auto-start.test.ts` > "should handle rapid concurrent state updates without errors" (run 29018597263). Log reconstruction showed the RPC server completed all 5 concurrent `startCommunity` calls (all 5 communities published their first IPNS record), but the test never reached `stop()` — the client was stuck in `Promise.all(starts)` because one JSON-RPC response never resolved its awaiting promise. Kubo goroutine dumps ruled out the known daemon-wedge class.

`PKCRpcClient` had no per-call timeout: `_timeoutSeconds` (20s) only guards connection opening, and rpc-websockets applies none of its own, so a single lost/unmatched response pends forever with zero diagnostics.

## Reproduction (red before fix)

`test/node/rpc/rpc-client-lost-response.test.ts` runs a minimal in-test JSON-RPC websocket server that answers 4 of 5 concurrent `startCommunity` calls and drops one response — the same shape as the CI incident. Against the unmodified client the test failed with `expected 'hung' to equal 'settled'` after a 30s sentinel (the call pends forever).

## Fix

- Wrap the underlying websocket call in `pTimeout` throwing `ERR_RPC_CALL_TIMED_OUT` with the RPC method and timeout in `details`. Default is a deliberately generous 5 minutes (overridable via `PKC_RPC_CALL_TIMEOUT_MS`): some calls do unbounded server-side work (`startCommunity` repins a whole community), so the goal is converting infinite hangs into diagnosable errors, not bounding slow calls.
- DEBUG-trace call receipt and response dispatch in `rpcWebsocketsRegister`, so if the (still unidentified, environment-dependent) response loss recurs in CI, the per-test logs will show whether the response was never dispatched (server side) or dispatched but never matched (client side).

## Verification

- Repro test green after the fix: the dropped call rejects with `ERR_RPC_CALL_TIMED_OUT` (method `startCommunity` in details), the other 4 resolve; kept as the regression test.
- `rpc.auto-start.test.ts` 12/12 green against the fixed build, plus 3 clean stress-loop runs of the same file on the unfixed build confirming the natural trigger is environment-dependent (overloaded Windows runner).
- `community-update-subscription-churn.rpc.test.ts` 5/5 green under the RPC config.
- `npm run build` and test type-checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable per-RPC-call timeout (via environment setting), preventing indefinite hangs when RPC responses are not received.
* **Bug Fixes**
  * RPC calls now time out instead of hanging indefinitely when responses are lost.
  * Timeout errors include the affected RPC method name and the timeout value.
* **Diagnostics**
  * Added trace-level logging that correlates concurrent JSON-RPC requests and responses.
* **Tests**
  * Added an integration test covering lost RPC responses and ensuring the correct timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->