### PR TITLE
test(helia): retry kubo pubsub publish when the seqno validator races

### DIFF
--- a/test/node-and-browser/helia/helia.test.ts
+++ b/test/node-and-browser/helia/helia.test.ts
@@ -139,7 +139,20 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             const numOfPeersAfterSubscribing = libp2pJsClient._helia.libp2p.getConnections().length;
             expect(numOfPeersAfterSubscribing).to.be.greaterThan(numOfPeersBeforeSubscribing);
 
-            await kuboRpc._client.pubsub.publish(mathCliNoMockedPubsubCommunityAddress, new TextEncoder().encode("test"));
+            // Kubo applies go-libp2p-pubsub's BasicSeqnoValidator to all topics and runs it inline for
+            // local publishes. Concurrent publishes from the same daemon (parallel test files and
+            // namesys-pubsub share it) can commit a higher seqno first, making this publish fail with
+            // HTTP 500 "validation ignored" even though the message is valid. A retry gets a fresh
+            // seqno, and the ignored attempt was never delivered so pubsubMsgs still ends up with 1.
+            const maxPublishAttempts = 3;
+            for (let attempt = 1; attempt <= maxPublishAttempts; attempt++) {
+                try {
+                    await kuboRpc._client.pubsub.publish(mathCliNoMockedPubsubCommunityAddress, new TextEncoder().encode("test"));
+                    break;
+                } catch (e) {
+                    if (attempt === maxPublishAttempts || !(e instanceof Error && e.message.includes("validation ignored"))) throw e;
+                }
+            }
 
             await new Promise((resolve) => setTimeout(resolve, 2000));
             expect(pubsubMsgs.length).to.equal(1);


### PR DESCRIPTION
## Problem

CI run 29677054512 (job `test-pkc-js-chrome-remote-libp2pjs`) failed a single test: `test/node-and-browser/helia/helia.test.ts` > "should connect to peers if we're subscribing over pubsub". The `kuboRpc._client.pubsub.publish(...)` call got HTTP 500 `validation ignored` from the test Kubo daemon.

## Root cause

Kubo (since at least 0.40, including 0.42.0 used in CI) registers go-libp2p-pubsub's `BasicSeqnoValidator` as a default validator on all topics (`core/node/libp2p/pubsub.go`). It tracks the highest seen seqno per peer ID (shared across topics) and returns ValidationIgnore for any message whose seqno is not strictly greater. Local publishes run it inline, and in go-libp2p-pubsub v0.16.0 an inline ValidationIgnore surfaces to the `pubsub pub` RPC call as a 500 `validation ignored`.

The race: a publish gets its seqno from an atomic counter in `Topic.validate()`, but the validator commits that seqno to the store later and independently. Two concurrent publishes from the same daemon can interleave so that the higher seqno commits first and the older publish is ignored. The test daemon is shared by parallel test files (community challenge pubsub) and its own namesys-pubsub IPNS publishes, all from the same peer ID, so concurrent publishes are routine and the single publish in this test occasionally loses the race.

## Fix

Retry the publish (up to 3 attempts) when the error message is `validation ignored`. Each retry gets a fresh seqno so it passes the validator, and the ignored attempt was never delivered to the mesh, so the `pubsubMsgs.length === 1` assertion is unaffected. Any other error still throws immediately.

Test-only change; no `src/` modifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved pubsub test reliability by retrying local message publication when validation is temporarily ignored.
  * Continued verifying that exactly one message is received with the expected content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->