### PR TITLE
fix(helia): cache direct-fetched IPNS records at the pubsub routing layer

### DIFF
--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -22,7 +22,14 @@ import { EventEmitter } from "events";
 import type { HeliaWithLibp2pPubsub } from "./types.js";
 import { PKCError } from "../pkc-error.js";
 import { Libp2pJsClient } from "./libp2pjsClient.js";
-import { connectToPubsubPeers, directFetchIpnsRecordFromProviders, getHeliaDebugContext, selectBitswapSessionSeedPeers } from "./util.js";
+import {
+    cacheIpnsRecordInPubsubLocalStore,
+    connectToPubsubPeers,
+    directFetchIpnsRecordFromProviders,
+    getHeliaDebugContext,
+    selectBitswapSessionSeedPeers
+} from "./util.js";
+import type { IpnsPubsubLocalStore } from "./util.js";
 import { createDefaultDialTransportGater } from "./dial-transport-filter.js";
 import { ipnsNameToIpnsOverPubsubTopic } from "../util.js";
 
@@ -275,8 +282,13 @@ export async function createLibp2pJsClientOrUseExistingOne(
                 signal.addEventListener("abort", onAbort, { once: true });
             });
 
+        const ipnsPubsubRouter = createIpnsPubusubRouter(helia);
+        // The router's localStore is where gossipsub-delivered records get cached (handleRecord).
+        // It's declared private but is a plain class field at runtime; the direct-fetch path below
+        // writes to it to keep the cached-record invariant (issue #210).
+        const ipnsPubsubLocalStore = (ipnsPubsubRouter as unknown as { localStore: IpnsPubsubLocalStore }).localStore;
         const ipnsNameResolver = ipns(helia, {
-            routers: [createIpnsPubusubRouter(helia)]
+            routers: [ipnsPubsubRouter]
         });
 
         // @helia/ipns constructs routers as [LocalStoreRouting, HeliaRouting, ...userRouters].
@@ -378,6 +390,26 @@ export async function createLibp2pJsClientOrUseExistingOne(
                                     // Record already validated inside the helper — unmarshal directly,
                                     // do NOT re-run ipnsValidator.
                                     const record = unmarshalIPNSRecord(direct.recordBytes);
+                                    // Direct fetch bypasses the pubsub router's handleRecord, which is
+                                    // where gossipsub-delivered records get cached at the routing layer.
+                                    // Persist the record there ourselves (newer-only, issue #210) so
+                                    // offline/fallback resolves and handleRecord's ipnsSelector see the
+                                    // freshest record we hold. Awaited so callers observe the cache as
+                                    // soon as this resolve returns; a cache failure must not fail the
+                                    // resolve itself.
+                                    try {
+                                        await cacheIpnsRecordInPubsubLocalStore({
+                                            localStore: ipnsPubsubLocalStore,
+                                            routingKey,
+                                            marshalledRecord: direct.recordBytes
+                                        });
+                                    } catch (cacheErr) {
+                                        log.trace(
+                                            "Failed to cache direct-fetched IPNS record at the pubsub routing layer for",
+                                            ipnsPubsubTopic,
+                                            cacheErr
+                                        );
+                                    }
                                     yield record.value;
                                     return;
                                 }
@@ -456,8 +488,10 @@ export async function createLibp2pJsClientOrUseExistingOne(
                         // so that path is inert — the old resolve()-based code skipped it too. IPNS here is
                         // pubsub-only (HTTP routers have getIPNS disabled in getDelegatedRoutingFields), and
                         // the pubsub router's get() never serves from cache; it always queries peers. Record
-                        // caching + ipnsSelector still happen inside the pubsub router's handleRecord
-                        // regardless of whether we go through resolve() or call router.get directly.
+                        // caching + ipnsSelector happen inside the pubsub router's handleRecord for
+                        // gossipsub-delivered records and router.get() fetches; the direct-fetch fast path
+                        // above bypasses handleRecord, so it writes the record to the router's localStore
+                        // itself (cacheIpnsRecordInPubsubLocalStore, issue #210).
                         let recordBytes: Uint8Array | undefined;
                         const routerErrors: Error[] = [];
                         for (const router of ipnsNameResolver.routers) {

--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -1,6 +1,8 @@
 import type { HeliaWithLibp2pPubsub } from "./types.js";
 import type { PeerId, PeerInfo } from "@libp2p/interface";
 import { CID } from "multiformats/cid";
+import { ipnsSelector } from "ipns/selector";
+import { equals as uint8ArrayEquals } from "uint8arrays/equals";
 import Logger from "../logger.js";
 import { PKCError } from "../pkc-error.js";
 import { pubsubTopicToDhtKeyCid } from "../util.js";
@@ -527,4 +529,38 @@ export async function directFetchIpnsRecordFromProviders({
         throw new PKCError("ERR_IPNS_DIRECT_FETCH_ABORTED", { pubsubTopic, peerToError, ...getHeliaDebugContext(helia) });
 
     return undefined;
+}
+
+// The subset of @helia/ipns's internal localStore (local-store.js) the direct-fetch path needs.
+// The pubsub router exposes it as a plain class field at runtime but declares it private, so
+// callers access it through this structural type.
+export interface IpnsPubsubLocalStore {
+    has(routingKey: Uint8Array, options?: { signal?: AbortSignal }): Promise<boolean>;
+    get(routingKey: Uint8Array, options?: { signal?: AbortSignal }): Promise<{ record: Uint8Array; created: Date }>;
+    put(routingKey: Uint8Array, marshalledRecord: Uint8Array, options?: { signal?: AbortSignal }): Promise<void>;
+}
+
+// Persist a validated IPNS record at the pubsub routing layer (issue #210). The pubsub router's
+// handleRecord only caches records that arrive over gossipsub or through its own router.get()
+// fetch, so a direct-fetch win (directFetchIpnsRecordFromProviders) would otherwise leave the
+// datastore empty or stale: offline/fallback resolves and handleRecord's ipnsSelector comparison
+// would then act on older state than the freshest record we just validated. Mirrors
+// handleRecord's newer-only semantics (minus the gossipsub re-publish): an identical or older
+// record than the cached one is never written. The caller must have validated the record.
+export async function cacheIpnsRecordInPubsubLocalStore({
+    localStore,
+    routingKey,
+    marshalledRecord
+}: {
+    localStore: IpnsPubsubLocalStore;
+    routingKey: Uint8Array;
+    marshalledRecord: Uint8Array;
+}): Promise<void> {
+    if (await localStore.has(routingKey)) {
+        const { record: currentRecord } = await localStore.get(routingKey);
+        if (uint8ArrayEquals(currentRecord, marshalledRecord)) return;
+        // ipnsSelector returns the index of the best record: 0 means the cached one is newer
+        if (ipnsSelector(routingKey, [currentRecord, marshalledRecord]) === 0) return;
+    }
+    await localStore.put(routingKey, marshalledRecord);
 }

--- a/test/node-and-browser/helia/helia.test.ts
+++ b/test/node-and-browser/helia/helia.test.ts
@@ -5,7 +5,8 @@ import {
     resolveWhenConditionIsTrue,
     mockPKCV2,
     addStringToIpfs,
-    createMockedCommunityIpns
+    createMockedCommunityIpns,
+    mockCommentToNotUsePagesForUpdates
 } from "../../../dist/node/test/test-util.js";
 import signers from "../../fixtures/signers.js";
 import validPageFixture from "../../fixtures/valid_page.json" with { type: "json" };
@@ -720,6 +721,10 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 const catSpy = vi.spyOn(heliaClient.heliaWithKuboRpcClientFunctions, "cat");
                 try {
                     await comment.update();
+                    // If the freshly published post has already landed in the community's regenerated
+                    // preloaded pages, the CommentUpdate is taken from there and the postUpdates walk
+                    // (and its cat() call asserted below) never runs — force the walk path.
+                    mockCommentToNotUsePagesForUpdates(comment);
                     await resolveWhenConditionIsTrue({ toUpdate: comment, predicate: async () => typeof comment.updatedAt === "number" });
                     await comment.stop();
 

--- a/test/node/community/helia-ipns-resolve-equivalence.unit.test.ts
+++ b/test/node/community/helia-ipns-resolve-equivalence.unit.test.ts
@@ -39,6 +39,32 @@ describeSkipIfRpc("Helia IPNS single-hop resolution equivalence", () => {
         if (heliaPKC) await heliaPKC.destroy();
     });
 
+    // Regression test for issue #210: the direct-fetch fast path used to return the record without
+    // writing it to the pubsub router's local store (handleRecord only caches gossipsub-delivered
+    // records and router.get() fetches), so an offline resolve right after a wrapper resolve only
+    // succeeded when kubo's gossipsub push happened to race in before it. A fresh IPNS name makes
+    // the direct fetch the only possible source of the record at assert time.
+    it("a direct-fetched record is cached at the pubsub routing layer before resolve returns (issue #210)", async () => {
+        const freshIpns = await createNewIpns();
+        await freshIpns.publishToIpns("helia ipns direct-fetch cache - fresh single hop content");
+        const freshName = freshIpns.signer.address;
+        await freshIpns.pkc.destroy();
+
+        const client = heliaPKC.clients.libp2pJsClients[Object.keys(heliaPKC.clients.libp2pJsClients)[0]];
+
+        const wrapperValues: string[] = [];
+        for await (const value of client.heliaWithKuboRpcClientFunctions.name.resolve(freshName, { nocache: true }))
+            wrapperValues.push(value as string);
+        const wrapperValue = wrapperValues[wrapperValues.length - 1];
+        expect(wrapperValue).to.be.a("string");
+        const wrapperCid = CID.parse(wrapperValue.split("/")[2]).toV1().toString();
+
+        // Immediately after the wrapper resolve returns, the record must be readable offline: the
+        // fast path must persist it itself instead of depending on the gossipsub push racing in.
+        const offlineResult = await client._heliaIpnsRouter.resolve(peerIdFromString(freshName), { offline: true });
+        expect(offlineResult.cid.toV1().toString()).to.equal(wrapperCid);
+    });
+
     it("wrapper single-hop resolve matches resolver.resolve() and the record is cached at the pubsub layer", async () => {
         const client = heliaPKC.clients.libp2pJsClients[Object.keys(heliaPKC.clients.libp2pJsClients)[0]];
         const ipnsNameAsPeerId = peerIdFromString(ipnsName);


### PR DESCRIPTION
## Problem (#210)

When `directFetchIpnsRecordFromProviders` wins, the resolve generator unmarshalled the record and returned without writing the bytes anywhere. The pubsub router's `handleRecord` (where records get cached into the datastore-backed localStore, guarded by `ipnsSelector`) only fires for gossipsub-delivered records and its own `router.get()` fetches, so after a direct-fetch win the datastore only got populated if kubo's gossipsub push happened to race in.

Consequences:
1. `helia-ipns-resolve-equivalence.unit.test.ts` failed with `RecordNotFoundError` on both ubuntu and macos node-local jobs in CI run 29086995128.
2. Offline/fallback resolves and `handleRecord`'s `ipnsSelector` comparison acted on stale or missing state rather than the freshest record we had just validated.

## Fix

After a direct-fetch win, persist the (already validated) record into the pubsub router's localStore with `handleRecord`'s newer-only semantics: identical records are skipped and `ipnsSelector` keeps the cached record when it is newer, so a record from a lagging peer can never clobber a newer cached one. The write is awaited inside the resolve (a cache failure is logged, never fails the resolve), so callers observe the cache as soon as the resolve returns.

The localStore is a plain class field at runtime but declared private, so it is accessed through a structural type (`IpnsPubsubLocalStore`); no new dependencies.

Also corrects the code comment that claimed record caching happens inside `handleRecord` regardless of the path taken.

## Regression test

New test in `helia-ipns-resolve-equivalence.unit.test.ts` resolves a fresh IPNS name (so the direct fetch is the only possible source of the record) and asserts an offline resolve succeeds immediately afterwards. Failed with `RecordNotFoundError` before the fix; green after. The full equivalence suite, `ipns-direct-fetch.unit.test.ts`, and `test/node-and-browser/helia/helia.test.ts` (remote-libp2pjs) all pass.

Closes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPNS resolution reliability by caching records retrieved through direct fetching.
  * Preserved successful resolution when caching encounters an error.

* **Tests**
  * Added regression coverage ensuring newly fetched IPNS records are immediately available for offline resolution.
  * Updated comment-fetching test coverage to verify post-update traversal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->