### PR TITLE
fix(helia): retry addr-limited provider dials once the provider stream completes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
             "devDependencies": {
                 "@commitlint/cli": "20.4.1",
                 "@commitlint/config-conventional": "20.5.0",
+                "@libp2p/circuit-relay-v2": "4.2.0",
                 "@release-it/conventional-changelog": "10.0.6",
                 "@types/better-sqlite3": "7.6.13",
                 "@types/debounce": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "devDependencies": {
         "@commitlint/cli": "20.4.1",
         "@commitlint/config-conventional": "20.5.0",
+        "@libp2p/circuit-relay-v2": "4.2.0",
         "@release-it/conventional-changelog": "10.0.6",
         "@types/better-sqlite3": "7.6.13",
         "@types/debounce": "1.2.1",

--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -1,5 +1,6 @@
 import type { HeliaWithLibp2pPubsub } from "./types.js";
-import type { PeerId, PeerInfo } from "@libp2p/interface";
+import type { PeerId, PeerInfo, PeerUpdate } from "@libp2p/interface";
+import type { Multiaddr } from "@multiformats/multiaddr";
 import { CID } from "multiformats/cid";
 import { ipnsSelector } from "ipns/selector";
 import { equals as uint8ArrayEquals } from "uint8arrays/equals";
@@ -54,6 +55,74 @@ const DIAL_ERROR_NAMES_RETRYABLE_AFTER_ADDR_MERGE = new Set(["DialDeniedError", 
 
 function isDialRetryableAfterAddrMerge(error: unknown): boolean {
     return DIAL_ERROR_NAMES_RETRYABLE_AFTER_ADDR_MERGE.has((error as Error)?.name);
+}
+
+function multiaddrIsCircuitRelay(addr: Multiaddr): boolean {
+    return addr.getComponents().some((component) => component.name === "p2p-circuit");
+}
+
+// Per-peer scheduler for the addr-merge retries (issues #213/#215). A peer marked retryable is
+// re-attempted the moment new data for it lands in the peerstore ('peer:update' — fired when a
+// slower router's merged record or identify contributes addrs), with provider-stream completion
+// as the fallback sweep for peers whose update fired before they were marked. Crucially the
+// retry NEVER waits for unrelated dials to settle: the old batch pass ran after
+// Promise.allSettled over every initial dial, so one slow-to-fail dial (production: 2-5s
+// relay-circuit dials, PR #214 benchmark) delayed a retry whose addrs had been sitting in the
+// peerstore since the slower router responded (~hundreds of ms). Each peer is retried once;
+// runRetry returning "not-ready" releases the slot so a later peer:update can try again.
+function createAddrMergeRetryScheduler({
+    helia,
+    runRetry
+}: {
+    helia: HeliaWithLibp2pPubsub;
+    runRetry: (peerId: PeerId) => Promise<"done" | "not-ready">;
+}) {
+    const retryablePeers = new Map<string, PeerId>();
+    const inFlightOrDone = new Set<string>();
+    const retryTasks: Promise<void>[] = [];
+    let providerStreamEnded = false;
+    let listenerRemoved = false;
+
+    const trigger = (peerId: PeerId): void => {
+        const key = peerId.toString();
+        if (inFlightOrDone.has(key)) return;
+        inFlightOrDone.add(key);
+        retryTasks.push(
+            runRetry(peerId).then(
+                (outcome) => {
+                    if (outcome === "not-ready") inFlightOrDone.delete(key);
+                },
+                () => undefined // runRetry does its own error recording; never reject the task
+            )
+        );
+    };
+
+    const onPeerUpdate = (evt: CustomEvent<PeerUpdate>): void => {
+        const peerId = evt.detail.peer.id;
+        if (retryablePeers.has(peerId.toString())) trigger(peerId);
+    };
+    helia.libp2p.addEventListener("peer:update", onPeerUpdate);
+
+    return {
+        // Register a peer as curable by a later addr merge. If the provider stream has already
+        // ended (all router records merged), retry immediately.
+        markRetryable(peerId: PeerId): void {
+            retryablePeers.set(peerId.toString(), peerId);
+            if (providerStreamEnded) trigger(peerId);
+        },
+        // The findProviders stream ended (or was aborted): every router's addrs that will ever
+        // arrive have been merged. Sweep the peers whose qualifying update fired before they
+        // were marked retryable, and stop listening.
+        onProviderStreamEnded(): void {
+            providerStreamEnded = true;
+            for (const peerId of retryablePeers.values()) trigger(peerId);
+            if (!listenerRemoved) {
+                listenerRemoved = true;
+                helia.libp2p.removeEventListener("peer:update", onPeerUpdate);
+            }
+        },
+        retryTasks
+    };
 }
 
 // Event-based wait for a remote peer to subscribe to `topic` on our gossipsub.
@@ -236,9 +305,28 @@ export async function connectToPubsubPeers({
     const inflightDialPromises: Promise<void>[] = [];
     const dialOptions = { ...options };
     // Peers whose dial failed only for lack of dialable addrs (see isDialRetryableAfterAddrMerge):
-    // retried once by id after the provider stream completes, when the peerstore holds the addrs
-    // the compound router merged from slower routers (issue #213).
-    const peersToRetryAfterProviderStream = new Map<string, PeerId>();
+    // re-dialed by id (re-reading the peerstore) the moment a later record/identify merges addrs
+    // for them, or at provider-stream completion (issues #213/#215). Dial-by-id keeps the circuit
+    // fallback here on purpose: a relayed connection is still useful to warmup (DCUtR upgrade,
+    // mesh discovery), unlike in the direct-fetch path.
+    const retryScheduler = createAddrMergeRetryScheduler({
+        helia,
+        runRetry: async (peerId) => {
+            if (options?.signal?.aborted) return "done";
+            try {
+                const conn = await helia.libp2p.dial(peerId, dialOptions);
+                connectedPeersWithContent.push(conn);
+                log.trace("Addr-merge retry dial connected to peer", peerId.toString());
+                return "done";
+            } catch (e) {
+                // Keep the original failure in peerDialToError; the retry failing adds no
+                // information. A still-addr-limited failure releases the retry slot so a later
+                // qualifying addr merge can try again.
+                log.trace("Addr-merge retry dial failed for peer", peerId.toString(), "due to error", e);
+                return isDialRetryableAfterAddrMerge(e) ? "not-ready" : "done";
+            }
+        }
+    });
     try {
         for await (const peer of helia.libp2p.contentRouting.findProviders(contentCid, { ...options, signal: findProvidersSignal })) {
             peersWithContent.push(peer as PeerInfo);
@@ -258,7 +346,7 @@ export async function connectToPubsubPeers({
                     }
                 } catch (e) {
                     const err = e as Error;
-                    if (isDialRetryableAfterAddrMerge(err)) peersToRetryAfterProviderStream.set(peer.id.toString(), peer.id);
+                    if (isDialRetryableAfterAddrMerge(err)) retryScheduler.markRetryable(peer.id);
                     peerDialToError[peer.id.toString()] = {
                         multiaddrs: peer.multiaddrs.map(String),
                         errorName: err.name,
@@ -292,34 +380,15 @@ export async function connectToPubsubPeers({
         }
     }
 
-    // Retry pass (issue #213): once every initial dial has settled, re-dial by id the peers whose
-    // dial failed only for lack of dialable addrs. The provider stream has completed by now, so
-    // the peerstore holds every router's merged addrs — including the dialable ones a slower
-    // router contributed for an already-yielded (deduped) peer. Runs in the background like the
-    // initial dials: a successful retry fires peer:connected/subscription-change, which resolves
-    // the subscriber wait below without delaying it.
-    if (inflightDialPromises.length && !options?.signal?.aborted) {
-        const initialDialPromises = [...inflightDialPromises];
-        inflightDialPromises.push(
-            (async () => {
-                await Promise.allSettled(initialDialPromises);
-                if (options?.signal?.aborted || peersToRetryAfterProviderStream.size === 0) return;
-                await Promise.allSettled(
-                    [...peersToRetryAfterProviderStream.values()].map(async (peerId) => {
-                        try {
-                            const conn = await helia.libp2p.dial(peerId, dialOptions);
-                            connectedPeersWithContent.push(conn);
-                            log.trace("Retry dial (post provider stream) connected to peer", peerId.toString());
-                        } catch (e) {
-                            // Keep the original failure in peerDialToError; the retry failing the
-                            // same way adds no information.
-                            log.trace("Retry dial (post provider stream) failed for peer", peerId.toString(), "due to error", e);
-                        }
-                    })
-                );
-            })()
-        );
-    }
+    // Provider stream ended (all router records merged, or the stream was aborted): sweep any
+    // retryable peers not already re-dialed via peer:update, and detach the listener. The
+    // retries run in the background like the initial dials — a successful retry fires
+    // peer:connected/subscription-change, which resolves the subscriber wait below without
+    // delaying it — and crucially they do NOT wait for the initial dials to settle (issue #215):
+    // most peer:update-triggered retries have already fired mid-stream, seconds before a slow
+    // relay-circuit dial would have released the old batch pass.
+    retryScheduler.onProviderStreamEnded();
+    inflightDialPromises.push(...retryScheduler.retryTasks);
 
     // Wait for the gossipsub subscription-change event — this is the signal that bitswap can
     // see at least one peer subscribed to the topic, so the subsequent IPNS resolve won't walk
@@ -516,10 +585,42 @@ export async function directFetchIpnsRecordFromProviders({
             ? AbortSignal.any([options.signal, findProvidersAbort.signal, resultController.signal])
             : AbortSignal.any([findProvidersAbort.signal, resultController.signal]);
         const dialFetchTasks: Promise<void>[] = [];
-        // Peers whose dial failed only for lack of dialable addrs (see isDialRetryableAfterAddrMerge):
-        // retried once by id after the provider stream completes, when the peerstore holds the addrs
-        // the compound router merged from slower routers (issue #213).
-        const peersToRetryAfterProviderStream = new Map<string, PeerId>();
+        // Peers with no fetch-usable addr right now (issues #213/#215): gater denied every addr
+        // known at dial time, no valid addrs were known at all, or every announced addr is
+        // /p2p-circuit (a relayed connection cannot serve /libp2p/fetch — it fails with
+        // LimitedConnectionError — so we never dial those here). All are curable the same way: a
+        // slower router's record for the deduped peer merges better addrs into the peerstore.
+        // Retried the moment that merge fires peer:update, dialing ONLY the direct addrs so the
+        // dial cannot fall back to a circuit addr and burn seconds on a connection the fetch
+        // cannot use.
+        const retryScheduler = createAddrMergeRetryScheduler({
+            helia,
+            runRetry: async (peerId) => {
+                if (winner || resultController.signal.aborted || options?.signal?.aborted) return "done";
+                const peerData = await helia.libp2p.peerStore.get(peerId).catch(() => undefined);
+                const directAddrs = (peerData?.addresses ?? [])
+                    .map(({ multiaddr }) => multiaddr)
+                    .filter((addr) => !multiaddrIsCircuitRelay(addr));
+                // No fetch-usable addr yet: release the slot so a later qualifying merge retries.
+                if (directAddrs.length === 0 || !(await helia.libp2p.isDialable(directAddrs))) return "not-ready";
+                try {
+                    const dialSignal = options?.signal
+                        ? AbortSignal.any([options.signal, resultController.signal])
+                        : resultController.signal;
+                    // Peerstore addrs are usually bare; the /p2p suffix associates the dial with
+                    // the peer so libp2p's per-peer dedupe/existing-connection reuse applies.
+                    const dialTargets = directAddrs.map((addr) => {
+                        const components = addr.getComponents();
+                        return components[components.length - 1]?.name === "p2p" ? addr : addr.encapsulate(`/p2p/${peerId.toString()}`);
+                    });
+                    await helia.libp2p.dial(dialTargets, { signal: dialSignal }); // no-op if already connected
+                    await tryFetchFromPeer(peerId, "provider");
+                } catch (e) {
+                    recordErr(peerId, e);
+                }
+                return "done";
+            }
+        });
         let attempted = 0;
         try {
             for await (const peer of helia.libp2p.contentRouting.findProviders(contentCid, { ...options, signal: findProvidersSignal })) {
@@ -533,6 +634,19 @@ export async function directFetchIpnsRecordFromProviders({
                 // at least one dialable announced addr count toward maxPeers. isDialable is a local
                 // check (gater + transport match), not a network round-trip.
                 const announcedAddrs = (peer as PeerInfo).multiaddrs ?? [];
+                // Circuit-only provider (issue #215): never dial it here — /libp2p/fetch cannot
+                // run over the limited relayed connection the dial would produce, so the dial
+                // only burns 2-5s. Merge its addrs (useful to warmup/identify, and a later direct
+                // addr must land on the same peerstore entry) and park it in the retry set: if a
+                // slower router or identify ever contributes a direct addr, it is dialed then.
+                // Does not consume a maxPeers slot for the same reason gater-denied providers
+                // don't (issue #188).
+                if (announcedAddrs.length > 0 && announcedAddrs.every(multiaddrIsCircuitRelay)) {
+                    await helia.libp2p.peerStore.merge(peer.id, { multiaddrs: announcedAddrs }).catch(() => undefined);
+                    log.trace("Skipping dial to circuit-only provider", peer.id.toString(), "for topic", pubsubTopic);
+                    retryScheduler.markRetryable(peer.id);
+                    continue;
+                }
                 const hasDialableAddr = announcedAddrs.length > 0 && (await helia.libp2p.isDialable(announcedAddrs));
                 dialFetchTasks.push(
                     (async () => {
@@ -550,7 +664,7 @@ export async function directFetchIpnsRecordFromProviders({
                             await helia.libp2p.dial(peer.id, { signal: dialSignal }); // no-op if already connected
                             await tryFetchFromPeer(peer.id, "provider");
                         } catch (e) {
-                            if (isDialRetryableAfterAddrMerge(e)) peersToRetryAfterProviderStream.set(peer.id.toString(), peer.id);
+                            if (isDialRetryableAfterAddrMerge(e)) retryScheduler.markRetryable(peer.id);
                             recordErr(peer.id, e);
                         }
                     })()
@@ -566,26 +680,17 @@ export async function directFetchIpnsRecordFromProviders({
             // exhaustion we return undefined so the caller falls back to router.get().
             if (!findProvidersSignal.aborted) log.trace("findProviders errored during direct IPNS fetch for topic", pubsubTopic, e);
         }
+        // Provider stream ended (all router records merged, or the stream was aborted): sweep
+        // any retryable peers not already re-dialed via peer:update BEFORE waiting for the
+        // initial dials — a slow-to-settle dial (e.g. 2-5s relay-circuit) must not delay a retry
+        // whose addrs have been in the peerstore for seconds (issue #215). Most retries have
+        // already fired mid-stream, the moment the slower router's merge fired peer:update.
+        retryScheduler.onProviderStreamEnded();
         await Promise.allSettled(dialFetchTasks);
-
-        // Retry pass (issue #213): the provider stream has completed and every initial dial has
-        // settled, so the peerstore holds every router's merged addrs — including the dialable
-        // ones a slower router contributed for an already-yielded (deduped) peer. Re-dial by id
-        // once per addr-limited failure, then fetch.
-        if (peersToRetryAfterProviderStream.size && !winner && !resultController.signal.aborted && !options?.signal?.aborted) {
-            await Promise.allSettled(
-                [...peersToRetryAfterProviderStream.values()].map(async (peerId) => {
-                    try {
-                        const dialSignal = options?.signal
-                            ? AbortSignal.any([options.signal, resultController.signal])
-                            : resultController.signal;
-                        await helia.libp2p.dial(peerId, { signal: dialSignal });
-                        await tryFetchFromPeer(peerId, "provider");
-                    } catch (e) {
-                        recordErr(peerId, e);
-                    }
-                })
-            );
+        // Drain retry tasks (they can grow while draining: a late initial-dial failure after
+        // stream end triggers its retry inline) so no in-flight fetch/dial leaks past return.
+        while (retryScheduler.retryTasks.length > 0) {
+            await Promise.allSettled(retryScheduler.retryTasks.splice(0));
         }
     })();
 

--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -42,6 +42,20 @@ interface PeerDialFailure {
     errorStack?: string;
 }
 
+// Dial failures that a later-arriving provider record can cure (issue #213). libp2p's
+// CompoundContentRouting.findProviders dedupes providers by peer id across routers: the first
+// router's record for a peer is the only one ever yielded, and a slower router's record with
+// better addrs (e.g. the browser-dialable /tls/ws one) is merged into the peerstore but never
+// re-yielded. So a dial that failed because the connection gater denied every addr known at dial
+// time (DialDeniedError), or because no valid addrs were known at all (NoValidAddressesError),
+// can succeed on a dial-by-id retry once the provider stream has completed — dial-by-id re-reads
+// the peerstore, which by then holds the merged addrs, at zero extra router traffic.
+const DIAL_ERROR_NAMES_RETRYABLE_AFTER_ADDR_MERGE = new Set(["DialDeniedError", "NoValidAddressesError"]);
+
+function isDialRetryableAfterAddrMerge(error: unknown): boolean {
+    return DIAL_ERROR_NAMES_RETRYABLE_AFTER_ADDR_MERGE.has((error as Error)?.name);
+}
+
 // Event-based wait for a remote peer to subscribe to `topic` on our gossipsub.
 // Resolves the moment gossipsub fires 'subscription-change' for the topic and the
 // subscriber list has actually become non-empty, or rejects on timeout/abort.
@@ -221,6 +235,10 @@ export async function connectToPubsubPeers({
     // even after this function returns — they populate bitswap's peer set as they finish.
     const inflightDialPromises: Promise<void>[] = [];
     const dialOptions = { ...options };
+    // Peers whose dial failed only for lack of dialable addrs (see isDialRetryableAfterAddrMerge):
+    // retried once by id after the provider stream completes, when the peerstore holds the addrs
+    // the compound router merged from slower routers (issue #213).
+    const peersToRetryAfterProviderStream = new Map<string, PeerId>();
     try {
         for await (const peer of helia.libp2p.contentRouting.findProviders(contentCid, { ...options, signal: findProvidersSignal })) {
             peersWithContent.push(peer as PeerInfo);
@@ -240,6 +258,7 @@ export async function connectToPubsubPeers({
                     }
                 } catch (e) {
                     const err = e as Error;
+                    if (isDialRetryableAfterAddrMerge(err)) peersToRetryAfterProviderStream.set(peer.id.toString(), peer.id);
                     peerDialToError[peer.id.toString()] = {
                         multiaddrs: peer.multiaddrs.map(String),
                         errorName: err.name,
@@ -271,6 +290,35 @@ export async function connectToPubsubPeers({
             };
             throw e;
         }
+    }
+
+    // Retry pass (issue #213): once every initial dial has settled, re-dial by id the peers whose
+    // dial failed only for lack of dialable addrs. The provider stream has completed by now, so
+    // the peerstore holds every router's merged addrs — including the dialable ones a slower
+    // router contributed for an already-yielded (deduped) peer. Runs in the background like the
+    // initial dials: a successful retry fires peer:connected/subscription-change, which resolves
+    // the subscriber wait below without delaying it.
+    if (inflightDialPromises.length && !options?.signal?.aborted) {
+        const initialDialPromises = [...inflightDialPromises];
+        inflightDialPromises.push(
+            (async () => {
+                await Promise.allSettled(initialDialPromises);
+                if (options?.signal?.aborted || peersToRetryAfterProviderStream.size === 0) return;
+                await Promise.allSettled(
+                    [...peersToRetryAfterProviderStream.values()].map(async (peerId) => {
+                        try {
+                            const conn = await helia.libp2p.dial(peerId, dialOptions);
+                            connectedPeersWithContent.push(conn);
+                            log.trace("Retry dial (post provider stream) connected to peer", peerId.toString());
+                        } catch (e) {
+                            // Keep the original failure in peerDialToError; the retry failing the
+                            // same way adds no information.
+                            log.trace("Retry dial (post provider stream) failed for peer", peerId.toString(), "due to error", e);
+                        }
+                    })
+                );
+            })()
+        );
     }
 
     // Wait for the gossipsub subscription-change event — this is the signal that bitswap can
@@ -468,6 +516,10 @@ export async function directFetchIpnsRecordFromProviders({
             ? AbortSignal.any([options.signal, findProvidersAbort.signal, resultController.signal])
             : AbortSignal.any([findProvidersAbort.signal, resultController.signal]);
         const dialFetchTasks: Promise<void>[] = [];
+        // Peers whose dial failed only for lack of dialable addrs (see isDialRetryableAfterAddrMerge):
+        // retried once by id after the provider stream completes, when the peerstore holds the addrs
+        // the compound router merged from slower routers (issue #213).
+        const peersToRetryAfterProviderStream = new Map<string, PeerId>();
         let attempted = 0;
         try {
             for await (const peer of helia.libp2p.contentRouting.findProviders(contentCid, { ...options, signal: findProvidersSignal })) {
@@ -498,6 +550,7 @@ export async function directFetchIpnsRecordFromProviders({
                             await helia.libp2p.dial(peer.id, { signal: dialSignal }); // no-op if already connected
                             await tryFetchFromPeer(peer.id, "provider");
                         } catch (e) {
+                            if (isDialRetryableAfterAddrMerge(e)) peersToRetryAfterProviderStream.set(peer.id.toString(), peer.id);
                             recordErr(peer.id, e);
                         }
                     })()
@@ -514,6 +567,26 @@ export async function directFetchIpnsRecordFromProviders({
             if (!findProvidersSignal.aborted) log.trace("findProviders errored during direct IPNS fetch for topic", pubsubTopic, e);
         }
         await Promise.allSettled(dialFetchTasks);
+
+        // Retry pass (issue #213): the provider stream has completed and every initial dial has
+        // settled, so the peerstore holds every router's merged addrs — including the dialable
+        // ones a slower router contributed for an already-yielded (deduped) peer. Re-dial by id
+        // once per addr-limited failure, then fetch.
+        if (peersToRetryAfterProviderStream.size && !winner && !resultController.signal.aborted && !options?.signal?.aborted) {
+            await Promise.allSettled(
+                [...peersToRetryAfterProviderStream.values()].map(async (peerId) => {
+                    try {
+                        const dialSignal = options?.signal
+                            ? AbortSignal.any([options.signal, resultController.signal])
+                            : resultController.signal;
+                        await helia.libp2p.dial(peerId, { signal: dialSignal });
+                        await tryFetchFromPeer(peerId, "provider");
+                    } catch (e) {
+                        recordErr(peerId, e);
+                    }
+                })
+            );
+        }
     })();
 
     // Await both branches so no in-flight fetch/dial leaks past return.

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -79,7 +79,13 @@ const ParsedKuboRpcClientOptionsSchema = z.custom<z.output<typeof TransformKuboR
 // I guess {libp2pOptions, heliaOptions, key} for now, this way we can experiment with passing any config to libp2pJsClientOptions. we can test different libp2p transport and stuff like that
 
 type heliaOptions = Parameters<typeof createHelia>[0];
-type libp2pOptions = ReturnType<typeof libp2pDefaults>;
+type libp2pDefaultOptions = ReturnType<typeof libp2pDefaults>;
+// helia-for-pkc spreads `libp2pOptions.services` ON TOP of its own explicit service map, so
+// callers may pass any subset of the default services — or additional ones (e.g. tests injecting
+// a circuit-relay server) — rather than the full map the helia default type demands.
+type libp2pOptions = Partial<Omit<libp2pDefaultOptions, "services">> & {
+    services?: Partial<libp2pDefaultOptions["services"]> & Record<string, unknown>;
+};
 
 export const PKCUserOptionBaseSchema = z.object({
     ipfsGatewayUrls: IpfsGatewayUrlSchema.array().optional(),
@@ -93,7 +99,7 @@ export const PKCUserOptionBaseSchema = z.object({
     libp2pJsClientsOptions: z
         .object({
             key: z.string().min(1),
-            libp2pOptions: z.custom<Partial<libp2pOptions>>().default({}),
+            libp2pOptions: z.custom<libp2pOptions>().default({}),
             heliaOptions: z.custom<Partial<heliaOptions>>().default({})
         })
         .array()

--- a/test/node/helia/ipns-direct-fetch.unit.test.ts
+++ b/test/node/helia/ipns-direct-fetch.unit.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it } from "vitest";
+import net from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { circuitRelayServer } from "@libp2p/circuit-relay-v2";
 import { createLibp2pJsClientOrUseExistingOne } from "../../../dist/node/helia/helia-for-pkc.js";
 import { directFetchIpnsRecordFromProviders } from "../../../dist/node/helia/util.js";
 import { MockHttpRouter } from "../../../dist/node/runtime/node/test/mock-http-router.js";
@@ -44,6 +46,31 @@ describeSkipIfRpc("directFetchIpnsRecordFromProviders (issue #185)", () => {
             } catch {
                 // already destroyed
             }
+        }
+    });
+
+    // A "tarpit" peer for issue #215: a raw TCP server that accepts connections and never speaks,
+    // so a libp2p /ws dial to it hangs (the WebSocket upgrade request is never answered) until
+    // connectionManager.addressDialTimeout aborts it. Stands in for the production relay-circuit
+    // dials that take 2-5s to fail (PR #214 benchmark) — a dial that is SLOW to settle, unlike the
+    // instantly-failing gater-denied dials the #213 tests use.
+    const tarpitServers: net.Server[] = [];
+    const tarpitSockets: net.Socket[] = [];
+    const startTarpitWsAddr = async (): Promise<string> => {
+        const server = net.createServer((socket) => {
+            tarpitSockets.push(socket);
+        });
+        tarpitServers.push(server);
+        await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+        const port = (server.address() as net.AddressInfo).port;
+        return `/ip4/127.0.0.1/tcp/${port}/ws`;
+    };
+
+    afterEach(async () => {
+        while (tarpitSockets.length) tarpitSockets.pop()!.destroy();
+        while (tarpitServers.length) {
+            const server = tarpitServers.pop()!;
+            await new Promise<void>((resolve) => server.close(() => resolve()));
         }
     });
 
@@ -266,6 +293,339 @@ describeSkipIfRpc("directFetchIpnsRecordFromProviders (issue #185)", () => {
         expect(result!.peerId).to.equal(publisher.ID);
         expect(uint8ArrayEquals(result!.recordBytes, marshalled), "served record bytes must match").to.equal(true);
         expect(elapsed, `direct fetch took ${elapsed}ms, expected well under the 10s floor`).to.be.lessThan(FAST_FETCH_MAX_MS);
+    });
+
+    // Issue #215 (follow-up to #213): the retry pass must be gated on the provider STREAM
+    // completing (that is when every router's addrs are merged into the peerstore), NOT on every
+    // initial dial settling. The PR #214 benchmark showed the production 6-router mix gains no
+    // latency from the retry because relay-circuit dials take 2-5s to fail, and the retry waits
+    // for them via Promise.allSettled(dialFetchTasks) even though the addrs it needs were merged
+    // seconds earlier. Reproduce with the #213 fast-poisoned/slow-good router pair PLUS a tarpit
+    // provider whose dial only settles at addressDialTimeout: the record must still be fetched at
+    // provider-stream-completion time (~SLOW_ROUTER_DELAY_MS), well before the tarpit dial settles.
+    it("retry of a gater-denied provider is not delayed by an unrelated slow dial still in flight (issue #215)", async () => {
+        const SLOW_ROUTER_DELAY_MS = 800; // provider stream completes here — all addrs merged
+        const TARPIT_DIAL_SETTLE_MS = 5_000; // connectionManager.addressDialTimeout — when the tarpit dial fails
+        const RETRY_UNGATED_MAX_MS = 3_500; // between the two: red waits for the tarpit (~5.2s), green needs only the stream (~1.2s)
+
+        const { routingKey, marshalled, topic, cid } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled });
+
+        // Fast router: the publisher with its WSS addr stripped (tcp-only, gater-denied → enters
+        // the retry set) plus the tarpit peer (dialable /ws addr, dial hangs until timeout).
+        const fastPoisonedRouter = new MockHttpRouter();
+        await fastPoisonedRouter.start();
+        startedRouters.push(fastPoisonedRouter);
+        fastPoisonedRouter.addProviderForTesting(cid, { ID: publisher.ID, Addrs: ["/ip4/127.0.0.1/tcp/40199"] });
+        const tarpitPeerId = peerIdFromPrivateKey(await generateKeyPair("Ed25519")).toString();
+        fastPoisonedRouter.addProviderForTesting(cid, { ID: tarpitPeerId, Addrs: [await startTarpitWsAddr()] });
+
+        // Slow router: the SAME publisher with its real /ws addrs — merged into the peerstore at
+        // ~SLOW_ROUTER_DELAY_MS when the provider stream completes (deduped, never yielded).
+        const slowGoodRouter = new MockHttpRouter({ providerGetDelayMs: SLOW_ROUTER_DELAY_MS });
+        await slowGoodRouter.start();
+        startedRouters.push(slowGoodRouter);
+        slowGoodRouter.addProviderForTesting(cid, publisher);
+
+        const node = await createNode({
+            routers: [fastPoisonedRouter.url, slowGoodRouter.url],
+            libp2pOptions: {
+                connectionGater: {
+                    denyDialMultiaddr: (multiaddr: Multiaddr) =>
+                        !multiaddr.getComponents().some((component) => component.name === "ws" || component.name === "wss")
+                },
+                // Bound the tarpit dial deterministically: it has a single addr, and the
+                // per-address timeout applies even when the dial carries its own abort signal.
+                connectionManager: { addressDialTimeout: TARPIT_DIAL_SETTLE_MS }
+            }
+        });
+
+        const start = Date.now();
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+        const elapsed = Date.now() - start;
+
+        expect(result, "the record must be fetched via the retry dial despite the tarpit dial still hanging").to.not.equal(undefined);
+        expect(result!.source).to.equal("provider");
+        expect(result!.peerId).to.equal(publisher.ID);
+        expect(uint8ArrayEquals(result!.recordBytes, marshalled), "served record bytes must match").to.equal(true);
+        expect(
+            elapsed,
+            `direct fetch took ${elapsed}ms: the retry needs only the completed provider stream (~${SLOW_ROUTER_DELAY_MS}ms), so ` +
+                `taking ~${TARPIT_DIAL_SETTLE_MS}ms means the retry pass is gated on the unrelated tarpit dial settling (issue #215)`
+        ).to.be.lessThan(RETRY_UNGATED_MAX_MS);
+    });
+
+    // Issue #215: a provider whose ONLY addrs are /p2p-circuit must not be dialed by the
+    // direct-fetch path at all. /libp2p/fetch over a limited (relayed) connection always fails
+    // with LimitedConnectionError, so the dial can never produce a record — it only burns 2-5s
+    // (the production relay dials measured in the PR #214 benchmark) and, today, delays the
+    // issue #213 retry pass that waits for it to settle. The dial outcome is irrelevant here
+    // (the relay is dead so it fails fast): the assertion is that no dial is ATTEMPTED.
+    it("does not dial a provider whose only addrs are p2p-circuit (issue #215)", async () => {
+        const { routingKey, marshalled, topic, cid } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled });
+
+        const router = new MockHttpRouter();
+        await router.start();
+        startedRouters.push(router);
+        router.addProviderForTesting(cid, publisher);
+        const relayPeerId = peerIdFromPrivateKey(await generateKeyPair("Ed25519")).toString();
+        const circuitOnlyPeerId = peerIdFromPrivateKey(await generateKeyPair("Ed25519")).toString();
+        router.addProviderForTesting(cid, {
+            ID: circuitOnlyPeerId,
+            Addrs: [`/ip4/127.0.0.1/tcp/1/ws/p2p/${relayPeerId}/p2p-circuit`]
+        });
+
+        const node = await createNode({ routers: [router.url] });
+        const dialSpy = vi.spyOn(node._helia.libp2p, "dial");
+
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+
+        expect(result, "the dialable publisher must still be fetched from").to.not.equal(undefined);
+        expect(result!.peerId).to.equal(publisher.ID);
+
+        const dialedTargets = dialSpy.mock.calls.flatMap(([target]) => (Array.isArray(target) ? target : [target])).map(String);
+        expect(
+            dialedTargets.some((target) => target === circuitOnlyPeerId || target.includes(`/p2p/${circuitOnlyPeerId}`)),
+            `a p2p-circuit-only provider must not be dialed in the direct-fetch path (fetch over a limited connection always ` +
+                `fails with LimitedConnectionError); dialed targets: ${dialedTargets.join(", ")}`
+        ).to.equal(false);
+    });
+
+    // Issue #215 green path: a circuit-only provider is parked (not dialed), but the moment a
+    // slower router's record merges a DIRECT addr for the same (deduped) peer into the peerstore,
+    // it must be dialed — with the direct addr only, never the circuit one — and the record
+    // fetched. This is the "retry-on-addr-update instead of hard skip" half of the policy: the
+    // companion test above pins that a circuit-only provider with no later direct addr is never
+    // dialed at all.
+    it("dials a parked circuit-only provider once a slower router contributes a direct addr (issue #215)", async () => {
+        const { routingKey, marshalled, topic, cid } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled });
+
+        // Fast router: the publisher announced ONLY via a (dead) relay.
+        const fastCircuitOnlyRouter = new MockHttpRouter();
+        await fastCircuitOnlyRouter.start();
+        startedRouters.push(fastCircuitOnlyRouter);
+        const relayPeerId = peerIdFromPrivateKey(await generateKeyPair("Ed25519")).toString();
+        fastCircuitOnlyRouter.addProviderForTesting(cid, {
+            ID: publisher.ID,
+            Addrs: [`/ip4/127.0.0.1/tcp/1/ws/p2p/${relayPeerId}/p2p-circuit`]
+        });
+
+        // Slow router: the SAME publisher with its real /ws addrs — merged into the peerstore
+        // when it responds (deduped, never yielded), which must trigger the parked peer's dial.
+        const slowGoodRouter = new MockHttpRouter({ providerGetDelayMs: 800 });
+        await slowGoodRouter.start();
+        startedRouters.push(slowGoodRouter);
+        slowGoodRouter.addProviderForTesting(cid, publisher);
+
+        const node = await createNode({ routers: [fastCircuitOnlyRouter.url, slowGoodRouter.url] });
+        const dialSpy = vi.spyOn(node._helia.libp2p, "dial");
+
+        const start = Date.now();
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+        const elapsed = Date.now() - start;
+
+        expect(result, "the record must be fetched once the direct addr lands in the peerstore").to.not.equal(undefined);
+        expect(result!.source).to.equal("provider");
+        expect(result!.peerId).to.equal(publisher.ID);
+        expect(uint8ArrayEquals(result!.recordBytes, marshalled), "served record bytes must match").to.equal(true);
+        expect(elapsed, `direct fetch took ${elapsed}ms, expected well under the 10s floor`).to.be.lessThan(FAST_FETCH_MAX_MS);
+
+        // The dial that connected must have used the direct addr only — the circuit addr must
+        // never appear in any dial target for the publisher.
+        const publisherDialTargets = dialSpy.mock.calls
+            .flatMap(([target]) => (Array.isArray(target) ? target : [target]))
+            .map(String)
+            .filter((target) => target === publisher.ID || target.includes(`/p2p/${publisher.ID}`));
+        expect(publisherDialTargets.length, "the parked provider must have been dialed after the addr merge").to.be.greaterThan(0);
+        expect(
+            publisherDialTargets.some((target) => target.includes("p2p-circuit")),
+            `no dial target for the publisher may include the circuit addr; targets: ${publisherDialTargets.join(", ")}`
+        ).to.equal(false);
+    });
+
+    // Issue #215 / CodeRabbit on PR #214: the retry set matches dial failures by ERROR NAME, and
+    // the tests so far only pinned "DialDeniedError". This pins the second name,
+    // "NoValidAddressesError": libp2p throws it when every known addr is filtered out BEFORE the
+    // gater runs — for a record whose addrs all use transports the node does not have. That is
+    // exactly what a browser (no tcp/quic transports) sees on a tcp/quic-only record; this Node
+    // client has no QUIC transport, so a quic-v1-only record reproduces it. If a libp2p upgrade
+    // renames the error, the retry silently stops firing for this failure mode and this test
+    // goes red. (An addr-less record cannot reproduce this: routers, including MockHttpRouter,
+    // drop providers without addrs.) The dial-count assertion proves the failing initial dial
+    // actually happened, so the test cannot pass vacuously via the slow router's own record.
+    it("retries a provider whose record only has untransportable addrs after a slower router contributes dialable ones (issue #215)", async () => {
+        const { routingKey, marshalled, topic, cid } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled });
+
+        // Fast router: the publisher's peer id with only a quic-v1 addr (no QUIC transport here).
+        const fastEmptyRouter = new MockHttpRouter();
+        await fastEmptyRouter.start();
+        startedRouters.push(fastEmptyRouter);
+        fastEmptyRouter.addProviderForTesting(cid, { ID: publisher.ID, Addrs: ["/ip4/127.0.0.1/udp/40199/quic-v1"] });
+
+        // Slow router: the SAME publisher with its real /ws addrs.
+        const slowGoodRouter = new MockHttpRouter({ providerGetDelayMs: 800 });
+        await slowGoodRouter.start();
+        startedRouters.push(slowGoodRouter);
+        slowGoodRouter.addProviderForTesting(cid, publisher);
+
+        const node = await createNode({ routers: [fastEmptyRouter.url, slowGoodRouter.url] });
+        const dialSpy = vi.spyOn(node._helia.libp2p, "dial");
+
+        const start = Date.now();
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+        const elapsed = Date.now() - start;
+
+        expect(result, "the record must be fetched via a retry once the slower router's addrs are merged").to.not.equal(undefined);
+        expect(result!.source).to.equal("provider");
+        expect(result!.peerId).to.equal(publisher.ID);
+        expect(uint8ArrayEquals(result!.recordBytes, marshalled), "served record bytes must match").to.equal(true);
+        expect(elapsed, `direct fetch took ${elapsed}ms, expected well under the 10s floor`).to.be.lessThan(FAST_FETCH_MAX_MS);
+
+        const publisherDialTargets = dialSpy.mock.calls
+            .flatMap(([target]) => (Array.isArray(target) ? target : [target]))
+            .map(String)
+            .filter((target) => target === publisher.ID || target.includes(`/p2p/${publisher.ID}`));
+        expect(
+            publisherDialTargets.length,
+            `expected the failing initial dial-by-id AND the retry dial (NoValidAddressesError path); targets: ${publisherDialTargets.join(", ")}`
+        ).to.be.greaterThanOrEqual(2);
+    });
+
+    // Issue #215: the retry must fire off the peerstore merge (libp2p 'peer:update'), NOT off
+    // provider-stream completion — a black-hole router (accepts the GET, never responds, never
+    // closes) keeps the compound findProviders stream open indefinitely, so a retry gated on the
+    // stream ending would never fire (and this test would time out). With the peer:update
+    // trigger, the retry fires the moment the slow router's record merges, while the loop is
+    // still pulling the black hole; the winning fetch then aborts findProviders and the call
+    // returns.
+    it("retries via the peerstore merge even while a black-hole router keeps the provider stream open (issue #215)", async () => {
+        const { routingKey, marshalled, topic, cid } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled });
+
+        const fastPoisonedRouter = new MockHttpRouter();
+        await fastPoisonedRouter.start();
+        startedRouters.push(fastPoisonedRouter);
+        fastPoisonedRouter.addProviderForTesting(cid, { ID: publisher.ID, Addrs: ["/ip4/127.0.0.1/tcp/40199"] });
+
+        const slowGoodRouter = new MockHttpRouter({ providerGetDelayMs: 800 });
+        await slowGoodRouter.start();
+        startedRouters.push(slowGoodRouter);
+        slowGoodRouter.addProviderForTesting(cid, publisher);
+
+        const blackHoleRouter = new MockHttpRouter({ faultMode: "blackHole" });
+        await blackHoleRouter.start();
+        startedRouters.push(blackHoleRouter);
+
+        const node = await createNode({
+            routers: [fastPoisonedRouter.url, slowGoodRouter.url, blackHoleRouter.url],
+            libp2pOptions: {
+                connectionGater: {
+                    denyDialMultiaddr: (multiaddr: Multiaddr) =>
+                        !multiaddr.getComponents().some((component) => component.name === "ws" || component.name === "wss")
+                }
+            }
+        });
+
+        const start = Date.now();
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+        const elapsed = Date.now() - start;
+
+        expect(result, "the record must be fetched despite the black-hole router keeping the stream open").to.not.equal(undefined);
+        expect(result!.source).to.equal("provider");
+        expect(result!.peerId).to.equal(publisher.ID);
+        expect(elapsed, `direct fetch took ${elapsed}ms, expected well under the 10s floor`).to.be.lessThan(3_500);
+    });
+
+    // Issue #215 premise pin: the reason circuit-only providers are skipped in this path is that
+    // /libp2p/fetch cannot run over a limited (relayed) connection — libp2p refuses to open the
+    // protocol stream. This test asserts that with a REAL relay: if a libp2p upgrade or config
+    // change ever makes this fetch succeed (e.g. @libp2p/fetch registering with
+    // runOnLimitedConnection, see issue #215), this test goes red and the skip policy must be
+    // re-evaluated — a relayed fetch would then be a usable last-resort tier.
+    it("libp2p/fetch over a limited (relayed) connection fails with LimitedConnectionError (issue #215 premise)", async () => {
+        const { routingKey, marshalled } = await makeRecord();
+
+        // Relay: a pkc node with the circuit-relay-v2 server service added, listening on /ws.
+        const relay = await createNode({ listen: true, libp2pOptions: { services: { relay: circuitRelayServer() } } });
+        const relayWsAddr = relay._helia.libp2p
+            .getMultiaddrs()
+            .map((m) => m.toString())
+            .find((a) => a.includes("/ws/"));
+        expect(relayWsAddr, "relay must expose a ws multiaddr (with /p2p suffix)").to.not.equal(undefined);
+
+        // Publisher: reachable ONLY via the relay (no direct listen addr), serving the record
+        // over the fetch protocol like a real record host would.
+        const publisher = await createNode({ libp2pOptions: { addresses: { listen: [`${relayWsAddr}/p2p-circuit`] } } });
+        const fetchService = publisher._helia.libp2p.services.fetch;
+        fetchService.unregisterLookupFunction("/ipns/");
+        fetchService.registerLookupFunction("/ipns/", async (key: Uint8Array) => {
+            if (uint8ArrayEquals(key, routingKey)) return marshalled;
+            return undefined;
+        });
+
+        // Wait for the relay reservation: the publisher's multiaddrs gain the /p2p-circuit addr.
+        const deadline = Date.now() + FAST_FETCH_MAX_MS;
+        const circuitAddrOf = () =>
+            publisher._helia.libp2p
+                .getMultiaddrs()
+                .map((m) => m.toString())
+                .find((a) => a.includes("/p2p-circuit"));
+        while (Date.now() < deadline && !circuitAddrOf()) await new Promise((r) => setTimeout(r, 100));
+        const circuitAddr = circuitAddrOf();
+        expect(circuitAddr, "publisher must obtain a relay reservation (/p2p-circuit multiaddr)").to.not.equal(undefined);
+
+        // Dial the publisher THROUGH the relay: the resulting connection is limited.
+        const node = await createNode({});
+        const connection = await node._helia.libp2p.dial(publisher._helia.libp2p.getMultiaddrs());
+        expect(connection.limits, "a relayed connection must be limited (data/duration caps)").to.not.equal(undefined);
+
+        // The fetch protocol must refuse to run over it.
+        let threw: Error | null = null;
+        try {
+            await node._helia.libp2p.services.fetch.fetch(publisher._helia.libp2p.peerId, routingKey);
+        } catch (e) {
+            threw = e as Error;
+        }
+        expect(threw, "fetch over a limited connection should have thrown").to.not.equal(null);
+        expect(threw!.name).to.equal("LimitedConnectionError");
     });
 
     // Subscriber branch: the publisher is already in getSubscribers(topic) and there is NO router

--- a/test/node/helia/ipns-direct-fetch.unit.test.ts
+++ b/test/node/helia/ipns-direct-fetch.unit.test.ts
@@ -208,6 +208,66 @@ describeSkipIfRpc("directFetchIpnsRecordFromProviders (issue #185)", () => {
         expect(elapsed, `direct fetch took ${elapsed}ms, expected well under the 10s floor`).to.be.lessThan(FAST_FETCH_MAX_MS);
     });
 
+    // Issue #213: when multiple routers serve records for the SAME peer, libp2p's
+    // CompoundContentRouting.findProviders dedupes by peer id — the first router's record is the
+    // only one ever yielded. A slower router's record with BETTER addrs (the browser-dialable
+    // /ws one) is merged into the peerstore but never yielded, so if the fast router's record
+    // had its WSS addrs stripped (in prod: an old router build strips dns4/WSS from every
+    // record), the one dial fails instantly with DialDeniedError and the record is never
+    // fetched even though a dialable addr is sitting in the peerstore moments later.
+    // The helper must retry dial-by-id (which re-reads the peerstore) after the provider
+    // stream completes, so the slower router's merged addrs get used.
+    it("retries a gater-denied provider after a slower router contributes dialable addrs (issue #213)", async () => {
+        const { routingKey, marshalled, topic, cid } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled });
+
+        // Fast router: serves the publisher's peer id with its WSS addr stripped (tcp-only),
+        // mirroring the poisoned production router. Responds immediately.
+        const fastPoisonedRouter = new MockHttpRouter();
+        await fastPoisonedRouter.start();
+        startedRouters.push(fastPoisonedRouter);
+        fastPoisonedRouter.addProviderForTesting(cid, { ID: publisher.ID, Addrs: ["/ip4/127.0.0.1/tcp/40199"] });
+
+        // Slow router: serves the SAME peer with its real /ws addrs after a delay, so the
+        // poisoned record deterministically wins the first (denied) dial and the good record
+        // only ever reaches the peerstore via the compound router's merge (never yielded).
+        const slowGoodRouter = new MockHttpRouter({ providerGetDelayMs: 800 });
+        await slowGoodRouter.start();
+        startedRouters.push(slowGoodRouter);
+        slowGoodRouter.addProviderForTesting(cid, publisher);
+
+        // Mirror the browser's WSS-only connection gater, so the tcp-only record is undialable.
+        const node = await createNode({
+            routers: [fastPoisonedRouter.url, slowGoodRouter.url],
+            libp2pOptions: {
+                connectionGater: {
+                    denyDialMultiaddr: (multiaddr: Multiaddr) =>
+                        !multiaddr.getComponents().some((component) => component.name === "ws" || component.name === "wss")
+                }
+            }
+        });
+
+        const start = Date.now();
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+        const elapsed = Date.now() - start;
+
+        expect(
+            result,
+            "the record must be fetched via a retry dial once the slower router's dialable addrs are in the peerstore"
+        ).to.not.equal(undefined);
+        expect(result!.source).to.equal("provider");
+        expect(result!.peerId).to.equal(publisher.ID);
+        expect(uint8ArrayEquals(result!.recordBytes, marshalled), "served record bytes must match").to.equal(true);
+        expect(elapsed, `direct fetch took ${elapsed}ms, expected well under the 10s floor`).to.be.lessThan(FAST_FETCH_MAX_MS);
+    });
+
     // Subscriber branch: the publisher is already in getSubscribers(topic) and there is NO router
     // record. The helper must still fetch from it — proving both sources are queried in parallel.
     it("fetches from a peer already in getSubscribers when no router record exists", async () => {

--- a/test/node/helia/warmup-connect-to-pubsub-peers.unit.test.ts
+++ b/test/node/helia/warmup-connect-to-pubsub-peers.unit.test.ts
@@ -8,6 +8,7 @@ import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
 import { generateKeyPair } from "@libp2p/crypto/keys";
 import { peerIdFromPrivateKey } from "@libp2p/peer-id";
 import type { Libp2pJsClient } from "../../../dist/node/helia/libp2pjsClient.js";
+import type { Multiaddr } from "@multiformats/multiaddr";
 
 // Warmup-level coverage for src/helia/util.ts connectToPubsubPeers — the production consumer of the
 // content-routing layer that the findProviders fault-tolerance suite (content-router-fault-tolerance.unit.test.ts)
@@ -59,11 +60,20 @@ describeSkipIfRpc("connectToPubsubPeers warmup (issue #171 follow-up)", () => {
     // Build a libp2p-js helia node. `listen` makes it bind a WebSocket listener (so it can be dialed and
     // serve as the subscriber); the node-under-test stays listen-less (the production default). The dummy
     // router keeps creation from throwing and is never expected to serve anything.
-    const createNode = async (opts: { listen?: boolean; routers?: string[] } = {}): Promise<Libp2pJsClient> => {
+    const createNode = async (
+        opts: {
+            listen?: boolean;
+            routers?: string[];
+            libp2pOptions?: Parameters<typeof createLibp2pJsClientOrUseExistingOne>[0]["libp2pOptions"];
+        } = {}
+    ): Promise<Libp2pJsClient> => {
         const client = (await createLibp2pJsClientOrUseExistingOne({
             key: `warmup-${keyCounter++}`,
             httpRoutersOptions: opts.routers ?? ["http://localhost:1"],
-            libp2pOptions: opts.listen ? { addresses: { listen: ["/ip4/127.0.0.1/tcp/0/ws"] } } : {},
+            libp2pOptions: {
+                ...(opts.listen ? { addresses: { listen: ["/ip4/127.0.0.1/tcp/0/ws"] } } : {}),
+                ...opts.libp2pOptions
+            },
             heliaOptions: {}
         })) as Libp2pJsClient;
         clientsToStop.push(client);
@@ -123,6 +133,53 @@ describeSkipIfRpc("connectToPubsubPeers warmup (issue #171 follow-up)", () => {
             FAST_WARMUP_MAX_MS
         );
         expect(connections.length, "should have connected to the dialable subscriber").to.be.greaterThan(0);
+        expect(node._helia.libp2p.services.pubsub.getSubscribers(topic).map((p) => p.toString())).to.include(subscriber.ID);
+    });
+
+    // Issue #213: libp2p's CompoundContentRouting.findProviders dedupes providers by peer id
+    // across routers — the first router's record for a peer is the only one ever yielded. If a
+    // fast router serves the subscriber's record with its WSS addr stripped (tcp-only), the one
+    // dial fails instantly with DialDeniedError under a ws-only gater; the slower router's record
+    // with the real /ws addr is merged into the peerstore but never yielded, so warmup used to
+    // eat the full 10s floor and throw ERR_FAILED_TO_DIAL_ANY_PEERS_PROVIDING_CID even though a
+    // dialable addr was in the peerstore moments after the failed dial. Warmup must retry
+    // dial-by-id (re-reading the peerstore) once the provider stream completes.
+    it("retries a gater-denied provider after a slower router contributes dialable addrs (issue #213)", async () => {
+        const topic = topicFor("retry-denied");
+        const cid = pubsubTopicToDhtKeyCid(topic).toString();
+        const subscriber = await startSubscriberNode(topic);
+
+        // Fast router: the subscriber's peer id with its WSS addr stripped (tcp-only), mirroring
+        // the poisoned production router. Responds immediately, so it always wins the first dial.
+        const fastPoisonedUrl = await startRouterServing(cid, { ID: subscriber.ID, Addrs: ["/ip4/127.0.0.1/tcp/40198"] });
+        // Slow router: the SAME peer with its real /ws addrs, delayed so its record only ever
+        // reaches the peerstore via the compound router's merge (deduped, never yielded).
+        const slowGoodRouter = new MockHttpRouter({ providerGetDelayMs: 800 });
+        await slowGoodRouter.start();
+        startedRouters.push(slowGoodRouter);
+        slowGoodRouter.addProviderForTesting(cid, subscriber);
+
+        // Mirror the browser's WSS-only connection gater, so the tcp-only record is undialable.
+        const node = await createNode({
+            routers: [fastPoisonedUrl, slowGoodRouter.url],
+            libp2pOptions: {
+                connectionGater: {
+                    denyDialMultiaddr: (multiaddr: Multiaddr) =>
+                        !multiaddr.getComponents().some((component) => component.name === "ws" || component.name === "wss")
+                }
+            }
+        });
+
+        const start = Date.now();
+        const connections = await connectToPubsubPeers({ helia: node._helia, pubsubTopic: topic, maxPeers: 4, log });
+        const elapsed = Date.now() - start;
+
+        expect(
+            elapsed,
+            `warmup took ${elapsed}ms, expected well under the ${TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS}ms floor via the retry dial`
+        ).to.be.lessThan(FAST_WARMUP_MAX_MS);
+        expect(connections.length, "the retry dial must have connected to the subscriber").to.be.greaterThan(0);
+        expect(connections.map((c) => c.remotePeer.toString())).to.include(subscriber.ID);
         expect(node._helia.libp2p.services.pubsub.getSubscribers(topic).map((p) => p.toString())).to.include(subscriber.ID);
     });
 

--- a/test/node/helia/warmup-connect-to-pubsub-peers.unit.test.ts
+++ b/test/node/helia/warmup-connect-to-pubsub-peers.unit.test.ts
@@ -1,3 +1,4 @@
+import net from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 import { createLibp2pJsClientOrUseExistingOne } from "../../../dist/node/helia/helia-for-pkc.js";
 import { connectToPubsubPeers } from "../../../dist/node/helia/util.js";
@@ -114,6 +115,31 @@ describeSkipIfRpc("connectToPubsubPeers warmup (issue #171 follow-up)", () => {
         return router.url;
     };
 
+    // A "tarpit" peer for issue #215: a raw TCP server that accepts connections and never speaks,
+    // so a libp2p /ws dial to it hangs (the WebSocket upgrade request is never answered) until
+    // connectionManager.addressDialTimeout aborts it. Stands in for the production relay-circuit
+    // dials that take 2-5s to fail (PR #214 benchmark) — a dial that is SLOW to settle, unlike the
+    // instantly-failing gater-denied dials the #213 test uses.
+    const tarpitServers: net.Server[] = [];
+    const tarpitSockets: net.Socket[] = [];
+    const startTarpitWsAddr = async (): Promise<string> => {
+        const server = net.createServer((socket) => {
+            tarpitSockets.push(socket);
+        });
+        tarpitServers.push(server);
+        await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+        const port = (server.address() as net.AddressInfo).port;
+        return `/ip4/127.0.0.1/tcp/${port}/ws`;
+    };
+
+    afterEach(async () => {
+        while (tarpitSockets.length) tarpitSockets.pop()!.destroy();
+        while (tarpitServers.length) {
+            const server = tarpitServers.pop()!;
+            await new Promise<void>((resolve) => server.close(() => resolve()));
+        }
+    });
+
     const topicFor = (suffix: string) => `warmup-test-topic-${suffix}-${keyCounter}`;
 
     // The happy path: one router serving a dialable, subscribed peer. Warmup must dial it, observe the
@@ -178,6 +204,98 @@ describeSkipIfRpc("connectToPubsubPeers warmup (issue #171 follow-up)", () => {
             elapsed,
             `warmup took ${elapsed}ms, expected well under the ${TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS}ms floor via the retry dial`
         ).to.be.lessThan(FAST_WARMUP_MAX_MS);
+        expect(connections.length, "the retry dial must have connected to the subscriber").to.be.greaterThan(0);
+        expect(connections.map((c) => c.remotePeer.toString())).to.include(subscriber.ID);
+        expect(node._helia.libp2p.services.pubsub.getSubscribers(topic).map((p) => p.toString())).to.include(subscriber.ID);
+    });
+
+    // Issue #215 / CodeRabbit on PR #214: pins the second retryable error name for warmup,
+    // "NoValidAddressesError" — thrown when every known addr is filtered out BEFORE the gater
+    // runs, i.e. a record whose addrs all use transports the node does not have (what a browser
+    // sees on a tcp/quic-only record; this Node client has no QUIC transport, so a quic-v1-only
+    // record reproduces it). The retry set matches by error NAME, so a libp2p rename would
+    // silently disable this retry class — this test goes red instead. Same topology as the
+    // gater-denied test above, but no gater is needed: the transport filter does the denying.
+    it("retries a provider whose record only has untransportable addrs after a slower router contributes dialable ones (issue #215)", async () => {
+        const topic = topicFor("retry-no-addrs");
+        const cid = pubsubTopicToDhtKeyCid(topic).toString();
+        const subscriber = await startSubscriberNode(topic);
+
+        const fastEmptyUrl = await startRouterServing(cid, { ID: subscriber.ID, Addrs: ["/ip4/127.0.0.1/udp/40198/quic-v1"] });
+        const slowGoodRouter = new MockHttpRouter({ providerGetDelayMs: 800 });
+        await slowGoodRouter.start();
+        startedRouters.push(slowGoodRouter);
+        slowGoodRouter.addProviderForTesting(cid, subscriber);
+
+        const node = await createNode({ routers: [fastEmptyUrl, slowGoodRouter.url] });
+
+        const start = Date.now();
+        const connections = await connectToPubsubPeers({ helia: node._helia, pubsubTopic: topic, maxPeers: 4, log });
+        const elapsed = Date.now() - start;
+
+        expect(
+            elapsed,
+            `warmup took ${elapsed}ms, expected well under the ${TOPIC_SUBSCRIBER_WAIT_TIMEOUT_MS}ms floor via the retry dial`
+        ).to.be.lessThan(FAST_WARMUP_MAX_MS);
+        expect(connections.length, "the retry dial must have connected to the subscriber").to.be.greaterThan(0);
+        expect(connections.map((c) => c.remotePeer.toString())).to.include(subscriber.ID);
+    });
+
+    // Issue #215 (follow-up to #213): warmup's retry pass must be gated on the provider STREAM
+    // completing (when every router's addrs are merged into the peerstore), NOT on every initial
+    // dial settling. The retry task currently awaits Promise.allSettled over ALL initial dials
+    // first, so one slow-to-settle dial (production: relay-circuit dials failing after 2-5s, per
+    // the PR #214 benchmark) delays the re-dial — and with it the subscription-change that resolves
+    // warmup — by seconds, even though the addrs the retry needs were merged much earlier.
+    // Reproduce with the #213 fast-poisoned/slow-good router pair PLUS a tarpit provider whose
+    // dial only settles at addressDialTimeout: warmup must still resolve via the retry at
+    // provider-stream-completion time (~SLOW_ROUTER_DELAY_MS), well before the tarpit dial settles.
+    it("retry of a gater-denied provider is not delayed by an unrelated slow dial still in flight (issue #215)", async () => {
+        const SLOW_ROUTER_DELAY_MS = 800; // provider stream completes here — all addrs merged
+        const TARPIT_DIAL_SETTLE_MS = 5_000; // connectionManager.addressDialTimeout — when the tarpit dial fails
+        const RETRY_UNGATED_MAX_MS = 3_500; // between the two: red waits for the tarpit (~5.3s), green needs only the stream (~1.3s)
+
+        const topic = topicFor("retry-gate");
+        const cid = pubsubTopicToDhtKeyCid(topic).toString();
+        const subscriber = await startSubscriberNode(topic);
+
+        // Fast router: the subscriber with its WSS addr stripped (tcp-only, gater-denied → enters
+        // the retry set) plus the tarpit peer (dialable /ws addr, dial hangs until timeout).
+        const fastPoisonedRouter = new MockHttpRouter();
+        await fastPoisonedRouter.start();
+        startedRouters.push(fastPoisonedRouter);
+        fastPoisonedRouter.addProviderForTesting(cid, { ID: subscriber.ID, Addrs: ["/ip4/127.0.0.1/tcp/40198"] });
+        fastPoisonedRouter.addProviderForTesting(cid, { ID: await newPeerIdStr(), Addrs: [await startTarpitWsAddr()] });
+
+        // Slow router: the SAME subscriber with its real /ws addrs — merged into the peerstore at
+        // ~SLOW_ROUTER_DELAY_MS when the provider stream completes (deduped, never yielded).
+        const slowGoodRouter = new MockHttpRouter({ providerGetDelayMs: SLOW_ROUTER_DELAY_MS });
+        await slowGoodRouter.start();
+        startedRouters.push(slowGoodRouter);
+        slowGoodRouter.addProviderForTesting(cid, subscriber);
+
+        const node = await createNode({
+            routers: [fastPoisonedRouter.url, slowGoodRouter.url],
+            libp2pOptions: {
+                connectionGater: {
+                    denyDialMultiaddr: (multiaddr: Multiaddr) =>
+                        !multiaddr.getComponents().some((component) => component.name === "ws" || component.name === "wss")
+                },
+                // Bound the tarpit dial deterministically: it has a single addr, and the
+                // per-address timeout applies even when the dial carries its own abort signal.
+                connectionManager: { addressDialTimeout: TARPIT_DIAL_SETTLE_MS }
+            }
+        });
+
+        const start = Date.now();
+        const connections = await connectToPubsubPeers({ helia: node._helia, pubsubTopic: topic, maxPeers: 4, log });
+        const elapsed = Date.now() - start;
+
+        expect(
+            elapsed,
+            `warmup took ${elapsed}ms: the retry needs only the completed provider stream (~${SLOW_ROUTER_DELAY_MS}ms), so ` +
+                `taking ~${TARPIT_DIAL_SETTLE_MS}ms means the retry pass is gated on the unrelated tarpit dial settling (issue #215)`
+        ).to.be.lessThan(RETRY_UNGATED_MAX_MS);
         expect(connections.length, "the retry dial must have connected to the subscriber").to.be.greaterThan(0);
         expect(connections.map((c) => c.remotePeer.toString())).to.include(subscriber.ID);
         expect(node._helia.libp2p.services.pubsub.getSubscribers(topic).map((p) => p.toString())).to.include(subscriber.ID);


### PR DESCRIPTION
Fixes #213.

## Problem

libp2p's `CompoundContentRouting.findProviders` dedupes providers by peer id across routers: the first router's record for a peer is the only one ever yielded. A slower router's record with better addrs (e.g. the browser-dialable `/tls/ws` one) is merged into the peerstore but never re-yielded. When a fast router serves WSS-stripped records (in prod: an old router build strips them from every record), the browser dials each provider once with useless addrs, gets `DialDeniedError` within ~30ms, and never dials again — even though the dialable addr lands in the peerstore ~200ms later. Verified in issue #213: adding that router dropped browser load success from 6/10 to 1/10, with 5/10 reps ending at zero libp2p connections and `Resolved IPNS name to undefined`.

## Fix

In `directFetchIpnsRecordFromProviders` and `connectToPubsubPeers` (`src/helia/util.ts`): track peers whose dial failed with `DialDeniedError` (gater denied every addr known at dial time) or `NoValidAddressesError` (no valid addrs known at all) — the two failures a later-merged record can cure. Once the provider stream completes and the initial dials settle, retry `libp2p.dial(peerId)` once per such peer. Dial-by-id re-reads the peerstore, which by then holds every router's merged addrs, so the retry connects with zero extra router traffic.

- Direct-fetch path: the retry runs inside the provider branch (before it resolves) and feeds the same first-valid-record-wins logic, bound to the same winner/caller abort signals.
- Warmup path: the retry runs in the background like the initial dials, so warmup return timing is unchanged; a successful retry fires `peer:connected`/`subscription-change`, which resolves the subscriber wait naturally.

## Tests (written first, red on unmodified src)

Both repros use two `MockHttpRouter`s serving the SAME peer id — a fast one with the WSS addr stripped (tcp-only) and a slow one (`providerGetDelayMs: 800`) with the real `/ws` addrs — plus a ws-only connection gater on the node-under-test, mirroring the browser:

- `test/node/helia/ipns-direct-fetch.unit.test.ts`: red = `directFetchIpnsRecordFromProviders` returned `undefined`; green = record fetched from the retried provider well under the 10s floor.
- `test/node/helia/warmup-connect-to-pubsub-peers.unit.test.ts`: red = full 10s floor then `ERR_FAILED_TO_DIAL_ANY_PEERS_PROVIDING_CID` with `peerDialToError` showing the `DialDeniedError` on the stripped addr; green = connected to the subscriber well under the floor. (Harness change: `createNode` now accepts `libp2pOptions` so a gater can be injected, same as the direct-fetch harness.)

Suites run green with the fix: `ipns-direct-fetch.unit.test.ts` (7), `warmup-connect-to-pubsub-peers.unit.test.ts` (5), `content-router-fault-tolerance.unit.test.ts` (29). `npm run build` and `npx tsc --project test/tsconfig.json --noEmit` pass.

## Out of scope (tracked in #213)

- Upstream js-libp2p improvement: re-yield a seen peer when a new record contributes previously-unknown addrs.
- Production cleanups: upgrading the WSS-stripping router build, seeders announcing no WSS at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved peer connection reliability by retrying dial failures once new, dialable peer addresses become available.
  - Enhanced PubSub peer warmup to recover from initially blocked or invalid addresses without being derailed by unrelated slow dials.
  - Improved IPNS direct record retrieval by retrying with newly discovered direct (non-circuit) connectivity while skipping circuit-only providers.
- **Tests**
  - Expanded coverage with network “tarpit” simulations and additional regression scenarios for retry timing and address merging.
- **Type/Config**
  - Updated option schema typing for more accurate partial libp2p configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->