### PR TITLE
feat(helia): expose a public, semver-covered accessor for the shared Helia node

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,29 @@ process.on('uncaughtException', (err) => console.error(err))
 
 Attaching an `'error'` listener directly on a `community`, `comment`, or other publication object stops the bubble-up: in that case the error stays on the child and is not re-emitted on the pkc instance.
 
+### `pkc.clients.libp2pJsClients[key].heliaNode`
+
+> When the instance runs an in-process libp2p/Helia node (`libp2pJsClientsOptions`), `heliaNode` returns the running [Helia](https://github.com/ipfs/helia) node so libraries that share the node (e.g. [@bitsocial/pubsub-voting](https://github.com/bitsocialnet/pubsub-voting), [bitsocial-seeder](https://github.com/bitsocialnet/bitsocial-seeder)) can drive it directly. This accessor is the public, semver-covered surface for reaching the node — a breaking change to what it returns is a breaking pkc-js release. Do not reach through the private `_helia` field.
+
+The returned node is guaranteed to carry, in addition to Helia's own surface:
+
+| Surface | Description |
+| -------- | -------- |
+| `libp2p.services.pubsub` | The [gossipsub](https://github.com/ChainSafe/js-libp2p-gossipsub) service registered at node construction |
+| `libp2p.services.fetch` | The [`@libp2p/fetch`](https://github.com/libp2p/js-libp2p/tree/main/packages/protocol-fetch) service registered at node construction |
+| `blockstore` | The node's block storage (bitswap-backed retrieval) |
+| `libp2p.contentRouting` | The delegated-routing aggregation over `httpRoutersOptions` |
+
+The accessor's return type is exported from the root entry as `HeliaWithLibp2pPubsub`, and the client's type as `Libp2pJsClient`.
+
+#### Example
+
+```js
+const pkc = await PKC({ libp2pJsClientsOptions: [{ key: 'main' }], httpRoutersOptions: ['https://peers.pleb.bot'] })
+const helia = pkc.clients.libp2pJsClients['main'].heliaNode
+helia.libp2p.services.pubsub.subscribe('my-topic')
+```
+
 ### `pkc.getMultisub(multisubAddress)` *(not yet implemented)*
 
 > Get a multisub by its `Address`. A multisub is a list of communities curated by the creator of the multisub. E.g. `'pkc.bso/#/m/john.bso'` would display a feed of the multisub communities curated by `'john.bso'` (multisub `Address` `'john.bso'`).

--- a/src/helia/libp2pjsClient.ts
+++ b/src/helia/libp2pjsClient.ts
@@ -26,6 +26,23 @@ export class Libp2pJsClient {
     key: Libp2pJsClientInit["key"];
     countOfUsesOfInstance: number;
 
+    /**
+     * The running Helia node backing this libp2p-js client — the public, semver-covered way for
+     * consumers that share the node (e.g. @bitsocial/pubsub-voting, bitsocial-seeder) to reach it,
+     * instead of the private `_helia` field (issue #221).
+     *
+     * The returned node is guaranteed to carry, in addition to Helia's own surface:
+     * - `libp2p.services.pubsub` — the gossipsub service registered at node construction
+     * - `libp2p.services.fetch` — the `@libp2p/fetch` service registered at node construction
+     * - `blockstore` — the node's block storage (bitswap-backed retrieval)
+     * - `libp2p.contentRouting` — the delegated-routing aggregation over `httpRoutersOptions`
+     *
+     * A breaking change to what this accessor returns is a breaking pkc-js release.
+     */
+    get heliaNode(): HeliaWithLibp2pPubsub {
+        return this._helia;
+    }
+
     constructor(libp2pJsClientOptions: Libp2pJsClientInit) {
         this._helia = libp2pJsClientOptions.helia;
         this._heliaUnixfs = libp2pJsClientOptions.heliaUnixfs;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,9 @@ export const challenges = PKC.challenges;
 // the root entry instead of deep-importing from "./schema.js".
 export type { NameResolverInterface } from "./schema.js";
 export type { NameResolver } from "./types.js";
+
+// Public re-exports: shared-Helia-node accessor (issue #221) — let consumers that run on the
+// shared node (e.g. @bitsocial/pubsub-voting, bitsocial-seeder) name the accessor's types from
+// the root entry instead of reaching through private fields or deep-importing internals.
+export type { Libp2pJsClient } from "./helia/libp2pjsClient.js";
+export type { HeliaWithLibp2pPubsub } from "./helia/types.js";

--- a/test/node-and-browser/pkc/pkc.test.ts
+++ b/test/node-and-browser/pkc/pkc.test.ts
@@ -174,6 +174,25 @@ describe("PKC options", async () => {
         await pkc.destroy();
     });
 
+    it(`libp2pJsClient.heliaNode publicly exposes the running Helia node with the semver-covered services (issue #221)`, async () => {
+        const pkc = await PKC({
+            libp2pJsClientsOptions: [{ key: "random" }],
+            httpRoutersOptions: ["https://notexist.com"],
+            dataPath: undefined
+        });
+        const libp2pJsClient = pkc.clients.libp2pJsClients["random"];
+        expect(libp2pJsClient.heliaNode).to.equal(libp2pJsClient._helia); // the running node itself, not a copy
+        // the surfaces the accessor guarantees (issue #221)
+        expect(libp2pJsClient.heliaNode.libp2p.services.pubsub.publish).to.be.a("function");
+        expect(libp2pJsClient.heliaNode.libp2p.services.pubsub.subscribe).to.be.a("function");
+        expect(libp2pJsClient.heliaNode.libp2p.services.fetch.fetch).to.be.a("function");
+        expect(libp2pJsClient.heliaNode.libp2p.services.fetch.registerLookupFunction).to.be.a("function");
+        expect(libp2pJsClient.heliaNode.blockstore.get).to.be.a("function");
+        expect(libp2pJsClient.heliaNode.libp2p.contentRouting.findProviders).to.be.a("function");
+        JSON.stringify(pkc); // the accessor must not reintroduce circular json
+        await pkc.destroy();
+    });
+
     it(`PKC({nameResolvers: [...]}) sets pkc.nameResolvers correctly`, async () => {
         const mockResolver = {
             key: "test-resolver",


### PR DESCRIPTION
Closes #221 — the remaining piece from #183.

## Problem

Consumers that run on the shared Helia node (`@bitsocial/pubsub-voting`, bitsocial-seeder) reach through `pkc.clients.libp2pJsClients[key]._helia`, which is private-by-convention and typed as raw Helia internals, so every internal churn is a consumer break (e.g. the multiformats 13/14 split).

## Change

- **`Libp2pJsClient.heliaNode`** — a documented public getter returning the running Helia node. Its JSDoc + README section pin the surfaces the accessor guarantees, exactly the ones consumers drive:
  - `libp2p.services.pubsub` (gossipsub, registered since 0.0.63)
  - `libp2p.services.fetch` (registered since 0.0.63, previously unexposed by any public surface)
  - `blockstore`
  - `libp2p.contentRouting` (the delegated-routing aggregation)
- **Root-entry type re-exports** — `Libp2pJsClient` and `HeliaWithLibp2pPubsub` (the accessor's return type) are exported from `src/index.ts`, following the existing `NameResolver` re-export pattern, so downstream code can name them without deep imports.
- **Semver commitment documented** — README and JSDoc state that a breaking change to what the accessor returns is a breaking pkc-js release.
- **Test** — `pkc.test.ts` gains a case that constructs a real in-process libp2p/Helia client (no test server needed) and asserts the accessor returns the same running node as `_helia`, that each guaranteed service surface is callable, and that the getter does not reintroduce circular JSON (`JSON.stringify(pkc)`).

Implemented as a prototype getter (not an own property), so `hideClassPrivateProps` / `JSON.stringify` behavior is unchanged.

## Verification

- `npm run build` passes (node + browser + `verify:browser-imports` + `verify:bundle`).
- `npx tsc --project test/tsconfig.json` passes.
- The new test passes; the two pre-existing failures elsewhere in `pkc.test.ts` without a running test server (`ECONNREFUSED 127.0.0.1:15001`) are unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added access to the running Helia node through the libp2p client.
  - The shared node exposes pubsub, fetching, block storage, and content-routing services for direct integration.
  - Added publicly importable types for the client and Helia node.

- **Documentation**
  - Updated API documentation with accessor details, supported services, return types, and a pubsub usage example.

- **Tests**
  - Added coverage confirming node access, required service APIs, and safe serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->