### PR TITLE
test(community): close initial-load race in 304-vs-newer gateway test

### DIFF
--- a/test/node/community/multiplegateways.update.test.ts
+++ b/test/node/community/multiplegateways.update.test.ts
@@ -263,14 +263,18 @@ describe("Test fetching community record from multiple gateways (isolated)", asy
             res.end("Not found");
         });
 
-        // Newer gateway - always returns a newer valid record
-        await createServer(NEWER_GATEWAY_PORT, (req, res) => {
+        // Newer gateway - always returns a newer valid record. Requests without If-None-Match
+        // (the initial getCommunity() load, where the first 200 wins the gateway race) are
+        // delayed so the conditional304 gateway deterministically loads first; update fetches
+        // carry If-None-Match and get the newer record immediately.
+        await createServer(NEWER_GATEWAY_PORT, async (req, res) => {
             res.setHeader("Access-Control-Allow-Origin", "*");
             if (!isRequestForTestSub(req)) {
                 res.statusCode = 404;
                 res.end("Not found");
                 return;
             }
+            if (!req.headers["if-none-match"]) await new Promise<void>((resolve) => setTimeout(resolve, 700));
             res.setHeader("x-ipfs-roots", newerRecordCid);
             res.setHeader("etag", `"${newerRecordCid}"`);
             res.end(newerRecordJson);


### PR DESCRIPTION
## Problem

The test `updates when one gateway returns 304 and another returns 200 with newer record` in `test/node/community/multiplegateways.update.test.ts` is flaky. It failed on the macOS job of run 29082493914 (PR #203) with:

```
AssertionError: expected 'QmcpdebyS4jQSg5a67NU6aNcwb89z14j6DhE2…' to equal 'QmcQ4MTrGFN9zSDnDPUhfbA77GCrKRwTp933k…'
```

On the initial `getCommunity()` load, both mock gateways answer 200 immediately and `selectWinningGatewayCommunity` resolves with the first record whose `updatedAt` beats the current one (0 on first load), so the first responder wins. The test assumes the conditional304 gateway wins that race. On slow runners (macOS CI) the newer gateway sometimes responds first, so `community.updateCid` ends up as the newer record's CID and the first assertion fails.

## Fix

Make the newer gateway deterministic instead of relying on response-order luck: it now delays (700ms) any request that carries no `If-None-Match` header. Only the initial load sends no `If-None-Match` (nothing is in `_updateCidsAlreadyLoaded` yet), so the conditional304 gateway always loads first. The follow-up `fetchNewUpdateForCommunity()` sends `If-None-Match` and still gets the newer record immediately, preserving the test's intent of a prompt 200-with-newer-record racing a 304 (distinct from the existing `delayedNewerGateway` test where the 200 arrives after the 304).

The delay never slows the suite: the initial load resolves off the conditional304 gateway in milliseconds and the in-flight delayed request is aborted by the fetch cleanup. The test still completes in ~14ms.

## Verification

- `node test/run-test-config.js --pkc-config "local-kubo-rpc,remote-pkc-rpc" test/node/community/multiplegateways.update.test.ts`: all 13 tests pass
- `npx tsc --project test/tsconfig.json --noEmit`: clean