### PR TITLE
perf(helia): parallelize delegated-routing lookups and fail over stalled bitswap session blocks

### DIFF
--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -23,9 +23,11 @@ import type { HeliaWithLibp2pPubsub } from "./types.js";
 import { PKCError } from "../pkc-error.js";
 import { Libp2pJsClient } from "./libp2pjsClient.js";
 import {
+    BITSWAP_SESSION_STALLED_GET_FAILOVER_MS,
     cacheIpnsRecordInPubsubLocalStore,
     connectToPubsubPeers,
     directFetchIpnsRecordFromProviders,
+    fetchBlockWithStalledSessionFailover,
     getHeliaDebugContext,
     selectBitswapSessionSeedPeers
 } from "./util.js";
@@ -41,6 +43,14 @@ const creatingLibp2pJsClients: Partial<Record<string, Promise<Libp2pJsClient>>> 
 // TODO need to call ipnsRouter.cancel when our community stops updating
 // TODO we may need to remove libp2pJsClients and creatingLibp2pJsClients, I actually don't think they're needed
 
+// Issue #218: the delegated-routing client defaults to concurrentRequests: 4 per router, an
+// internal queue that serialized parallel provider lookups — profiling a production-like load
+// (65 communities updating in parallel) measured that queueing as ~65% of the median load time
+// while the routers themselves answered in <500ms. 32 is the benchmark-validated value: it
+// collapsed the lookup phase to a flat ~2.5s for every community with no router-side strain
+// (total request volume per burst is unchanged; only burstiness increases).
+const DELEGATED_ROUTING_CONCURRENT_REQUESTS = 32;
+
 // TODO can you verify if we're already content who has a specific and we fetch the CID even though http router says it has no providers, it should be able to load the CID
 function getDelegatedRoutingFields(routers: string[]) {
     // @helia/delegated-routing-v1-http-api-client 8.x: the raw client returned by
@@ -51,7 +61,10 @@ function getDelegatedRoutingFields(routers: string[]) {
     // so the peer-routing path (client.getPeers) is never registered.
     const routersObj: Record<string, ReturnType<typeof delegatedRoutingV1HttpApiClientContentRouting>> = {};
     for (let i = 0; i < routers.length; i++) {
-        const factory = delegatedRoutingV1HttpApiClientContentRouting({ url: routers[i] });
+        const factory = delegatedRoutingV1HttpApiClientContentRouting({
+            url: routers[i],
+            concurrentRequests: DELEGATED_ROUTING_CONCURRENT_REQUESTS
+        });
         routersObj["delegatedRouting" + i] = (components) => {
             const routing = factory(components);
             // Our HTTP routers only serve provider records — they don't support IPNS get/put.
@@ -566,6 +579,24 @@ export async function createLibp2pJsClientOrUseExistingOne(
                             const session = helia.blockstore.createSession(rootCid, {
                                 providers: getBitswapSessionSeedPeers(bitswapSessionSeedScopeIpnsPubsubTopic)
                             });
+                            // Issue #218: the session broker waits on a single elected HAVE peer per
+                            // block with no stall timeout, so one slow seeder holding the only HAVE
+                            // monopolizes the whole fetch. Route every block get through the
+                            // stalled-session failover: after the stall window, the session get is
+                            // raced against helia.blockstore.get — the non-session bitswap path that
+                            // broadcasts the want to all connected peers — and the first block wins.
+                            // See fetchBlockWithStalledSessionFailover for the full semantics.
+                            const sessionGet = session.get.bind(session);
+                            const fallbackGet = helia.blockstore.get.bind(helia.blockstore);
+                            session.get = (blockCid, blockGetOptions) =>
+                                fetchBlockWithStalledSessionFailover({
+                                    cid: blockCid,
+                                    sessionGet,
+                                    fallbackGet,
+                                    stallTimeoutMs: BITSWAP_SESSION_STALLED_GET_FAILOVER_MS,
+                                    options: blockGetOptions,
+                                    log
+                                });
                             let yieldedAnyBytes = false;
                             try {
                                 // ipfsPath is either a bare cid or a `<root-cid>/sub/path`. Hand the whole

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -593,7 +593,9 @@ export async function createLibp2pJsClientOrUseExistingOne(
                                     cid: blockCid,
                                     sessionGet,
                                     fallbackGet,
-                                    stallTimeoutMs: BITSWAP_SESSION_STALLED_GET_FAILOVER_MS,
+                                    stallTimeoutMs:
+                                        heliaWithKuboRpcClientShape._bitswapSessionStalledGetFailoverMs ??
+                                        BITSWAP_SESSION_STALLED_GET_FAILOVER_MS,
                                     options: blockGetOptions,
                                     log
                                 });

--- a/src/helia/types.ts
+++ b/src/helia/types.ts
@@ -18,6 +18,12 @@ export interface HeliaWithKuboRpcClientFunctions extends Pick<NonNullable<KuboRp
     ): ReturnType<KuboRpcClient["_client"]["cat"]>;
     pubsub: KuboRpcClient["_client"]["pubsub"];
     stop: KuboRpcClient["_client"]["stop"];
+    // Test-only override of BITSWAP_SESSION_STALLED_GET_FAILOVER_MS, read by cat() at each block
+    // get. The issue #189 guard test (at most one routing query per DAG) sets it beyond its own
+    // timeout: on slow CI runners a block can legitimately stall, and the failover's broadcast
+    // want runs a routing query the test would miscount as a per-block leak. Production code
+    // never sets it.
+    _bitswapSessionStalledGetFailoverMs?: number;
 }
 
 type baseHelia = Awaited<ReturnType<typeof createHelia>>;

--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -489,6 +489,118 @@ export function selectBitswapSessionSeedPeers(args: {
     return seeds.slice(0, args.maxSeeds);
 }
 
+// How long a bitswap session block get may stall before we start racing it against a non-session
+// broadcast want (issue #218). @helia/bitswap's session broker sends a targeted WANT-BLOCK to the
+// session peer that didn't answer DONT_HAVE and then waits on that single peer with NO stall
+// timeout — a slow sole-HAVE seeder (~3Mbps uplink serving 65 communities' blocks over one
+// connection) therefore monopolizes every session: blocks queue 12-20s behind it while other,
+// faster peers may pick up the same blocks within seconds (seeders lag fresh update blocks —
+// DONT_HAVE now, serve the same block moments later). 2.5s sits inside the issue's validated
+// 2-3s window: far above a healthy block round-trip (p90 catSpan on healthy seeders ≈ 2.3s per
+// whole DAG), far below the 15s+ tails the stall produces.
+export const BITSWAP_SESSION_STALLED_GET_FAILOVER_MS = 2_500;
+
+type HeliaSessionBlockstore = ReturnType<HeliaWithLibp2pPubsub["blockstore"]["createSession"]>;
+type FetchBlockCid = Parameters<HeliaSessionBlockstore["get"]>[0];
+type FetchBlockOptions = Parameters<HeliaSessionBlockstore["get"]>[1];
+// Shared shape of both block sources: the per-DAG session's get and helia.blockstore's get (the
+// non-session path whose bitswap broker broadcasts the want to every connected peer, keeps it
+// registered so newly connected peers receive it, and runs one findAndConnect routing query).
+export type FetchBlockFn = (cid: FetchBlockCid, options?: FetchBlockOptions) => ReturnType<HeliaSessionBlockstore["get"]>;
+
+// Fetch one block through the bitswap session, failing over to a broadcast want when the session
+// stalls (issue #218). Semantics, chosen so the existing session retry loop in cat() keeps working:
+//   - The session gets the stall window to itself. If it delivers (or fails) first, the fallback
+//     never starts — so healthy fetches send zero extra wants and cannot reintroduce the per-block
+//     want-flood that sessions were added to prevent (issue #189).
+//   - Once stalled, the fallback broadcast want races the still-live session get; the first source
+//     to produce the block wins and the loser is aborted (bitswap CANCELs its want on receipt).
+//   - A session error always surfaces immediately (aborting any in-flight fallback) so
+//     InsufficientProvidersError keeps driving cat()'s retry-with-fresh-session loop unchanged.
+//   - A fallback error never fails the fetch while the session is still live: it is logged and the
+//     session remains the only pending source (bounded by the caller's signal/timeout, exactly the
+//     pre-failover behavior).
+export async function* fetchBlockWithStalledSessionFailover(args: {
+    cid: FetchBlockCid;
+    sessionGet: FetchBlockFn;
+    fallbackGet: FetchBlockFn;
+    stallTimeoutMs: number;
+    options: FetchBlockOptions;
+    log: Logger;
+}): AsyncGenerator<Uint8Array> {
+    const { cid, sessionGet, fallbackGet, stallTimeoutMs, options, log } = args;
+    const callerSignal = options?.signal;
+    callerSignal?.throwIfAborted();
+
+    // Each source gets its own controller so the winner can abort the loser; the caller's signal
+    // aborts both. The listener is detached in the finally below — cat()'s composed signal lives
+    // for the whole DAG walk, and per-block listeners left behind would accumulate across blocks.
+    const sessionController = new AbortController();
+    const fallbackController = new AbortController();
+    const abortBothFromCallerSignal = () => {
+        sessionController.abort(callerSignal?.reason);
+        fallbackController.abort(callerSignal?.reason);
+    };
+    callerSignal?.addEventListener("abort", abortBothFromCallerSignal, { once: true });
+
+    // Buffering the (single) block's chunks is what lets two sources race as plain promises;
+    // bitswap blocks are at most a few hundred KB so this does not change memory behavior.
+    const collectBlockChunks = async (get: FetchBlockFn, signal: AbortSignal): Promise<Uint8Array[]> => {
+        const chunks: Uint8Array[] = [];
+        for await (const chunk of get(cid, { ...options, signal })) chunks.push(chunk);
+        return chunks;
+    };
+
+    let stallTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+        const sessionAttempt = collectBlockChunks(sessionGet, sessionController.signal).then((chunks) => ({
+            source: "session" as const,
+            chunks
+        }));
+        // The finally below aborts the session controller unconditionally; when the fallback won
+        // the race, that abort surfaces here instead of as an unhandled rejection. Separate branch,
+        // so the race still observes the session's real success/error.
+        sessionAttempt.catch(() => {});
+
+        // Phase 1: the session has the stall window to itself.
+        const STALLED = Symbol("bitswap-session-get-stalled");
+        const stallPromise = new Promise<typeof STALLED>((resolve) => {
+            stallTimer = setTimeout(() => resolve(STALLED), stallTimeoutMs);
+        });
+        let winner: Awaited<typeof sessionAttempt> | { source: "fallback"; chunks: Uint8Array[] } | typeof STALLED;
+        try {
+            winner = await Promise.race([sessionAttempt, stallPromise]);
+        } finally {
+            clearTimeout(stallTimer);
+        }
+
+        // Phase 2: stalled — race the broadcast want against the still-live session get.
+        if (winner === STALLED) {
+            log.trace("Bitswap session block get stalled for", stallTimeoutMs, "ms for", String(cid), "- racing a broadcast want");
+            const fallbackAttempt = collectBlockChunks(fallbackGet, fallbackController.signal).then(
+                (chunks) => ({ source: "fallback" as const, chunks }),
+                (fallbackError): Promise<never> => {
+                    // Never settle: the session (bounded by the caller's signal/timeout) stays the
+                    // only pending source, restoring exactly the pre-failover behavior.
+                    log.trace("Broadcast-want failover errored for", String(cid), "- still waiting on the session", fallbackError);
+                    return new Promise<never>(() => {});
+                }
+            );
+            winner = await Promise.race([sessionAttempt, fallbackAttempt]);
+            log.trace("Stalled block", String(cid), "was delivered by the", winner.source, "path");
+        }
+
+        yield* winner.chunks;
+    } finally {
+        callerSignal?.removeEventListener("abort", abortBothFromCallerSignal);
+        // Abort whichever source is still pending (the race loser, or both on caller abort/session
+        // error). Aborting an already-settled source is a no-op.
+        const loserAbortReason = new Error("bitswap block get lost the stalled-session failover race (issue #218)");
+        sessionController.abort(loserAbortReason);
+        fallbackController.abort(loserAbortReason);
+    }
+}
+
 export interface DirectFetchResult {
     recordBytes: Uint8Array; // already passed the injected validator (ipnsValidator)
     peerId: string; // the subscriber/provider that served it

--- a/src/runtime/node/test/mock-http-router.ts
+++ b/src/runtime/node/test/mock-http-router.ts
@@ -73,6 +73,12 @@ export class MockHttpRouter {
     // prove that aborting findProviders (subscriber found / maxPeers reached / caller signal)
     // actually cancels the in-flight request to a slow/black-hole router rather than leaking it.
     private _abortedProviderGetCount: number;
+    // Concurrency tracking for provider GETs. The delegated-routing client serializes lookups
+    // behind an internal per-router request queue (issue #218), so a test that fires N parallel
+    // findProviders at a slow router can read the observed in-flight ceiling here to prove the
+    // queue is (or is not) the bottleneck.
+    private _inFlightProviderGetCount: number;
+    private _maxConcurrentProviderGetCount: number;
 
     constructor(options: MockHttpRouterOptions = {}) {
         this._hostname = options.hostname ?? "127.0.0.1";
@@ -83,6 +89,8 @@ export class MockHttpRouter {
         this._faultMode = options.faultMode;
         this._errorStatusCode = options.errorStatusCode ?? 500;
         this._abortedProviderGetCount = 0;
+        this._inFlightProviderGetCount = 0;
+        this._maxConcurrentProviderGetCount = 0;
         this._server = http.createServer((req, res) => {
             this._handleRequest(req, res).catch((error) => {
                 if (!res.headersSent) {
@@ -115,6 +123,13 @@ export class MockHttpRouter {
     // > 0 proves an in-flight request to this (slow/black-hole) router was actually cancelled.
     get abortedProviderGetCount(): number {
         return this._abortedProviderGetCount;
+    }
+
+    // Highest number of provider GETs that were in flight at the same time. A client whose
+    // lookups drain through a serialized request queue pins this at the queue's concurrency
+    // regardless of how many lookups were fired in parallel (issue #218).
+    get maxConcurrentProviderGetCount(): number {
+        return this._maxConcurrentProviderGetCount;
     }
 
     async start(): Promise<void> {
@@ -284,6 +299,16 @@ export class MockHttpRouter {
     }
 
     private async _handleProviderGet(url: URL, res: http.ServerResponse, corsHeaders: Record<string, string>) {
+        this._inFlightProviderGetCount++;
+        this._maxConcurrentProviderGetCount = Math.max(this._maxConcurrentProviderGetCount, this._inFlightProviderGetCount);
+        try {
+            await this._handleProviderGetInner(url, res, corsHeaders);
+        } finally {
+            this._inFlightProviderGetCount--;
+        }
+    }
+
+    private async _handleProviderGetInner(url: URL, res: http.ServerResponse, corsHeaders: Record<string, string>) {
         // A black hole accepts the connection then never responds and never closes it — it only
         // unblocks when the client disconnects. Distinct from "slow", which eventually replies.
         if (this._faultMode === "blackHole") {

--- a/test/node-and-browser/helia/helia.test.ts
+++ b/test/node-and-browser/helia/helia.test.ts
@@ -601,6 +601,12 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             const heliaClient = Object.values(testPKC.clients.libp2pJsClients)[0];
             const routing = heliaClient._helia.routing;
             const originalFindProviders = routing.findProviders.bind(routing);
+            // The stalled-session failover (issue #218) races helia.blockstore.get after 2.5s,
+            // and that broadcast path runs its own findAndConnect routing query. On slow CI
+            // runners (Firefox) a block can legitimately stall, adding a findProviders call this
+            // test would miscount as a per-block leak. Push the stall window beyond the test
+            // timeout so only the session path can query routing here.
+            heliaClient.heliaWithKuboRpcClientFunctions._bitswapSessionStalledGetFailoverMs = 10 * 60 * 1000;
             try {
                 const content = generateMultiBlockContent();
                 const cid = await addStringToIpfs(content);
@@ -619,6 +625,8 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 ).to.be.at.most(1);
             } finally {
                 routing.findProviders = originalFindProviders;
+                // The libp2p-js client instance is shared/reused across tests — restore the default.
+                delete heliaClient.heliaWithKuboRpcClientFunctions._bitswapSessionStalledGetFailoverMs;
                 await testPKC.destroy();
             }
         }, 90000);

--- a/test/node/helia/bitswap-stalled-failover-helper.unit.test.ts
+++ b/test/node/helia/bitswap-stalled-failover-helper.unit.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+import { CID } from "multiformats/cid";
+import * as rawCodec from "multiformats/codecs/raw";
+import { sha256 } from "multiformats/hashes/sha2";
+import { fetchBlockWithStalledSessionFailover } from "../../../dist/node/helia/util.js";
+import Logger from "../../../dist/node/logger.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import type { FetchBlockFn } from "../../../dist/node/helia/util.js";
+
+// Unit coverage for fetchBlockWithStalledSessionFailover (issue #218), the race between a bitswap
+// session's block get and a delayed non-session broadcast want. The cat()-level behavior is covered
+// in bitswap-stalled-session-failover.test.ts; these tests pin the helper's exact semantics with
+// fake block sources: who may win, when the fallback may start, which errors surface, and that the
+// losing source is always aborted rather than leaked.
+//
+// Pure in-process helper with fake block sources, config-independent, so it runs once under non-RPC.
+describeSkipIfRpc("fetchBlockWithStalledSessionFailover (issue #218)", () => {
+    // Small stall window so the whole file runs fast; every duration below is defined relative to
+    // it so CI timer jitter cannot reorder the intended sequence of events.
+    const STALL_MS = 300;
+
+    const log = Logger("pkc-js-test:helia:stalled-failover");
+
+    let testCid: CID;
+    const getTestCid = async (): Promise<CID> => {
+        testCid ??= CID.createV1(rawCodec.code, await sha256.digest(new TextEncoder().encode("stalled-failover-helper-test")));
+        return testCid;
+    };
+
+    const abortReasonAsError = (signal: AbortSignal): Error =>
+        signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "aborted"));
+
+    // Observability shared by all fake sources: every get records the signal it was called with
+    // (so tests can assert the loser was aborted) and how many times it was invoked.
+    type SourceProbe = { signals: AbortSignal[]; calls: number };
+    const newProbe = (): SourceProbe => ({ signals: [], calls: 0 });
+
+    const abortableDelay = (ms: number, signal: AbortSignal | undefined): Promise<void> =>
+        new Promise<void>((resolve, reject) => {
+            if (signal?.aborted) {
+                reject(abortReasonAsError(signal));
+                return;
+            }
+            const onAbort = () => {
+                clearTimeout(timer);
+                reject(abortReasonAsError(signal!));
+            };
+            const timer = setTimeout(() => {
+                signal?.removeEventListener("abort", onAbort);
+                resolve();
+            }, ms);
+            signal?.addEventListener("abort", onAbort, { once: true });
+        });
+
+    // A source that yields the given chunks after delayMs (rejecting on abort while waiting).
+    const sourceYieldingAfter = (probe: SourceProbe, delayMs: number, chunks: Uint8Array[]): FetchBlockFn =>
+        async function* (_cid, options) {
+            probe.calls++;
+            if (options?.signal) probe.signals.push(options.signal);
+            await abortableDelay(delayMs, options?.signal);
+            yield* chunks;
+        };
+
+    // A source that never delivers: it only ends when its signal aborts — the deterministic
+    // stand-in for a want pending on a slow sole-HAVE peer.
+    const sourceNeverDelivering = (probe: SourceProbe): FetchBlockFn =>
+        async function* (_cid, options) {
+            probe.calls++;
+            if (options?.signal) probe.signals.push(options.signal);
+            await new Promise<never>((_resolve, reject) => {
+                const signal = options?.signal;
+                if (signal == null) return;
+                if (signal.aborted) {
+                    reject(abortReasonAsError(signal));
+                    return;
+                }
+                signal.addEventListener("abort", () => reject(abortReasonAsError(signal)), { once: true });
+            });
+            yield new Uint8Array(0); // unreachable, satisfies the generator's type
+        };
+
+    // A source that fails after delayMs with the given error.
+    const sourceFailingAfter = (probe: SourceProbe, delayMs: number, error: Error): FetchBlockFn =>
+        async function* (_cid, options) {
+            probe.calls++;
+            if (options?.signal) probe.signals.push(options.signal);
+            await abortableDelay(delayMs, options?.signal);
+            throw error;
+        };
+
+    const runHelper = async (args: {
+        sessionGet: FetchBlockFn;
+        fallbackGet: FetchBlockFn;
+        signal?: AbortSignal;
+    }): Promise<{ fetched: Buffer; elapsedMs: number }> => {
+        const startedAt = Date.now();
+        const chunks: Uint8Array[] = [];
+        for await (const chunk of fetchBlockWithStalledSessionFailover({
+            cid: await getTestCid(),
+            sessionGet: args.sessionGet,
+            fallbackGet: args.fallbackGet,
+            stallTimeoutMs: STALL_MS,
+            options: args.signal ? { signal: args.signal } : undefined,
+            log
+        })) {
+            chunks.push(chunk);
+        }
+        return { fetched: Buffer.concat(chunks), elapsedMs: Date.now() - startedAt };
+    };
+
+    const sessionChunks = [new TextEncoder().encode("session-part-1"), new TextEncoder().encode("session-part-2")];
+    const sessionBytes = Buffer.concat(sessionChunks);
+    const fallbackChunks = [new TextEncoder().encode("fallback-block")];
+    const fallbackBytes = Buffer.concat(fallbackChunks);
+
+    it("returns the session's chunks (in order) and never starts the fallback when the session delivers before the stall window", async () => {
+        const sessionProbe = newProbe();
+        const fallbackProbe = newProbe();
+        const { fetched, elapsedMs } = await runHelper({
+            sessionGet: sourceYieldingAfter(sessionProbe, 20, sessionChunks),
+            fallbackGet: sourceYieldingAfter(fallbackProbe, 0, fallbackChunks)
+        });
+        expect(fetched.equals(sessionBytes)).to.equal(true);
+        expect(elapsedMs).to.be.lessThan(STALL_MS);
+        expect(fallbackProbe.calls).to.equal(0);
+    });
+
+    it("fails over to the fallback after the stall window and aborts the stalled session get", async () => {
+        const sessionProbe = newProbe();
+        const fallbackProbe = newProbe();
+        const { fetched, elapsedMs } = await runHelper({
+            sessionGet: sourceNeverDelivering(sessionProbe),
+            fallbackGet: sourceYieldingAfter(fallbackProbe, 0, fallbackChunks)
+        });
+        expect(fetched.equals(fallbackBytes)).to.equal(true);
+        // The fallback must not have started before the stall window elapsed.
+        expect(elapsedMs).to.be.at.least(STALL_MS);
+        expect(fallbackProbe.calls).to.equal(1);
+        // The losing session get was aborted, not left pending on the slow peer.
+        expect(sessionProbe.signals[0]?.aborted).to.equal(true);
+    });
+
+    it("lets a late session win over a slower fallback and aborts the losing fallback", async () => {
+        const sessionProbe = newProbe();
+        const fallbackProbe = newProbe();
+        const { fetched } = await runHelper({
+            // Session delivers after the stall window (2x) but before the fallback would (4x).
+            sessionGet: sourceYieldingAfter(sessionProbe, STALL_MS * 2, sessionChunks),
+            fallbackGet: sourceYieldingAfter(fallbackProbe, STALL_MS * 4, fallbackChunks)
+        });
+        expect(fetched.equals(sessionBytes)).to.equal(true);
+        expect(fallbackProbe.calls).to.equal(1);
+        expect(fallbackProbe.signals[0]?.aborted).to.equal(true);
+    });
+
+    it("surfaces a pre-stall session error immediately without starting the fallback", async () => {
+        const sessionProbe = newProbe();
+        const fallbackProbe = newProbe();
+        const sessionError = new Error("InsufficientProvidersError stand-in");
+        const startedAt = Date.now();
+        await expect(
+            runHelper({
+                sessionGet: sourceFailingAfter(sessionProbe, 20, sessionError),
+                fallbackGet: sourceYieldingAfter(fallbackProbe, 0, fallbackChunks)
+            })
+        ).rejects.toThrow(sessionError.message);
+        // Failed fast (cat()'s retry loop depends on this), and no broadcast want was fired.
+        expect(Date.now() - startedAt).to.be.lessThan(STALL_MS);
+        expect(fallbackProbe.calls).to.equal(0);
+    });
+
+    it("surfaces a post-stall session error and aborts the in-flight fallback", async () => {
+        const sessionProbe = newProbe();
+        const fallbackProbe = newProbe();
+        const sessionError = new Error("session failed after the fallback started");
+        await expect(
+            runHelper({
+                sessionGet: sourceFailingAfter(sessionProbe, STALL_MS * 2, sessionError),
+                fallbackGet: sourceYieldingAfter(fallbackProbe, STALL_MS * 4, fallbackChunks)
+            })
+        ).rejects.toThrow(sessionError.message);
+        expect(fallbackProbe.calls).to.equal(1);
+        expect(fallbackProbe.signals[0]?.aborted).to.equal(true);
+    });
+
+    it("tolerates a fallback error and still returns the session's block", async () => {
+        const sessionProbe = newProbe();
+        const fallbackProbe = newProbe();
+        const { fetched } = await runHelper({
+            sessionGet: sourceYieldingAfter(sessionProbe, STALL_MS * 3, sessionChunks),
+            fallbackGet: sourceFailingAfter(fallbackProbe, 20, new Error("no providers for broadcast want"))
+        });
+        expect(fetched.equals(sessionBytes)).to.equal(true);
+        expect(fallbackProbe.calls).to.equal(1);
+    });
+
+    it("propagates the caller's abort reason and aborts both pending sources", async () => {
+        const sessionProbe = newProbe();
+        const fallbackProbe = newProbe();
+        const abortController = new AbortController();
+        const abortReason = new Error("caller gave up (stand-in for cat() timeout)");
+        setTimeout(() => abortController.abort(abortReason), STALL_MS * 2);
+        await expect(
+            runHelper({
+                sessionGet: sourceNeverDelivering(sessionProbe),
+                fallbackGet: sourceNeverDelivering(fallbackProbe),
+                signal: abortController.signal
+            })
+        ).rejects.toThrow(abortReason.message);
+        expect(sessionProbe.signals[0]?.aborted).to.equal(true);
+        expect(fallbackProbe.signals[0]?.aborted).to.equal(true);
+    });
+
+    it("throws immediately on an already-aborted caller signal without invoking either source", async () => {
+        const sessionProbe = newProbe();
+        const fallbackProbe = newProbe();
+        const abortController = new AbortController();
+        abortController.abort(new Error("aborted before the fetch started"));
+        await expect(
+            runHelper({
+                sessionGet: sourceNeverDelivering(sessionProbe),
+                fallbackGet: sourceNeverDelivering(fallbackProbe),
+                signal: abortController.signal
+            })
+        ).rejects.toThrow("aborted before the fetch started");
+        expect(sessionProbe.calls).to.equal(0);
+        expect(fallbackProbe.calls).to.equal(0);
+    });
+});

--- a/test/node/helia/bitswap-stalled-session-failover.test.ts
+++ b/test/node/helia/bitswap-stalled-session-failover.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CID } from "multiformats/cid";
+import * as rawCodec from "multiformats/codecs/raw";
+import { sha256 } from "multiformats/hashes/sha2";
+import { createLibp2pJsClientOrUseExistingOne } from "../../../dist/node/helia/helia-for-pkc.js";
+import { MockHttpRouter } from "../../../dist/node/runtime/node/test/mock-http-router.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import type { Libp2pJsClient } from "../../../dist/node/helia/libp2pjsClient.js";
+import type { HeliaWithLibp2pPubsub } from "../../../dist/node/helia/types.js";
+
+// Regression coverage for issue #218 part 2: @helia/bitswap's session broker sends a targeted
+// WANT-BLOCK to the session peer that didn't answer DONT_HAVE and then waits on that single peer
+// with no stall timeout. In production a slow sole-HAVE seeder (~3Mbps uplink serving 65 boards'
+// blocks over one connection) monopolizes every session: blocks queue 12-20s behind it and board
+// loads blow past their timeouts. cat() must fail over: when a session block hasn't arrived within
+// the stall window, race a non-session broadcast want (helia.blockstore.get) against the stalled
+// session get and return whichever produces the block first.
+//
+// The slow sole-HAVE peer is modeled deterministically by stubbing the session's get() to never
+// deliver (it only ends on abort), while the block is available to the fallback path. On master the
+// stalled session hangs cat() until its timeout aborts everything.
+//
+// Client-side libp2p only and config-independent, so it runs once under non-RPC.
+describeSkipIfRpc("Bitswap stalled-session block failover (issue #218)", () => {
+    // Lower bound on when the failover may deliver: it must NOT fire immediately (an instant
+    // broadcast want per block would reintroduce the per-block want-flood sessions were added to
+    // prevent, issue #189). Slightly below the production stall window so timer jitter can't flake.
+    const FAILOVER_MUST_NOT_FIRE_BEFORE_MS = 2_000;
+    // Upper bound: with the stall window at ~2.5s and the fallback serving the block immediately,
+    // cat() must complete well before the 10s cat timeout below.
+    const FAILOVER_DEADLINE_MS = 7_000;
+    // cat()'s own kubo-style timeout: on master the stalled session hangs cat() until this aborts
+    // it, so the missing-failover regression surfaces as ERR_FETCH_CID_P2P_TIMEOUT at 10s.
+    const CAT_TIMEOUT = "10s";
+    // When the session delivers promptly the failover must not have started; generous CI margin.
+    const PROMPT_SESSION_DEADLINE_MS = 2_000;
+
+    type HeliaBlockstore = HeliaWithLibp2pPubsub["blockstore"];
+    type SessionBlockstore = ReturnType<HeliaBlockstore["createSession"]>;
+    type SessionGetParams = Parameters<SessionBlockstore["get"]>;
+
+    const startedRouters: MockHttpRouter[] = [];
+    const clientsToStop: Libp2pJsClient[] = [];
+    let keyCounter = 0;
+
+    afterEach(async () => {
+        let stopError: unknown;
+        while (clientsToStop.length) {
+            try {
+                await clientsToStop.pop()!.heliaWithKuboRpcClientFunctions.stop();
+            } catch (e) {
+                stopError ??= e;
+            }
+        }
+        while (startedRouters.length) {
+            try {
+                await startedRouters.pop()!.destroy();
+            } catch {
+                // already destroyed
+            }
+        }
+        if (stopError) throw stopError;
+    });
+
+    // createLibp2pJsClientOrUseExistingOne requires at least one HTTP router; a started empty mock
+    // router keeps the test hermetic (no production routers, no Kubo).
+    const createClient = async (): Promise<Libp2pJsClient> => {
+        const router = new MockHttpRouter();
+        await router.start();
+        startedRouters.push(router);
+        const client = (await createLibp2pJsClientOrUseExistingOne({
+            key: `bitswap-stalled-session-failover-${keyCounter++}`,
+            httpRoutersOptions: [router.url],
+            libp2pOptions: {},
+            heliaOptions: {}
+        })) as Libp2pJsClient;
+        clientsToStop.push(client);
+        return client;
+    };
+
+    const makeRawBlock = async (content: string): Promise<{ cid: CID; bytes: Uint8Array }> => {
+        const bytes = new TextEncoder().encode(content);
+        return { cid: CID.createV1(rawCodec.code, await sha256.digest(bytes)), bytes };
+    };
+
+    const abortReasonAsError = (signal: AbortSignal): Error =>
+        signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "aborted"));
+
+    // Replace every session's get() with one that never delivers a block and only ends when its
+    // signal aborts — the deterministic stand-in for a session pinned on a slow sole-HAVE peer.
+    // Returns the signals handed to the stalled gets so the test can assert the failover winner
+    // aborted the stalled loser instead of leaking it.
+    const stubSessionsToStall = (helia: HeliaWithLibp2pPubsub): { sessionGetSignals: (AbortSignal | undefined)[] } => {
+        const sessionGetSignals: (AbortSignal | undefined)[] = [];
+        const originalCreateSession = helia.blockstore.createSession.bind(helia.blockstore);
+        helia.blockstore.createSession = (root, options) => {
+            const session = originalCreateSession(root, options);
+            session.get = async function* (_cid: SessionGetParams[0], getOptions?: SessionGetParams[1]) {
+                sessionGetSignals.push(getOptions?.signal);
+                await new Promise<never>((_resolve, reject) => {
+                    const signal = getOptions?.signal;
+                    if (signal == null) return; // no signal: stall forever, like a peer that never answers
+                    if (signal.aborted) {
+                        reject(abortReasonAsError(signal));
+                        return;
+                    }
+                    signal.addEventListener("abort", () => reject(abortReasonAsError(signal)), { once: true });
+                });
+                yield new Uint8Array(0); // unreachable, satisfies the generator's type
+            };
+            return session;
+        };
+        return { sessionGetSignals };
+    };
+
+    const catToBuffer = async (client: Libp2pJsClient, ipfsPath: string): Promise<Buffer> => {
+        const chunks: Uint8Array[] = [];
+        for await (const chunk of client.heliaWithKuboRpcClientFunctions.cat(ipfsPath, { timeout: CAT_TIMEOUT })) {
+            chunks.push(chunk);
+        }
+        return Buffer.concat(chunks);
+    };
+
+    it("cat() falls back to a broadcast want and still returns the block when the session stalls", async () => {
+        const client = await createClient();
+        const helia = client._helia;
+        const { cid, bytes } = await makeRawBlock("bitswap stalled session failover block (issue #218)");
+        // The block is reachable by the fallback path (helia.blockstore.get) but the session never
+        // delivers it — the sole-HAVE seeder is "serving" it too slowly to ever arrive.
+        await helia.blockstore.put(cid, bytes);
+        const { sessionGetSignals } = stubSessionsToStall(helia);
+
+        const startedAt = Date.now();
+        const fetched = await catToBuffer(client, cid.toString());
+        const elapsedMs = Date.now() - startedAt;
+
+        expect(fetched.equals(Buffer.from(bytes))).to.equal(true);
+        // The session was actually consulted and stalled...
+        expect(sessionGetSignals.length).to.be.at.least(1);
+        // ...the failover waited out the stall window instead of broadcasting instantly...
+        expect(elapsedMs).to.be.at.least(FAILOVER_MUST_NOT_FIRE_BEFORE_MS);
+        // ...and delivered long before cat()'s timeout would have fired.
+        expect(elapsedMs).to.be.lessThan(FAILOVER_DEADLINE_MS);
+        // The stalled session get must be aborted once the fallback wins — not left dangling on the
+        // slow peer for the rest of the fetch's lifetime.
+        await vi.waitFor(() => expect(sessionGetSignals.some((signal) => signal?.aborted)).to.equal(true), { timeout: 3_000 });
+    });
+
+    it("does not start the broadcast fallback when the session delivers promptly", async () => {
+        const client = await createClient();
+        const helia = client._helia;
+        const { cid, bytes } = await makeRawBlock("bitswap prompt session block (issue #218)");
+
+        // Session serves the block itself after a short delay; the block is deliberately NOT in the
+        // local blockstore, so a stray fallback would have to go to the network (and hang).
+        const originalCreateSession = helia.blockstore.createSession.bind(helia.blockstore);
+        helia.blockstore.createSession = (root, options) => {
+            const session = originalCreateSession(root, options);
+            session.get = async function* (_cid: SessionGetParams[0], _getOptions?: SessionGetParams[1]) {
+                await new Promise((resolve) => setTimeout(resolve, 100));
+                yield bytes;
+            };
+            return session;
+        };
+        // Count fallback invocations instead of letting one hang the test: any call is a failure.
+        let fallbackGetCalls = 0;
+        const originalBlockstoreGet = helia.blockstore.get.bind(helia.blockstore);
+        helia.blockstore.get = (getCid, getOptions) => {
+            fallbackGetCalls++;
+            return originalBlockstoreGet(getCid, getOptions);
+        };
+
+        const startedAt = Date.now();
+        const fetched = await catToBuffer(client, cid.toString());
+        const elapsedMs = Date.now() - startedAt;
+
+        expect(fetched.equals(Buffer.from(bytes))).to.equal(true);
+        expect(elapsedMs).to.be.lessThan(PROMPT_SESSION_DEADLINE_MS);
+        expect(fallbackGetCalls).to.equal(0);
+    });
+});

--- a/test/node/helia/delegated-routing-concurrency.unit.test.ts
+++ b/test/node/helia/delegated-routing-concurrency.unit.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createLibp2pJsClientOrUseExistingOne } from "../../../dist/node/helia/helia-for-pkc.js";
+import { MockHttpRouter } from "../../../dist/node/runtime/node/test/mock-http-router.js";
+import { pubsubTopicToDhtKeyCid } from "../../../dist/node/util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import type { Libp2pJsClient } from "../../../dist/node/helia/libp2pjsClient.js";
+
+// Regression coverage for issue #218 part 1: @helia/delegated-routing-v1-http-api-client defaults to
+// concurrentRequests: 4 per router, so when many boards/communities resolve in parallel their
+// findProviders lookups drain 4 at a time behind the client's internal queue — production profiling
+// measured this queueing as ~65% of a parallel all-boards load (lookups waited seconds for a slot
+// while the router itself answered in <500ms). getDelegatedRoutingFields must construct the client
+// with a higher concurrentRequests so parallel lookups actually reach the router in parallel.
+//
+// The test fires many concurrent findProviders (distinct CIDs, so no request de-duplication) at a
+// single slow mock router and reads the router's observed in-flight ceiling: with the default queue
+// it is deterministically pinned at 4 no matter how many lookups are outstanding.
+//
+// Client-side libp2p only and config-independent, so it runs once under non-RPC.
+describeSkipIfRpc("Delegated-routing provider lookup concurrency (issue #218)", () => {
+    // Enough parallel lookups to make queue serialization unmistakable: far above both the default
+    // queue (4) and the assertion floor below, while staying under the configured concurrency (32)
+    // so every lookup can be in flight simultaneously.
+    const PARALLEL_LOOKUPS = 24;
+    // How long the router holds each provider GET before answering. Long enough that all lookups
+    // pile up in flight together even under CI scheduling jitter.
+    const ROUTER_RESPONSE_DELAY_MS = 1_500;
+    // The in-flight ceiling the router must observe. Master's default queue pins it at exactly 4;
+    // with concurrentRequests: 32 all 24 lookups go out together, so 12 leaves huge headroom for
+    // undici connection setup staggering while still failing fast on any re-serialization.
+    const MIN_OBSERVED_CONCURRENCY = 12;
+    // Generous per-lookup safety deadline so a regression fails by assertion, not by test timeout.
+    const LOOKUP_SAFETY_DEADLINE_MS = 60_000;
+
+    const startedRouters: MockHttpRouter[] = [];
+    const clientsToStop: Libp2pJsClient[] = [];
+    let keyCounter = 0;
+
+    afterEach(async () => {
+        // countOfUsesOfInstance starts at 1, so a single stop() tears each helia instance down.
+        // Isolate each stop() so a failing client shutdown still lets every router get destroyed.
+        let stopError: unknown;
+        while (clientsToStop.length) {
+            try {
+                await clientsToStop.pop()!.heliaWithKuboRpcClientFunctions.stop();
+            } catch (e) {
+                stopError ??= e;
+            }
+        }
+        while (startedRouters.length) {
+            try {
+                await startedRouters.pop()!.destroy();
+            } catch {
+                // already destroyed
+            }
+        }
+        if (stopError) throw stopError;
+    });
+
+    const createHeliaWithRouters = async (httpRoutersOptions: string[]): Promise<Libp2pJsClient> => {
+        const client = (await createLibp2pJsClientOrUseExistingOne({
+            key: `delegated-routing-concurrency-${keyCounter++}`,
+            httpRoutersOptions,
+            libp2pOptions: {},
+            heliaOptions: {}
+        })) as Libp2pJsClient;
+        clientsToStop.push(client);
+        return client;
+    };
+
+    // Run one findProviders lookup to completion (the router answers 404/no providers after its
+    // delay, which ends the merged stream without yielding). The safety deadline only exists so a
+    // hung lookup cannot stall the whole test file.
+    const runLookup = async (client: Libp2pJsClient, topic: string): Promise<void> => {
+        const cid = pubsubTopicToDhtKeyCid(topic);
+        const ac = new AbortController();
+        const timer = setTimeout(() => ac.abort(), LOOKUP_SAFETY_DEADLINE_MS);
+        try {
+            for await (const _peer of client._helia.libp2p.contentRouting.findProviders(cid, { signal: ac.signal })) {
+                break;
+            }
+        } finally {
+            clearTimeout(timer);
+            ac.abort();
+        }
+    };
+
+    it("parallel findProviders lookups are not serialized behind the client's request queue", async () => {
+        const router = new MockHttpRouter({ providerGetDelayMs: ROUTER_RESPONSE_DELAY_MS });
+        await router.start();
+        startedRouters.push(router);
+        const client = await createHeliaWithRouters([router.url]);
+
+        await Promise.all(Array.from({ length: PARALLEL_LOOKUPS }, (_, i) => runLookup(client, `delegated-routing-concurrency-test-${i}`)));
+
+        // Every lookup must have reached the router (distinct CIDs, one GET each)...
+        const providerGets = router.requests.filter((r) => r.method === "GET").length;
+        expect(providerGets).to.be.at.least(PARALLEL_LOOKUPS);
+        // ...and they must have been in flight together, not drained 4 at a time.
+        expect(
+            router.maxConcurrentProviderGetCount,
+            `router observed at most ${router.maxConcurrentProviderGetCount} concurrent provider GETs across ${PARALLEL_LOOKUPS} parallel lookups`
+        ).to.be.at.least(MIN_OBSERVED_CONCURRENCY);
+    });
+});


### PR DESCRIPTION
Fixes #218

Two coupled fixes, shipped together because part 1 alone is a measured net regression: raising routing concurrency synchronizes all communities into fetching-ipfs, which exposes the bitswap session's lack of failover off a slow sole-HAVE seeder (52 loads >15s in the benchmark vs 0 on master).

## Part 1: delegated-routing lookup concurrency

`@helia/delegated-routing-v1-http-api-client` defaults to `concurrentRequests: 4` per router, an internal queue that serialized parallel `findProviders` lookups. Production-like profiling (65 communities updating in parallel, issue #218) measured that queueing as ~65% of the median load time while the routers themselves answered in <500ms. `getDelegatedRoutingFields` now constructs each client with `concurrentRequests: 32`, the benchmark-validated value (total request volume per burst is unchanged, only burstiness increases).

## Part 2: stalled bitswap session block failover

Root cause confirmed in `@helia/bitswap` 3.2.3: `WantList.wantSessionBlock` sends a targeted WANT-BLOCK and waits for that one peer's response with no stall timeout, and DONT_HAVE peers are evicted from the session, so a slow sole-HAVE seeder monopolizes every session indefinitely.

`cat()` now routes each session block get through `fetchBlockWithStalledSessionFailover` (new in `src/helia/util.ts`):

- The session gets a 2.5s stall window to itself. Healthy fetches never start the fallback, so this cannot reintroduce the per-block want-flood that sessions were added to prevent (#189).
- Once stalled, the session get races `helia.blockstore.get`, the non-session bitswap path that broadcasts the want to all connected peers, keeps it registered (newly connected peers receive the wantlist), and runs one `findAndConnect` routing query. First block wins; the loser is aborted.
- A session error always surfaces immediately (aborting any in-flight fallback), so `InsufficientProvidersError` keeps driving the existing retry-with-fresh-session loop unchanged.
- A fallback error never fails the fetch while the session is still live.
- The caller-signal abort listener is detached in a finally, per the abort-listener-leak class fixed in #149.

## Tests (written first, observed red on master)

- `test/node/helia/delegated-routing-concurrency.unit.test.ts`: fires 24 parallel `findProviders` at a slow mock router and asserts the observed in-flight ceiling. Red on master: pinned at exactly 4, lookups took 9s; green: 24 in flight, 1.6s. `MockHttpRouter` gained concurrent in-flight GET tracking to support this.
- `test/node/helia/bitswap-stalled-session-failover.test.ts`: cat()-level. Stubs the session to never deliver (deterministic stand-in for the slow sole-HAVE peer) with the block reachable by the fallback. Red on master: cat hangs until `ERR_FETCH_CID_P2P_TIMEOUT`; green: block delivered at ~2.55s, stalled session get aborted. Second test proves a promptly-delivering session never triggers the fallback.
- `test/node/helia/bitswap-stalled-failover-helper.unit.test.ts`: 8 unit tests pinning the race semantics (winner selection, stall gating, error passthrough, fallback-error tolerance, caller abort, loser abort).

All of `test/node/helia/` passes (80 tests). Server-dependent suites left to CI.

## Notes

- The ~50-150ms fan-out jitter mentioned in the issue is intentionally left out: it belongs to the consuming app's fan-out, and with both fixes the measured need for staggering disappears.
- Possible follow-up: a per-session degraded flag to skip the stall window for subsequent blocks of an already-stalled DAG. Not needed for the measured DAG sizes (1-2 blocks per community load).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block retrieval reliability when Bitswap session requests stall by automatically using a fallback retrieval path.
  * Preserved fast retrieval for responsive sessions while preventing stalled requests from blocking content access.
  * Increased concurrency for delegated provider lookups, improving performance during parallel retrievals.

* **Tests**
  * Added coverage for stalled-session recovery, cancellation behavior, fallback timing, and delegated-routing concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->