### PR TITLE
perf(helia): scope bitswap session seed peers to the community being fetched

### DIFF
--- a/src/clients/base-client-manager.ts
+++ b/src/clients/base-client-manager.ts
@@ -715,7 +715,15 @@ export class BaseClientsManager {
 
     async _fetchCidP2P(
         cidV0: string,
-        loadOpts: { maxFileSizeBytes: number; timeoutMs: number; abortSignal?: AbortSignal }
+        loadOpts: {
+            maxFileSizeBytes: number;
+            timeoutMs: number;
+            abortSignal?: AbortSignal;
+            // IPNS-over-pubsub record topic of the community the CID belongs to, used to scope
+            // bitswap session seed peers when fetching through helia (issue #202). Ignored (and
+            // never forwarded) when the fetch goes through kubo-rpc-client.
+            bitswapSessionSeedScopeIpnsPubsubTopic?: string;
+        }
     ): Promise<string> {
         const log = Logger("pkc-js:clients-manager:_fetchCidP2P");
         throwIfAbortSignalAborted(loadOpts.abortSignal);
@@ -724,7 +732,13 @@ export class BaseClientsManager {
         const ipfsClient = this.getIpfsClientWithKuboRpcClientFunctions();
 
         const fetchPromise = async () => {
-            const rawData = await all(ipfsClient.cat(cidV0, { length: loadOpts.maxFileSizeBytes, timeout: `${loadOpts.timeoutMs}ms` }));
+            const seedScopeOptions =
+                "_helia" in kuboRpcOrHelia && loadOpts.bitswapSessionSeedScopeIpnsPubsubTopic
+                    ? { bitswapSessionSeedScopeIpnsPubsubTopic: loadOpts.bitswapSessionSeedScopeIpnsPubsubTopic }
+                    : undefined;
+            const rawData = await all(
+                ipfsClient.cat(cidV0, { length: loadOpts.maxFileSizeBytes, timeout: `${loadOpts.timeoutMs}ms`, ...seedScopeOptions })
+            );
             const data = uint8ArrayConcat(rawData);
             const fileContent = uint8ArrayToString(data);
 

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -550,7 +550,8 @@ export class CommunityClientsManager extends PKCClientsManager {
             rawCommunityJsonString = await this._fetchCidP2P(latestCommunityCid, {
                 maxFileSizeBytes: MAX_FILE_SIZE_BYTES_FOR_COMMUNITY_IPFS,
                 timeoutMs: this._pkc._timeouts["community-ipfs"],
-                abortSignal: this._community._getStopAbortSignal()
+                abortSignal: this._community._getStopAbortSignal(),
+                bitswapSessionSeedScopeIpnsPubsubTopic: this._community.ipnsPubsubTopic
             });
         } catch (e) {
             //@ts-expect-error

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -206,23 +206,18 @@ export async function createLibp2pJsClientOrUseExistingOne(
         // still tops the session up with independently-discovered providers — seeding all 5 slots
         // would eliminate router traffic entirely but also all discovery redundancy.
         const MAX_BITSWAP_SESSION_SEED_PEERS = 3;
-        // Most-recent-first peer ids that served us an IPNS record via the direct-fetch fast path
-        // (see DirectFetchResult). They're the best session seeds: in the pkc topology the record
-        // server essentially always has the blocks its record points to.
-        const RECENT_IPNS_RECORD_SERVERS_MAX = 8;
-        const recentIpnsRecordServerPeerIdStrings: string[] = [];
-        const rememberIpnsRecordServerPeer = (peerIdString: string) => {
-            const existingIndex = recentIpnsRecordServerPeerIdStrings.indexOf(peerIdString);
-            if (existingIndex !== -1) recentIpnsRecordServerPeerIdStrings.splice(existingIndex, 1);
-            recentIpnsRecordServerPeerIdStrings.unshift(peerIdString);
-            if (recentIpnsRecordServerPeerIdStrings.length > RECENT_IPNS_RECORD_SERVERS_MAX) recentIpnsRecordServerPeerIdStrings.pop();
-        };
-        const getBitswapSessionSeedPeers = () => {
+        // scopeIpnsPubsubTopic is the IPNS-over-pubsub record topic of the community whose CID is
+        // being fetched (issue #202). Its current subscribers are the best seeds: the community's
+        // record server must be subscribed there to serve records on it, and in the pkc topology
+        // it provides every block under the community. Stateless by design — a per-name
+        // remembered-record-servers list would go stale on disconnect and can point at another
+        // community's server in multi-community apps.
+        const getBitswapSessionSeedPeers = (scopeIpnsPubsubTopic?: string) => {
             const pubsub = helia.libp2p.services.pubsub;
             return selectBitswapSessionSeedPeers({
                 connectedPeers: helia.libp2p.getPeers(),
+                scopedPubsubSubscriberPeerIdStrings: scopeIpnsPubsubTopic ? pubsub.getSubscribers(scopeIpnsPubsubTopic).map(String) : [],
                 pubsubSubscriberPeerIdStrings: pubsub.getTopics().flatMap((topic) => pubsub.getSubscribers(topic).map(String)),
-                recentIpnsRecordServerPeerIdStrings,
                 maxSeeds: MAX_BITSWAP_SESSION_SEED_PEERS
             });
         };
@@ -380,9 +375,6 @@ export async function createLibp2pJsClientOrUseExistingOne(
                                         source: direct.source,
                                         peerId: direct.peerId
                                     };
-                                    // The record server is the best seed for the bitswap session
-                                    // that will fetch the record's blocks right after this resolve.
-                                    rememberIpnsRecordServerPeer(direct.peerId);
                                     // Record already validated inside the helper — unmarshal directly,
                                     // do NOT re-run ipnsValidator.
                                     const record = unmarshalIPNSRecord(direct.recordBytes);
@@ -514,6 +506,8 @@ export async function createLibp2pJsClientOrUseExistingOne(
                 // underlying blockstore helia uses, so nothing else changes.
                 const rootCid = CID.parse(ipfsPath.split("/")[0]);
                 const timeoutMs = parseKuboStyleTimeoutMs(options?.timeout); // throws on unparseable timeout at call time
+                // Our own option, not kubo-rpc-client's — strip it so it never reaches unixfs cat.
+                const { bitswapSessionSeedScopeIpnsPubsubTopic, ...unixfsCatOptions } = options ?? {};
 
                 return (async function* () {
                     // Bound the fetch's lifetime: honor the caller's signal AND the kubo-style
@@ -535,7 +529,9 @@ export async function createLibp2pJsClientOrUseExistingOne(
                             : undefined;
                     try {
                         for (let attempt = 0; ; attempt++) {
-                            const session = helia.blockstore.createSession(rootCid, { providers: getBitswapSessionSeedPeers() });
+                            const session = helia.blockstore.createSession(rootCid, {
+                                providers: getBitswapSessionSeedPeers(bitswapSessionSeedScopeIpnsPubsubTopic)
+                            });
                             let yieldedAnyBytes = false;
                             try {
                                 // ipfsPath is either a bare cid or a `<root-cid>/sub/path`. Hand the whole
@@ -543,7 +539,7 @@ export async function createLibp2pJsClientOrUseExistingOne(
                                 // asHeliaCatCid above for why the `path` option would re-trip the
                                 // exporter's CID identity check.
                                 const catIterable = unixfs({ blockstore: session }).cat(asHeliaCatCid(ipfsPath), {
-                                    ...options,
+                                    ...unixfsCatOptions,
                                     signal: controller.signal
                                 });
                                 for await (const chunk of catIterable) {

--- a/src/helia/types.ts
+++ b/src/helia/types.ts
@@ -7,7 +7,15 @@ import type { Fetch } from "@libp2p/fetch";
 export interface HeliaWithKuboRpcClientFunctions extends Pick<NonNullable<KuboRpcClient["_client"]>, "add" | "cat" | "pubsub" | "stop"> {
     add: KuboRpcClient["_client"]["add"];
     name: Pick<KuboRpcClient["_client"]["name"], "resolve">;
-    cat: KuboRpcClient["_client"]["cat"];
+    // cat accepts one extra option on top of kubo-rpc-client's: the IPNS-over-pubsub record
+    // topic of the community whose CID is being fetched, used to scope bitswap session seed
+    // peers to that community's subscribers (issue #202). Kubo-rpc-client callers never pass it.
+    // Method syntax (not an arrow-function property) so the implementation's narrower string
+    // ipfsPath stays assignable via bivariant parameter checking, same as the original Pick.
+    cat(
+        ipfsPath: Parameters<KuboRpcClient["_client"]["cat"]>[0],
+        options?: Parameters<KuboRpcClient["_client"]["cat"]>[1] & { bitswapSessionSeedScopeIpnsPubsubTopic?: string }
+    ): ReturnType<KuboRpcClient["_client"]["cat"]>;
     pubsub: KuboRpcClient["_client"]["pubsub"];
     stop: KuboRpcClient["_client"]["stop"];
 }

--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -335,20 +335,22 @@ export async function connectToPubsubPeers({
     return connectedPeersWithContent;
 }
 
-// Pick which already-connected peers to seed a bitswap session with (issue #189). Seeded
+// Pick which already-connected peers to seed a bitswap session with (issues #189, #202). Seeded
 // providers are consumed by @helia/utils' AbstractSession before it queries routing, so a good
 // seed means the first WANT-BLOCK goes out immediately and routing is only a background top-up.
 // Priority order mirrors "who most likely has the DAG we're about to walk":
-//   1. peers that recently served us an IPNS record over the direct-fetch path (in the pkc
-//      topology the record server essentially always has the blocks the record points to)
-//   2. gossipsub subscribers of topics we're subscribed to (community-serving peers)
+//   1. gossipsub subscribers of the fetched community's IPNS-over-pubsub record topic — the
+//      community's record server must be subscribed there to serve records on it, and in the
+//      pkc topology it provides every block under the community (record, pages, comments,
+//      postUpdates); other subscribers are followers that recently fetched the same blocks
+//   2. gossipsub subscribers of any other topic we're subscribed to (community-serving peers)
 //   3. any other connected peer
 // The cap must stay below the session's maxProviders (default 5) so the background routing
 // query keeps contributing discovery redundancy instead of being crowded out by seeds.
 export function selectBitswapSessionSeedPeers(args: {
     connectedPeers: PeerId[];
+    scopedPubsubSubscriberPeerIdStrings: string[]; // subscribers of the fetched community's IPNS record topic
     pubsubSubscriberPeerIdStrings: string[];
-    recentIpnsRecordServerPeerIdStrings: string[]; // most recent first
     maxSeeds: number;
 }): PeerId[] {
     if (args.connectedPeers.length === 0 || args.maxSeeds <= 0) return [];
@@ -362,7 +364,7 @@ export function selectBitswapSessionSeedPeers(args: {
             seeds.push(connectedPeer);
         }
     };
-    args.recentIpnsRecordServerPeerIdStrings.forEach(pushIfConnected);
+    args.scopedPubsubSubscriberPeerIdStrings.forEach(pushIfConnected);
     args.pubsubSubscriberPeerIdStrings.forEach(pushIfConnected);
     for (const peer of args.connectedPeers) pushIfConnected(peer.toString());
     return seeds.slice(0, args.maxSeeds);

--- a/src/pages/pages-client-manager.ts
+++ b/src/pages/pages-client-manager.ts
@@ -241,7 +241,13 @@ export class BasePagesClientsManager extends BaseClientsManager {
         const pageTimeoutMs = this._pkc._timeouts["page-ipfs"];
         try {
             const rawJson = await this._retryTransientP2PFetch(
-                () => this._fetchCidP2P(pageCid, { maxFileSizeBytes: pageMaxSize, timeoutMs: pageTimeoutMs, abortSignal }),
+                () =>
+                    this._fetchCidP2P(pageCid, {
+                        maxFileSizeBytes: pageMaxSize,
+                        timeoutMs: pageTimeoutMs,
+                        abortSignal,
+                        bitswapSessionSeedScopeIpnsPubsubTopic: this._pages._community.ipnsPubsubTopic
+                    }),
                 { log, context: `page ${pageCid}`, abortSignal }
             );
             return this.parsePageJson(parseJsonWithPKCErrorIfFails(rawJson)) as PageIpfs;

--- a/src/pages/pages.ts
+++ b/src/pages/pages.ts
@@ -20,6 +20,11 @@ import type { PageRuntimeFields } from "./util.js";
 type BaseProps = {
     community: Pick<RemoteCommunity, "publicKey" | "name" | "signature"> & {
         _getStopAbortSignal?: () => AbortSignal | undefined;
+        // IPNS-over-pubsub record topic of the community these pages belong to, used to scope
+        // bitswap session seed peers when fetching page CIDs through helia (issue #202).
+        // PostsPages/ModQueuePages read it off the RemoteCommunity instance itself; RepliesPages
+        // get it propagated by Comment.setCommunityAddress.
+        ipnsPubsubTopic?: RemoteCommunity["ipnsPubsubTopic"];
     };
     pkc: PKC;
 };

--- a/src/publications/comment/comment-client-manager.ts
+++ b/src/publications/comment/comment-client-manager.ts
@@ -14,7 +14,14 @@ import { FailedToFetchCommentUpdateFromGatewaysError, PKCError } from "../../pkc
 import { verifyCommentIpfs, verifyCommentUpdate } from "../../signer/signatures.js";
 import { getPKCAddressFromPublicKeySync } from "../../signer/util.js";
 import Logger from "../../logger.js";
-import { getPostUpdateTimestampRange, hideClassPrivateProps, isAbortError, resolveWhenPredicateIsTrue } from "../../util.js";
+import {
+    getPostUpdateTimestampRange,
+    hideClassPrivateProps,
+    ipnsNameToIpnsOverPubsubTopic,
+    isAbortError,
+    isIpns,
+    resolveWhenPredicateIsTrue
+} from "../../util.js";
 import { PublicationClientsManager } from "../publication-client-manager.js";
 import { RemoteCommunity } from "../../community/remote-community.js";
 import { findCommentInPageInstance, findCommentInPageInstanceRecursively, findCommentInParsedPages } from "../../pages/util.js";
@@ -140,6 +147,18 @@ export class CommentClientsManager extends PublicationClientsManager {
         return `${folderCid}/` + postCid + "/update";
     }
 
+    // IPNS-over-pubsub record topic of the comment's community, used to scope bitswap session
+    // seed peers when fetching this comment's CIDs through helia (issue #202). Prefer the
+    // updating community instance (anchor-aware for delegated/domain communities); otherwise an
+    // IPNS community address IS the anchor IPNS name, so the topic is derivable directly.
+    // Undefined (unscoped fetch) for a bare cid-only comment whose community isn't known yet.
+    private _bitswapSessionSeedScopeIpnsPubsubTopic(): string | undefined {
+        if (this._communityForUpdating?.community?.ipnsPubsubTopic) return this._communityForUpdating.community.ipnsPubsubTopic;
+        const communityAddress = this._comment.communityAddress;
+        if (communityAddress && isIpns(communityAddress)) return ipnsNameToIpnsOverPubsubTopic(communityAddress);
+        return undefined;
+    }
+
     _updateKuboRpcClientOrHeliaState(
         newState: CommentKuboRpcClient["state"] | CommentLibp2pJsClient["state"],
         kuboRpcOrHelia: PKC["clients"]["kuboRpcClients"][string] | PKC["clients"]["libp2pJsClients"][string]
@@ -187,7 +206,8 @@ export class CommentClientsManager extends PublicationClientsManager {
                         this._fetchCidP2P(path, {
                             maxFileSizeBytes: MAX_FILE_SIZE_BYTES_FOR_COMMENT_UPDATE,
                             timeoutMs: commentUpdateTimeoutMs,
-                            abortSignal
+                            abortSignal,
+                            bitswapSessionSeedScopeIpnsPubsubTopic: this._bitswapSessionSeedScopeIpnsPubsubTopic()
                         }),
                     { abortSignal, log, context: `post-update ${path}` }
                 );
@@ -429,7 +449,8 @@ export class CommentClientsManager extends PublicationClientsManager {
             commentRawString = await this._fetchCidP2P(cid, {
                 maxFileSizeBytes: 1024 * 1024,
                 timeoutMs: commentTimeoutMs,
-                abortSignal: this._comment._getStopAbortSignal()
+                abortSignal: this._comment._getStopAbortSignal(),
+                bitswapSessionSeedScopeIpnsPubsubTopic: this._bitswapSessionSeedScopeIpnsPubsubTopic()
             });
         } catch (e) {
             //@ts-expect-error

--- a/src/publications/comment/comment.ts
+++ b/src/publications/comment/comment.ts
@@ -3,7 +3,9 @@ import {
     createAbortError,
     deepMergeRuntimeFields,
     hideClassPrivateProps,
+    ipnsNameToIpnsOverPubsubTopic,
     isAbortError,
+    isIpns,
     retryKuboIpfsAdd,
     shortifyCid,
     sleepUntilTimeoutOrAbort
@@ -631,6 +633,11 @@ export class Comment
         super.setCommunityAddress(newCommunityAddress);
         this.replies._community.publicKey = this.communityPublicKey;
         this.replies._community.name = this.communityName;
+        // An IPNS community address IS the anchor IPNS name (see names-and-addresses.md), so the
+        // record topic is derivable directly. Domain addresses stay unscoped (issue #202).
+        this.replies._community.ipnsPubsubTopic = isIpns(newCommunityAddress)
+            ? ipnsNameToIpnsOverPubsubTopic(newCommunityAddress)
+            : undefined;
     }
 
     private _isCommentIpfsErrorRetriable(err: PKCError | Error): boolean {

--- a/test/node-and-browser/helia/helia.test.ts
+++ b/test/node-and-browser/helia/helia.test.ts
@@ -8,6 +8,7 @@ import {
     createMockedCommunityIpns
 } from "../../../dist/node/test/test-util.js";
 import signers from "../../fixtures/signers.js";
+import validPageFixture from "../../fixtures/valid_page.json" with { type: "json" };
 import { describe, it, beforeAll, afterAll, expect, vi } from "vitest";
 import type { PKC } from "../../../dist/node/pkc/pkc.js";
 import type { Comment } from "../../../dist/node/publications/comment/comment.js";
@@ -646,5 +647,99 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 await testPKC.destroy();
             }
         }, 90000);
+    });
+
+    // Issue #202: every CID fetched over the helia transport belongs to a community, and that
+    // community's record server (a subscriber of its IPNS-over-pubsub topic) by construction
+    // provides every block under it. Fetch call sites therefore pass the community's IPNS record
+    // pubsub topic through _fetchCidP2P -> cat() as a seed scope, so the bitswap session seeds
+    // subscribers of THAT topic first instead of a global recent-record-servers list that can
+    // point at another community's server in multi-community apps.
+    describe(`Bitswap session seeds are scoped to the community being fetched (issue #202) - ${config.name}`, () => {
+        const getScopeOfCatCall = (options: unknown): string | undefined =>
+            (options as { bitswapSessionSeedScopeIpnsPubsubTopic?: string } | undefined)?.bitswapSessionSeedScopeIpnsPubsubTopic;
+
+        it("fetching a page passes the community's IPNS record pubsub topic as the session seed scope", async () => {
+            const testPKC = await config.pkcInstancePromise({ forceMockPubsub: true });
+            try {
+                const heliaClient = Object.values(testPKC.clients.libp2pJsClients)[0];
+                const mockCommunity = await testPKC.createCommunity({ address: signers[0].address });
+                expect(mockCommunity.ipnsPubsubTopic).to.be.a("string");
+
+                const pageCid = await addStringToIpfs(JSON.stringify(validPageFixture));
+                mockCommunity.posts.pageCids = { ...mockCommunity.posts.pageCids, hot: pageCid };
+
+                const catSpy = vi.spyOn(heliaClient.heliaWithKuboRpcClientFunctions, "cat");
+                try {
+                    await mockCommunity.posts.getPage({ cid: pageCid });
+                    const pageCatCall = catSpy.mock.calls.find(([path]) => path === pageCid);
+                    expect(pageCatCall, `expected a cat() call for page cid ${pageCid}`).to.exist;
+                    expect(getScopeOfCatCall(pageCatCall![1])).to.equal(mockCommunity.ipnsPubsubTopic);
+                } finally {
+                    catSpy.mockRestore();
+                }
+            } finally {
+                await testPKC.destroy();
+            }
+        }, 90000);
+
+        it("fetching the community record CID passes the community's IPNS record pubsub topic as the session seed scope", async () => {
+            const testPKC = await config.pkcInstancePromise({ forceMockPubsub: false });
+            try {
+                const heliaClient = Object.values(testPKC.clients.libp2pJsClients)[0];
+                const catSpy = vi.spyOn(heliaClient.heliaWithKuboRpcClientFunctions, "cat");
+                try {
+                    const community = await testPKC.createCommunity({ address: mathCliNoMockedPubsubCommunityAddress });
+                    await community.update();
+                    await resolveWhenConditionIsTrue({
+                        toUpdate: community,
+                        predicate: async () => typeof community.updatedAt === "number"
+                    });
+                    await community.stop();
+                    expect(community.updateCid).to.be.a("string");
+                    const recordCatCall = catSpy.mock.calls.find(([path]) => path === community.updateCid);
+                    expect(recordCatCall, `expected a cat() call for community record cid ${community.updateCid}`).to.exist;
+                    expect(getScopeOfCatCall(recordCatCall![1])).to.equal(community.ipnsPubsubTopic);
+                } finally {
+                    catSpy.mockRestore();
+                }
+            } finally {
+                await testPKC.destroy();
+            }
+        }, 90000);
+
+        it("fetching CommentIpfs and the postUpdates CommentUpdate walk pass the community's session seed scope", async () => {
+            const testPKC = await config.pkcInstancePromise({ forceMockPubsub: false });
+            try {
+                const post = await generatePostToAnswerMathQuestion({ communityAddress: mathCliNoMockedPubsubCommunityAddress }, testPKC);
+                await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+                expect(post.cid).to.be.a("string");
+
+                const heliaClient = Object.values(testPKC.clients.libp2pJsClients)[0];
+                const comment = await testPKC.createComment({ cid: post.cid!, communityAddress: mathCliNoMockedPubsubCommunityAddress });
+                const catSpy = vi.spyOn(heliaClient.heliaWithKuboRpcClientFunctions, "cat");
+                try {
+                    await comment.update();
+                    await resolveWhenConditionIsTrue({ toUpdate: comment, predicate: async () => typeof comment.updatedAt === "number" });
+                    await comment.stop();
+
+                    const expectedScope = ipnsNameToIpnsOverPubsubTopic(mathCliNoMockedPubsubCommunityAddress);
+
+                    const commentIpfsCatCall = catSpy.mock.calls.find(([path]) => path === post.cid);
+                    expect(commentIpfsCatCall, `expected a cat() call for CommentIpfs cid ${post.cid}`).to.exist;
+                    expect(getScopeOfCatCall(commentIpfsCatCall![1])).to.equal(expectedScope);
+
+                    const updateWalkCatCall = catSpy.mock.calls.find(
+                        ([path]) => typeof path === "string" && path.endsWith(`/${post.cid}/update`)
+                    );
+                    expect(updateWalkCatCall, `expected a cat() call for the postUpdates walk of ${post.cid}`).to.exist;
+                    expect(getScopeOfCatCall(updateWalkCatCall![1])).to.equal(expectedScope);
+                } finally {
+                    catSpy.mockRestore();
+                }
+            } finally {
+                await testPKC.destroy();
+            }
+        }, 120000);
     });
 });

--- a/test/node/helia/bitswap-session-seed-peers.unit.test.ts
+++ b/test/node/helia/bitswap-session-seed-peers.unit.test.ts
@@ -4,74 +4,105 @@ import { peerIdFromPrivateKey } from "@libp2p/peer-id";
 import type { PeerId } from "@libp2p/interface";
 import { selectBitswapSessionSeedPeers } from "../../../dist/node/helia/util.js";
 
-// Unit coverage for the seed-selection helper behind the per-DAG bitswap sessions (issue #189).
-// The integration behavior (one routing query per DAG, seeded fetch with routing blinded) is
-// covered in test/node-and-browser/helia/helia.test.ts; this pins the pure ordering/dedupe/cap
-// logic: recent IPNS record servers first, then pubsub subscribers, then any other connected
-// peer — all restricted to currently-connected peers.
-describe("selectBitswapSessionSeedPeers (issue #189)", () => {
+// Unit coverage for the seed-selection helper behind the per-DAG bitswap sessions (issues #189,
+// #202). The integration behavior (one routing query per DAG, seeded fetch with routing blinded,
+// scope plumbing from the fetch call sites) is covered in
+// test/node-and-browser/helia/helia.test.ts; this pins the pure ordering/dedupe/cap logic:
+// subscribers of the fetched community's IPNS record topic first (its record server must be
+// subscribed there to serve records, and by construction provides every block under the
+// community), then subscribers of any other subscribed topic, then any other connected peer —
+// all restricted to currently-connected peers.
+describe("selectBitswapSessionSeedPeers (issues #189, #202)", () => {
     const newPeerId = async (): Promise<PeerId> => peerIdFromPrivateKey(await generateKeyPair("Ed25519"));
 
     it("returns empty when there are no connected peers, regardless of candidates", async () => {
-        const disconnectedRecordServer = await newPeerId();
+        const disconnectedSubscriber = await newPeerId();
         expect(
             selectBitswapSessionSeedPeers({
                 connectedPeers: [],
-                pubsubSubscriberPeerIdStrings: [disconnectedRecordServer.toString()],
-                recentIpnsRecordServerPeerIdStrings: [disconnectedRecordServer.toString()],
+                scopedPubsubSubscriberPeerIdStrings: [disconnectedSubscriber.toString()],
+                pubsubSubscriberPeerIdStrings: [disconnectedSubscriber.toString()],
                 maxSeeds: 3
             })
         ).to.deep.equal([]);
     });
 
-    it("orders seeds: record servers, then pubsub subscribers, then remaining connected peers", async () => {
-        const recordServer = await newPeerId();
+    it("orders seeds: scoped-topic subscribers, then other subscribers, then remaining connected peers", async () => {
+        const scopedSubscriber = await newPeerId();
+        const otherTopicSubscriber = await newPeerId();
+        const plainConnected = await newPeerId();
+        const seeds = selectBitswapSessionSeedPeers({
+            connectedPeers: [plainConnected, otherTopicSubscriber, scopedSubscriber],
+            scopedPubsubSubscriberPeerIdStrings: [scopedSubscriber.toString()],
+            // the unscoped list contains subscribers of ALL subscribed topics, scoped ones included
+            pubsubSubscriberPeerIdStrings: [otherTopicSubscriber.toString(), scopedSubscriber.toString()],
+            maxSeeds: 3
+        });
+        expect(seeds.map(String)).to.deep.equal([scopedSubscriber.toString(), otherTopicSubscriber.toString(), plainConnected.toString()]);
+    });
+
+    it("a scoped-topic subscriber outranks an earlier-listed subscriber of another topic", async () => {
+        const scopedSubscriber = await newPeerId();
+        const otherTopicSubscriber = await newPeerId();
+        const seeds = selectBitswapSessionSeedPeers({
+            connectedPeers: [otherTopicSubscriber, scopedSubscriber],
+            scopedPubsubSubscriberPeerIdStrings: [scopedSubscriber.toString()],
+            pubsubSubscriberPeerIdStrings: [otherTopicSubscriber.toString(), scopedSubscriber.toString()],
+            maxSeeds: 1
+        });
+        expect(seeds.map(String)).to.deep.equal([scopedSubscriber.toString()]);
+    });
+
+    it("falls back to subscriber-then-connected ordering when no scope is given", async () => {
         const subscriber = await newPeerId();
         const plainConnected = await newPeerId();
         const seeds = selectBitswapSessionSeedPeers({
-            connectedPeers: [plainConnected, subscriber, recordServer],
+            connectedPeers: [plainConnected, subscriber],
+            scopedPubsubSubscriberPeerIdStrings: [],
             pubsubSubscriberPeerIdStrings: [subscriber.toString()],
-            recentIpnsRecordServerPeerIdStrings: [recordServer.toString()],
             maxSeeds: 3
         });
-        expect(seeds.map(String)).to.deep.equal([recordServer.toString(), subscriber.toString(), plainConnected.toString()]);
+        expect(seeds.map(String)).to.deep.equal([subscriber.toString(), plainConnected.toString()]);
     });
 
-    it("ignores record servers and subscribers that are no longer connected", async () => {
-        const disconnectedRecordServer = await newPeerId();
+    it("ignores scoped subscribers and other subscribers that are no longer connected", async () => {
+        const disconnectedScopedSubscriber = await newPeerId();
         const connectedPeer = await newPeerId();
         const seeds = selectBitswapSessionSeedPeers({
             connectedPeers: [connectedPeer],
-            pubsubSubscriberPeerIdStrings: [disconnectedRecordServer.toString()],
-            recentIpnsRecordServerPeerIdStrings: [disconnectedRecordServer.toString()],
+            scopedPubsubSubscriberPeerIdStrings: [disconnectedScopedSubscriber.toString()],
+            pubsubSubscriberPeerIdStrings: [disconnectedScopedSubscriber.toString()],
             maxSeeds: 3
         });
         expect(seeds.map(String)).to.deep.equal([connectedPeer.toString()]);
     });
 
     it("dedupes a peer that appears in multiple tiers", async () => {
-        const recordServerAndSubscriber = await newPeerId();
+        const scopedAndUnscopedSubscriber = await newPeerId();
         const seeds = selectBitswapSessionSeedPeers({
-            connectedPeers: [recordServerAndSubscriber],
-            pubsubSubscriberPeerIdStrings: [recordServerAndSubscriber.toString()],
-            recentIpnsRecordServerPeerIdStrings: [recordServerAndSubscriber.toString()],
+            connectedPeers: [scopedAndUnscopedSubscriber],
+            scopedPubsubSubscriberPeerIdStrings: [scopedAndUnscopedSubscriber.toString()],
+            pubsubSubscriberPeerIdStrings: [scopedAndUnscopedSubscriber.toString()],
             maxSeeds: 3
         });
-        expect(seeds.map(String)).to.deep.equal([recordServerAndSubscriber.toString()]);
+        expect(seeds.map(String)).to.deep.equal([scopedAndUnscopedSubscriber.toString()]);
     });
 
     it("caps the result at maxSeeds, dropping the lowest-priority tier first", async () => {
-        const recordServerA = await newPeerId();
-        const recordServerB = await newPeerId();
-        const subscriber = await newPeerId();
+        const scopedSubscriberA = await newPeerId();
+        const scopedSubscriberB = await newPeerId();
+        const otherTopicSubscriber = await newPeerId();
         const plainConnected = await newPeerId();
         const seeds = selectBitswapSessionSeedPeers({
-            connectedPeers: [plainConnected, subscriber, recordServerB, recordServerA],
-            pubsubSubscriberPeerIdStrings: [subscriber.toString()],
-            // most recent first — recordServerA served a record more recently than recordServerB
-            recentIpnsRecordServerPeerIdStrings: [recordServerA.toString(), recordServerB.toString()],
+            connectedPeers: [plainConnected, otherTopicSubscriber, scopedSubscriberB, scopedSubscriberA],
+            scopedPubsubSubscriberPeerIdStrings: [scopedSubscriberA.toString(), scopedSubscriberB.toString()],
+            pubsubSubscriberPeerIdStrings: [otherTopicSubscriber.toString()],
             maxSeeds: 3
         });
-        expect(seeds.map(String)).to.deep.equal([recordServerA.toString(), recordServerB.toString(), subscriber.toString()]);
+        expect(seeds.map(String)).to.deep.equal([
+            scopedSubscriberA.toString(),
+            scopedSubscriberB.toString(),
+            otherTopicSubscriber.toString()
+        ]);
     });
 });


### PR DESCRIPTION
Closes #202

## Problem

#191 seeds each per-DAG bitswap session from a global state: the 8 most recent IPNS record servers across all names, then gossipsub subscribers of all subscribed topics, then any connected peer. In a multi-community app the global LRU churns, so a page/comment fetch for community X can get seeded with community Y's record server, which has no guarantee of holding X's blocks. The subscriber tier is also unscoped: subscribers of an unrelated community's topic rank equal to subscribers of the community actually being fetched.

## Change

Every CID fetched over the helia transport belongs to a community, and the community's record server must be subscribed to that community's IPNS-over-pubsub record topic to serve records on it, while by construction providing every block under the community (record, pages, comments, postUpdates buckets). So the fetch call sites now pass that topic through `_fetchCidP2P` → `cat()` as `bitswapSessionSeedScopeIpnsPubsubTopic`, and seed selection becomes:

1. current subscribers of the fetched community's record topic (record server + followers that recently fetched the same blocks)
2. subscribers of any other subscribed topic
3. any other connected peer

still filtered to connected peers and capped at 3, below the session's `maxProviders` of 5, so the background routing query keeps contributing independently-discovered providers.

The remembered-record-servers list (`recentIpnsRecordServerPeerIdStrings` / `rememberIpnsRecordServerPeer`) is deleted rather than scoped per name: `getSubscribers(topic)` is stateless, self-updates on disconnect, and subsumes it whenever a scope is available. The direct-fetch fast path itself is unchanged.

Scope sources per call site:

- community record CID: `community.ipnsPubsubTopic` (anchor-aware for delegated communities)
- pages: `_pages._community.ipnsPubsubTopic`; PostsPages/ModQueuePages read it off the RemoteCommunity instance, RepliesPages get it propagated by `Comment.setCommunityAddress` (an IPNS community address IS the anchor IPNS name; domain addresses stay unscoped)
- CommentIpfs + postUpdates walk: the updating community instance, falling back to deriving the topic from an IPNS community address

Fetches with no known community (bare cid-only `getComment`) keep today's unscoped behavior. The option is forwarded to the helia `cat()` only, never to kubo-rpc-client, and is stripped before reaching `@helia/unixfs`.

## Tests

Written first and observed red against unmodified `src/` (the page fetch's `cat()` call carried no seed scope: `expected undefined to equal '/record/...'`; the unit-test signature change red-failed the test type-check):

- `test/node-and-browser/helia/helia.test.ts`: page fetch, community record fetch, and CommentIpfs + postUpdates walk each pass the community's record topic as the session seed scope.
- `test/node/helia/bitswap-session-seed-peers.unit.test.ts`: scoped tier ordering (including outranking an earlier-listed subscriber of another topic), no-scope fallback, connected-only filtering, dedupe across tiers, maxSeeds cap.

Runs: unit 7/7; helia integration 23/23 (3 new) under `remote-libp2pjs`; pages/community-posts/community-update/getcomment suites 64/64 under `remote-libp2pjs` and 21 passed / 4 skipped under `remote-kubo-rpc,remote-pkc-rpc` — with one exception: a key-migration test under the PKC RPC Remote variant times out, and the identical timeout reproduces on an unmodified master build against the same test server, so it is pre-existing/environmental (this change does not execute in the RPC path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer-to-peer content retrieval by prioritizing peers subscribed to the relevant community topic.
  * Applied consistent peer selection for pages, community data, comments, and updates.
  * Improved reliability when fetching content through Bitswap sessions.

* **Tests**
  * Added regression coverage verifying community-scoped peer selection across supported content types.
  * Updated peer-priority tests for scoped subscribers, fallback behavior, deduplication, and connection filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->