### PR TITLE
fix(rpc): re-attach notification handler after websocket reconnect and mark subscriptions stale

### DIFF
--- a/src/clients/rpc-client/pkc-rpc-client.ts
+++ b/src/clients/rpc-client/pkc-rpc-client.ts
@@ -77,6 +77,7 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
     private _callTimeoutMs: number;
     private _openConnectionPromise?: Promise<any>;
     private _destroyRequested: boolean;
+    private _notificationSocket?: unknown; // the socket our notification handler is currently attached to
     constructor(rpcServerUrl: string) {
         super();
         assert(rpcServerUrl, "pkc.pkcRpcClientsOptions needs to be defined to create a new rpc client");
@@ -131,8 +132,7 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
 
             this._webSocketClient = new WebSocketClient(this._websocketServerUrl);
             log("Created a new WebSocket instance with url " + this._websocketServerUrl);
-            //@ts-expect-error
-            this._webSocketClient.socket.on("message", (jsonMessage) => {
+            const handleNotificationMessage = (jsonMessage: string) => {
                 const message = JSON.parse(jsonMessage);
                 const subscriptionId = message?.params?.subscription;
                 if (subscriptionId) {
@@ -143,14 +143,29 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
                         message.params.result = this._deserializeRpcError(message.params.result);
                         delete (<any>message.params.result).stack; // Need to delete locally generated stack traces
                     }
-                    if (this._subscriptionEvents[subscriptionId].listenerCount(message?.params?.event) === 0)
-                        this._pendingSubscriptionMsgs[subscriptionId].push(message);
-                    else this._subscriptionEvents[subscriptionId].emit(message?.params?.event, message);
+                    this._emitOrBufferSubscriptionMessage(subscriptionId, message);
                 }
-            });
+            };
+            // rpc-websockets replaces its socket object on every reconnect and only re-attaches its own
+            // internals, so a handler bound to the old socket silently stops receiving notifications
+            // while calls keep working (issue #197). Re-attach to the current socket on every open.
+            const attachNotificationHandler = () => {
+                //@ts-expect-error
+                const currentSocket = this._webSocketClient.socket;
+                if (!currentSocket || currentSocket === this._notificationSocket) return false;
+                this._notificationSocket = currentSocket;
+                currentSocket.on("message", handleNotificationMessage);
+                return true;
+            };
+            attachNotificationHandler();
 
             this._webSocketClient.on("open", () => {
                 log("Connected to RPC server", this._websocketServerUrl);
+                const socketWasReplaced = attachNotificationHandler();
+                // A new socket after we already had one means the connection was re-established. The
+                // server keys subscriptions to the old connection, so existing subscriptions will never
+                // emit again — surface that loudly instead of letting consumers wait forever.
+                if (socketWasReplaced && Object.keys(this._subscriptionEvents).length > 0) this._emitStaleSubscriptionErrors();
                 this.setState("connected");
             });
             // forward errors to PKC
@@ -384,6 +399,34 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
     private _initSubscriptionEvent(subscriptionId: number) {
         if (!this._subscriptionEvents[subscriptionId]) this._subscriptionEvents[subscriptionId] = new EventEmitter();
         if (!this._pendingSubscriptionMsgs[subscriptionId]) this._pendingSubscriptionMsgs[subscriptionId] = [];
+    }
+
+    private _emitOrBufferSubscriptionMessage(
+        subscriptionId: number,
+        message: { params: { event: string; subscription: number; result: unknown } }
+    ) {
+        if (this._subscriptionEvents[subscriptionId].listenerCount(message.params.event) === 0)
+            this._pendingSubscriptionMsgs[subscriptionId].push(message);
+        else this._subscriptionEvents[subscriptionId].emit(message.params.event, message);
+    }
+
+    // The server keys subscriptions to a connection; after a reconnect they will never emit again.
+    // Notify every live subscription with an error event shaped like a wire notification so existing
+    // error handlers (e.g. RpcRemoteCommunity._handleRpcErrorEvent) surface it to consumers.
+    private _emitStaleSubscriptionErrors() {
+        const log = Logger("pkc-js:pkc-rpc-client:_emitStaleSubscriptionErrors");
+        for (const subscriptionIdString of Object.keys(this._subscriptionEvents)) {
+            const subscriptionId = Number(subscriptionIdString);
+            log(`Marking RPC subscription (${subscriptionId}) as stale after websocket reconnect`, this._websocketServerUrl);
+            const staleError = new PKCError("ERR_RPC_SUBSCRIPTION_STALE_AFTER_RECONNECT", {
+                subscriptionId,
+                rpcServerUrl: this._websocketServerUrl
+            });
+            this._initSubscriptionEvent(subscriptionId);
+            this._emitOrBufferSubscriptionMessage(subscriptionId, {
+                params: { result: staleError, subscription: subscriptionId, event: "error" }
+            });
+        }
     }
 
     async startCommunity(communityIdentifier: CommunityIdentifierRpcParam): Promise<RpcSubscriptionIdResult> {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -369,6 +369,7 @@ export enum messages {
     ERR_RPC_CLIENT_TRYING_TO_DELETE_REMOTE_COMMUNITY = "RPC client is attempting to delete remote community",
     ERR_GENERIC_RPC_CLIENT_CALL_ERROR = "RPC client received an unknown error when executing call over websocket",
     ERR_RPC_CALL_TIMED_OUT = "RPC client call timed out without receiving a response from the RPC server",
+    ERR_RPC_SUBSCRIPTION_STALE_AFTER_RECONNECT = "The RPC websocket connection was re-established; subscriptions from the previous connection are stale and will not emit further events",
     ERR_RPC_CLIENT_CHALLENGE_NAME_NOT_AVAILABLE_ON_SERVER = "The challenge name is not available on the RPC server. Available challenges are listed in details.availableChallenges",
     ERR_ROLE_ADDRESS_NAME_COULD_NOT_BE_RESOLVED = "Role address name could not be resolved",
 

--- a/test/node/rpc/rpc-client-notification-delivery.test.ts
+++ b/test/node/rpc/rpc-client-notification-delivery.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { WebSocketServer, type WebSocket, type RawData } from "ws";
+import { EventEmitter } from "events";
+import PKCRpcClient from "../../../dist/node/clients/rpc-client/pkc-rpc-client.js";
+
+// Repro harness for issue #197: the RPC server relayed update/error notifications for a fresh
+// communityUpdateSubscribe, but the client never observed a single event and the test hung.
+// Each case delivers notifications at a different point relative to the subscribe response, all
+// orderings a real server produces:
+//   - "before":    server emits events while the subscribe handler is still running (startCommunity
+//                  emits "update" before start() returns), so frames precede the response
+//   - "after":     server emits right after dispatching the response (the ordering in CI run
+//                  29060395726 — error at +17ms, update at +41ms)
+//   - "reconnect": the websocket drops after subscribing and rpc-websockets auto-reconnects; the
+//                  server sends the next notification on the new socket. PKCRpcClient binds its raw
+//                  notification handler to `_webSocketClient.socket` once in _init, so if the socket
+//                  object is replaced on reconnect the handler is left on the dead socket.
+
+interface JsonRpcRequest {
+    jsonrpc: "2.0";
+    id?: number;
+    method: string;
+    params: unknown[];
+}
+
+const SUBSCRIPTION_ID = 424242;
+
+const updateNotification = () =>
+    JSON.stringify({
+        jsonrpc: "2.0",
+        method: "communityUpdate",
+        params: { result: { updatedAt: 1234567890 }, subscription: SUBSCRIPTION_ID, event: "update" }
+    });
+
+const errorNotification = () =>
+    JSON.stringify({
+        jsonrpc: "2.0",
+        method: "communityUpdate",
+        params: {
+            result: { code: "ERR_COMMUNITY_NAME_RESOLVES_TO_DIFFERENT_PUBLIC_KEY", message: "test error", details: {} },
+            subscription: SUBSCRIPTION_ID,
+            event: "error"
+        }
+    });
+
+class ScriptableRpcServer {
+    wss: WebSocketServer;
+    port: number;
+    sockets: WebSocket[] = [];
+    /** called with (socket, message) for each JSON-RPC call; return false to suppress the default response */
+    onCall?: (socket: WebSocket, message: JsonRpcRequest) => boolean | void;
+
+    private constructor(wss: WebSocketServer, port: number) {
+        this.wss = wss;
+        this.port = port;
+        wss.on("connection", (socket: WebSocket) => {
+            this.sockets.push(socket);
+            socket.on("message", (raw: RawData) => {
+                const message = JSON.parse(raw.toString()) as JsonRpcRequest;
+                if (typeof message.id !== "number") return;
+                const sendDefaultResponse = this.onCall?.(socket, message);
+                if (sendDefaultResponse === false) return;
+                socket.send(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { subscriptionId: SUBSCRIPTION_ID } }));
+            });
+        });
+    }
+
+    static async create(): Promise<ScriptableRpcServer> {
+        const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+        await EventEmitter.once(wss, "listening");
+        const address = wss.address();
+        if (address === null || typeof address === "string") throw Error("Expected WebSocketServer to listen on a TCP port");
+        return new ScriptableRpcServer(wss, address.port);
+    }
+
+    get latestSocket(): WebSocket {
+        const socket = this.sockets[this.sockets.length - 1];
+        if (!socket) throw Error("No websocket connection established yet");
+        return socket;
+    }
+
+    async waitForNewConnection(previousCount: number, timeoutMs = 10_000): Promise<WebSocket> {
+        const start = Date.now();
+        while (Date.now() - start < timeoutMs) {
+            if (this.sockets.length > previousCount) return this.latestSocket;
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        throw Error("Timed out waiting for the client to reconnect");
+    }
+
+    async destroy() {
+        for (const client of this.wss.clients) client.terminate();
+        await new Promise<void>((resolve, reject) => this.wss.close((err) => (err ? reject(err) : resolve())));
+    }
+}
+
+// Mirrors the standard consumer pattern from RpcRemoteCommunity._initRpcUpdateSubscription:
+// subscribe -> register listeners -> flush pending messages
+const subscribeWithStandardWiring = async (client: PKCRpcClient, receivedEvents: string[]) => {
+    const { subscriptionId } = await client.communityUpdateSubscribe({ publicKey: "12D3KooWFakePublicKeyForNotificationTest" });
+    client
+        .getSubscription(subscriptionId)
+        .on("update", () => receivedEvents.push("update"))
+        .on("error", () => receivedEvents.push("error"));
+    client.emitAllPendingMessages(subscriptionId);
+    return subscriptionId;
+};
+
+const waitFor = async (predicate: () => boolean, timeoutMs: number): Promise<boolean> => {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        if (predicate()) return true;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    return predicate();
+};
+
+describe("PKCRpcClient subscription notification delivery (issue #197)", () => {
+    let server: ScriptableRpcServer;
+    let client: PKCRpcClient;
+
+    afterEach(async () => {
+        await client?.destroy();
+        await server?.destroy();
+    });
+
+    it("delivers notifications sent before the subscribe response", async () => {
+        server = await ScriptableRpcServer.create();
+        server.onCall = (socket, message) => {
+            if (message.method !== "communityUpdateSubscribe") return;
+            socket.send(updateNotification());
+            socket.send(errorNotification());
+            // default response is sent after the notifications
+        };
+        client = new PKCRpcClient(`ws://127.0.0.1:${server.port}`);
+
+        const receivedEvents: string[] = [];
+        await subscribeWithStandardWiring(client, receivedEvents);
+
+        expect(await waitFor(() => receivedEvents.length === 2, 5_000), `received only: ${receivedEvents.join(",")}`).to.equal(true);
+        expect(receivedEvents).to.include("update");
+        expect(receivedEvents).to.include("error");
+    });
+
+    it("delivers notifications sent right after the subscribe response", async () => {
+        server = await ScriptableRpcServer.create();
+        server.onCall = (socket, message) => {
+            if (message.method !== "communityUpdateSubscribe") return;
+            setImmediate(() => {
+                socket.send(updateNotification());
+                socket.send(errorNotification());
+            });
+        };
+        client = new PKCRpcClient(`ws://127.0.0.1:${server.port}`);
+
+        const receivedEvents: string[] = [];
+        await subscribeWithStandardWiring(client, receivedEvents);
+
+        expect(await waitFor(() => receivedEvents.length === 2, 5_000), `received only: ${receivedEvents.join(",")}`).to.equal(true);
+        expect(receivedEvents).to.include("update");
+        expect(receivedEvents).to.include("error");
+    });
+
+    it("delivers notifications sent after the websocket reconnects", async () => {
+        server = await ScriptableRpcServer.create();
+        client = new PKCRpcClient(`ws://127.0.0.1:${server.port}`);
+
+        const receivedEvents: string[] = [];
+        await subscribeWithStandardWiring(client, receivedEvents);
+        const updateCount = () => receivedEvents.filter((e) => e === "update").length;
+
+        // Sanity: delivery works on the original socket
+        server.latestSocket.send(updateNotification());
+        expect(await waitFor(() => updateCount() === 1, 5_000), "notification on original socket was not delivered").to.equal(true);
+
+        // Drop the connection; rpc-websockets reconnects automatically (default reconnect: true)
+        const connectionCountBeforeDrop = server.sockets.length;
+        server.latestSocket.terminate();
+        const newSocket = await server.waitForNewConnection(connectionCountBeforeDrop);
+
+        // The server relays the next event on the new connection
+        newSocket.send(updateNotification());
+
+        expect(
+            await waitFor(() => updateCount() === 2, 5_000),
+            "notification after reconnect was not delivered — raw socket handler is bound to the dead socket"
+        ).to.equal(true);
+    });
+
+    it("emits a stale-subscription error on live subscriptions after the websocket reconnects", async () => {
+        server = await ScriptableRpcServer.create();
+        client = new PKCRpcClient(`ws://127.0.0.1:${server.port}`);
+
+        const receivedEvents: string[] = [];
+        const receivedErrors: { code?: string }[] = [];
+        const { subscriptionId } = await client.communityUpdateSubscribe({ publicKey: "12D3KooWFakePublicKeyForNotificationTest" });
+        client
+            .getSubscription(subscriptionId)
+            .on("update", () => receivedEvents.push("update"))
+            .on("error", (message: { params: { result: { code?: string } } }) => receivedErrors.push(message.params.result));
+        client.emitAllPendingMessages(subscriptionId);
+
+        // Drop the connection; rpc-websockets reconnects automatically. The server-side subscription
+        // is keyed to the dead connection, so the client must tell consumers it went stale.
+        const connectionCountBeforeDrop = server.sockets.length;
+        server.latestSocket.terminate();
+        await server.waitForNewConnection(connectionCountBeforeDrop);
+
+        expect(await waitFor(() => receivedErrors.length === 1, 5_000), "no stale-subscription error was emitted after reconnect").to.equal(
+            true
+        );
+        expect(receivedErrors[0].code).to.equal("ERR_RPC_SUBSCRIPTION_STALE_AFTER_RECONNECT");
+    });
+});


### PR DESCRIPTION
Fixes #197. Stacked on #196 (both touch `pkc-rpc-client.ts`); will retarget to `master` once #196 merges.

## Problem

CI run 29060395726, `test-pkc-rpc`: the RPC server relayed update/error events for a fresh `communityUpdateSubscribe` within one second of the test starting, yet the client never observed a single event and the test hung for 160s.

## Root cause (reproduced deterministically)

`PKCRpcClient._init` bound its raw notification handler to `this._webSocketClient.socket` exactly once. rpc-websockets auto-reconnects on any connection blip (default `reconnect: true`) and **replaces the socket object**, re-attaching only its own internals — so RPC calls keep working while every subscription notification lands on a dead socket. Silent, permanent event loss for all subscriptions on that client. Two aggravating factors: the server relays via `connections[id]?.send?.()` (a silent no-op to a dead connection), and server-side subscriptions are keyed to the old connection, so even a live handler would receive nothing after reconnect.

The new regression suite (`test/node/rpc/rpc-client-notification-delivery.test.ts`) proves it with a minimal in-test JSON-RPC websocket server:

- notifications sent **before** the subscribe response: delivered (pending-message buffering) — passed before the fix
- notifications sent **right after** the response: delivered — passed before the fix
- notifications sent **after an auto-reconnect**: **red before the fix** (`notification after reconnect was not delivered`), green after

## Fix

- Re-attach the notification handler to the current socket on every rpc-websockets `open` (no-op when the socket is unchanged).
- When the socket was replaced (a reconnect), emit `ERR_RPC_SUBSCRIPTION_STALE_AFTER_RECONNECT` on every live subscription emitter, shaped like a wire error notification so existing consumer error handlers (`RpcRemoteCommunity._handleRpcErrorEvent` etc.) surface it. Consumers now fail loudly instead of waiting forever on a subscription the server will never feed again.

Transparent re-subscription after reconnect (restoring the update flow end-to-end) is intentionally out of scope; the stale error gives consumers the signal to re-subscribe themselves.

## Verification

- New regression suite 4/4 (reconnect case red before the fix).
- Full `src/rpc/test/node` suite 59/59.
- `rpc-client-lost-response` regression (from #196) still green.
- `community-update-subscription-churn.rpc` 5/5 under the RPC config.
- `npm run build` and test type-checks pass.