### PR TITLE
fix(community): stop stale_replies from re-flagging parents of its own batch

### DIFF
--- a/src/runtime/node/community/db-handler.ts
+++ b/src/runtime/node/community/db-handler.ts
@@ -1875,7 +1875,15 @@ export class DbHandler {
                 JOIN ${TABLES.COMMENT_UPDATES} cu_child ON cu_child.cid = child_ref.value
                 WHERE cu_parent.replies IS NOT NULL
                   AND json_type(cu_parent.replies, '$.best.commentCids') = 'array'
-                  AND cu_child.updatedAt > cu_parent.insertedAt
+                  -- Compare against the parent's updatedAt, not its insertedAt (issue #230). insertedAt is
+                  -- the batch's start timestamp, shared by every row the batch writes (issue #209/#211),
+                  -- while updatedAt is stamped when that row is actually calculated. A batch walks a post
+                  -- tree deepest-depth-first, so a child is always calculated before its parent and its
+                  -- updatedAt lands after the batch's start: comparing against insertedAt re-flagged every
+                  -- parent of any batch spanning >= 1 second, which produced another such batch, and the
+                  -- update loop never converged. updatedAt is when the parent's replies page was actually
+                  -- generated, which is the point the child's data could have gone stale relative to.
+                  AND cu_child.updatedAt > cu_parent.updatedAt
             ),
             base_updates AS (
                 SELECT * FROM direct_updates

--- a/test/node/community/commentsToUpdate.batch-span-loop.community.test.ts
+++ b/test/node/community/commentsToUpdate.batch-span-loop.community.test.ts
@@ -1,0 +1,175 @@
+import { mockPKC } from "../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { it, expect, vi } from "vitest";
+import { of as calculateIpfsCidV0Lib } from "typestub-ipfs-only-hash";
+import { randomUUID } from "node:crypto";
+import env from "../../../dist/node/version.js";
+import { calculateStringSizeSameAsIpfsAddCidV0 } from "../../../dist/node/util.js";
+import { updateCommentsThatNeedToBeUpdated } from "../../../dist/node/runtime/node/community/local-community/comment-updates.js";
+
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
+import type { CommentsTableRowInsert } from "../../../dist/node/publications/comment/types.js";
+
+// Regression test for issue #230.
+//
+// updateCommentsThatNeedToBeUpdated() stamps every CommentUpdate row it writes with
+// batchStartTimestamp — a timestamp captured before the batch's flag query runs (issue #209/#211) —
+// while each row's updatedAt is stamped when that row is actually calculated. A post tree is walked
+// deepest-depth-first, so a child is always calculated before its parent and the child's updatedAt
+// lands later than the batch's start.
+//
+// The stale_replies CTE in queryCommentsToBeUpdated() compared cu_child.updatedAt against
+// cu_parent.insertedAt, so any batch spanning >= 1 second re-flagged every parent whose preloaded
+// `best` replies page held a child updated in that same batch. Re-flagging produced another
+// >= 1 second batch, which re-flagged again: the loop never converged. A production node was
+// re-signing and republishing the same ~291 comments every ~2 minutes with no new votes, edits,
+// moderations or replies, and rotating every post's updateCid along with them.
+//
+// This test drives a real batch whose page generation is slowed past the one-second boundary, then
+// asserts the queue drains. Uses LocalCommunity internals (_dbHandler, _pageGenerator) which live
+// server-side under RPC and are unreachable from the client, so it cannot run under RPC.
+describeSkipIfRpc("update loop converges when a batch spans more than one second (issue #230)", function () {
+    it("does not requeue comments that were all recalculated by the same slow batch", async () => {
+        const context = await createCommunityWithFakeIpfs();
+        try {
+            const { community } = context;
+
+            // A chain of replies, so each parent's preloaded `best` page references a child that the
+            // same batch recalculates. A chain (rather than one post with several replies) is what
+            // makes the batch cross the one-second boundary: updateCommentsThatNeedToBeUpdated
+            // processes one depth level at a time and awaits each level, and updatedAt is stamped when
+            // a comment's calculation *starts*, so only accumulated work from deeper levels can push a
+            // child's updatedAt past the batch's start second. Seeded well in the past so the comment
+            // rows themselves never satisfy direct_updates' `child.insertedAt >= cu.insertedAt`.
+            const seededAt = Math.floor(Date.now() / 1000) - 3600;
+            const chainCids = await seedReplyChain(community, { depth: 4, seededAt });
+
+            const pageGenerator = community._pageGenerator;
+            const originalGeneratePostPages = pageGenerator.generatePostPages.bind(pageGenerator);
+            const originalGenerateReplyPages = pageGenerator.generateReplyPages.bind(pageGenerator);
+            const slowPageGeneration = () => new Promise((resolve) => setTimeout(resolve, 800));
+
+            const postPagesSpy = vi
+                .spyOn(pageGenerator, "generatePostPages")
+                .mockImplementation(async (...args: Parameters<typeof originalGeneratePostPages>) => {
+                    await slowPageGeneration();
+                    return originalGeneratePostPages(...args);
+                });
+            const replyPagesSpy = vi
+                .spyOn(pageGenerator, "generateReplyPages")
+                .mockImplementation(async (...args: Parameters<typeof originalGenerateReplyPages>) => {
+                    await slowPageGeneration();
+                    return originalGenerateReplyPages(...args);
+                });
+
+            const rows = await updateCommentsThatNeedToBeUpdated(community);
+            expect(rows.length, "the batch should have recalculated every comment in the chain").to.equal(chainCids.length);
+
+            const storedUpdates = chainCids.map((cid) => community._dbHandler.queryStoredCommentUpdate({ cid })!);
+            const batchInsertedAt = storedUpdates[0].insertedAt;
+            expect(
+                new Set(storedUpdates.map((update) => update.insertedAt)).size,
+                "every row of one batch shares the batch's start timestamp as insertedAt"
+            ).to.equal(1);
+            // Precondition of the bug: without at least one child stamped in a later second than the
+            // batch's start, stale_replies could not fire and the assertion below would pass vacuously.
+            expect(
+                storedUpdates.filter((update) => update.updatedAt > batchInsertedAt).length,
+                "the batch must span at least a second for this test to exercise the bug"
+            ).to.be.at.least(1);
+
+            // syncPostUpdatesWithIpfs does this once the updates reach MFS; without it every row stays
+            // flagged by direct_updates and the assertion below would pass for the wrong reason.
+            community._dbHandler.markCommentsAsPublishedToPostUpdates(rows.map((row) => row.newCommentUpdate.cid));
+
+            const flaggedAfterBatch = community._dbHandler.queryCommentsToBeUpdated().map((comment) => comment.cid);
+            expect(
+                flaggedAfterBatch,
+                "nothing changed since the batch, so the next loop must have no work — a non-empty queue here is the perpetual update loop of issue #230"
+            ).to.be.empty;
+
+            postPagesSpy.mockRestore();
+            replyPagesSpy.mockRestore();
+        } finally {
+            await context.cleanup();
+        }
+    });
+});
+
+interface CommunityContext {
+    pkc: PKCType;
+    community: LocalCommunity;
+    cleanup: () => Promise<void>;
+}
+
+async function createCommunityWithFakeIpfs(): Promise<CommunityContext> {
+    const pkc: PKCType = await mockPKC();
+    const community = (await pkc.createCommunity()) as LocalCommunity;
+    await community._dbHandler.initDbIfNeeded();
+    await community._dbHandler.createOrMigrateTablesIfNeeded();
+    vi.spyOn(community._clientsManager, "getDefaultKuboRpcClient").mockReturnValue({
+        _client: createFakeIpfsClient()
+    } as unknown as ReturnType<typeof community._clientsManager.getDefaultKuboRpcClient>);
+    return {
+        pkc,
+        community,
+        cleanup: async () => {
+            await community._dbHandler.destoryConnection();
+            await community.delete();
+            await pkc.destroy();
+        }
+    };
+}
+
+function createFakeIpfsClient() {
+    const noopAsync = async (): Promise<void> => {};
+    return {
+        add: async (content: string) => {
+            const size = await calculateStringSizeSameAsIpfsAddCidV0(content);
+            const cid = await calculateIpfsCidV0Lib(`${content.length}-${randomUUID()}`);
+            return { cid, path: cid, size };
+        },
+        pin: { rm: noopAsync },
+        files: { rm: noopAsync },
+        key: { rm: noopAsync },
+        routing: {
+            async *provide(): AsyncGenerator<never, void, unknown> {
+                return;
+            }
+        }
+    };
+}
+
+// Seeds a post and a single chain of replies hanging off it: post -> reply -> reply -> ...
+// Returned cids are ordered from the post downwards.
+async function seedReplyChain(community: LocalCommunity, { depth, seededAt }: { depth: number; seededAt: number }): Promise<string[]> {
+    const buildRow = (cid: string, commentDepth: number, parentCid: string | null, postCid: string, timestamp: number) =>
+        ({
+            cid,
+            authorSignerAddress: `12D3KooAuthor-${cid}`,
+            author: { address: `12D3KooAuthor-${cid}` },
+            parentCid,
+            postCid,
+            communityPublicKey: community.signer.address,
+            content: `content-${cid}`,
+            title: commentDepth === 0 ? `title-${cid}` : null,
+            timestamp,
+            depth: commentDepth,
+            signature: { type: "ed25519", signature: "sig", publicKey: "pk", signedPropertyNames: [] },
+            protocolVersion: env.PROTOCOL_VERSION,
+            pendingApproval: null,
+            insertedAt: timestamp
+        }) as unknown as CommentsTableRowInsert;
+
+    const cids = await Promise.all(
+        Array.from({ length: depth + 1 }, (_, index) => calculateIpfsCidV0Lib(`chain-${index}-${randomUUID()}`))
+    );
+    const postCid = cids[0];
+
+    community._dbHandler.insertComments(
+        cids.map((cid, index) => buildRow(cid, index, index === 0 ? null : cids[index - 1], postCid, seededAt + index))
+    );
+
+    return cids;
+}

--- a/test/node/community/commentsToUpdate.db.community.test.ts
+++ b/test/node/community/commentsToUpdate.db.community.test.ts
@@ -1353,4 +1353,49 @@ describeSkipIfRpc("db-handler.queryCommentsToBeUpdated", function () {
         expect(cids).to.include(reply.cid, "reply should be enqueued because its replies JSON is stale");
         expect(cids).to.include(post.cid, "post should also be enqueued when descendant replies JSON becomes stale");
     });
+
+    // Regression test for issue #230. Every CommentUpdate row written by one update batch carries the
+    // same insertedAt (batchStartTimestamp, captured before the flag query — see issue #209/#211),
+    // while each row's updatedAt is stamped when that row is actually calculated.
+    // updateCommentsThatNeedToBeUpdated walks a post tree deepest-depth-first, so a child is always
+    // calculated before its parent and the child's updatedAt lands later than the batch's start.
+    // stale_replies compared the child's updatedAt against the parent's insertedAt, so any batch
+    // spanning >= 1 second re-flagged the parent on the next loop, which produced another >= 1 second
+    // batch, and so on. Observed in production as the same ~291 comments being re-signed and
+    // republished every ~2 minutes with no new votes, edits, moderations or replies.
+    it("does not requeue a parent whose replies page was regenerated in the same batch as its child (issue #230)", async () => {
+        const batchStart = currentTimestamp();
+        // Comment rows must predate the batch, otherwise direct_updates flags the parent instead
+        const seededAt = batchStart - 3600;
+
+        const post = insertComment({ timestamp: seededAt, overrides: { insertedAt: seededAt } });
+        const reply = insertComment({
+            depth: 1,
+            parentCid: post.cid,
+            postCid: post.cid,
+            timestamp: seededAt + 1,
+            overrides: { insertedAt: seededAt + 1 }
+        });
+
+        // The batch calculates the deepest depth first: the reply's update is stamped 2s into the
+        // batch and the post's 5s in, but both rows carry the batch's start timestamp as insertedAt.
+        insertCommentUpdate(reply, {
+            publishedToPostUpdatesMFS: 1,
+            updatedAt: batchStart + 2,
+            insertedAt: batchStart
+        });
+        insertCommentUpdate(post, {
+            publishedToPostUpdatesMFS: 1,
+            updatedAt: batchStart + 5,
+            insertedAt: batchStart,
+            childCount: 1,
+            replyCount: 1,
+            lastChildCid: reply.cid,
+            // The post's page was generated after the reply's row was written, so it already embeds
+            // the reply's latest updatedAt — nothing about it is stale.
+            replies: JSON.stringify({ best: { commentCids: [reply.cid] } })
+        });
+
+        expect(commentCidsNeedingUpdate()).to.be.empty;
+    });
 });


### PR DESCRIPTION
Fixes #230.

## The bug

`queryCommentsToBeUpdated()`'s `stale_replies` CTE compared `cu_child.updatedAt` against `cu_parent.insertedAt`. Those two columns come from different clocks:

- `insertedAt` is `batchStartTimestamp`, captured **before the batch's flag query runs** and shared by every row that batch writes (#209 / #211).
- `updatedAt` is stamped when that row is **actually calculated**.

`updateCommentsThatNeedToBeUpdated()` walks a post tree deepest-depth-first, so a child is always calculated before its parent and its `updatedAt` lands after the batch's start second.

Any batch spanning >= 1 second therefore re-flagged every parent whose preloaded `best` replies page held a child updated in that same batch. Re-flagging produced another >= 1 second batch, which re-flagged again: the update loop never converged.

## Production symptom

A node running `0.0.71` was re-updating **exactly 291 comments every ~2 minutes for 3+ hours straight** on `pleblore.bso`, with **zero** new votes, edits, moderations or replies in that window. Running the CTEs individually against a copy of that DB:

```
direct_updates            0     <- nothing real to update
stale_replies           134     <- the trigger
base_updates            134
distinct_authors_flagged 94     <- authors_to_update amplifies 2-4x
after_author_expansion  291     <- matches the log line exactly
```

146 of the 151 stale parent/child pairs in another community shared an **identical** `insertedAt` (same batch), with the child's `updatedAt` 2-49 seconds later.

Across all communities on that node: roughly **226,000 CommentUpdate calculations in 3 hours**, nearly all redundant. Each one costs a page generation, an ed25519 signature, a full `verifyCommentUpdate` re-verification, an MFS write plus flush, and a new community IPNS record, and it rotates every post's `updateCid` every ~2 minutes so a CID never survives long enough to be announced to the HTTP routers.

The one community that had converged was the only one whose last batch completed inside a single second (`MAX(updatedAt) - insertedAt = 0`), which confirms the >= 1 second batch span is the trigger.

## The fix

Compare against `cu_parent.updatedAt` — when the parent's replies page was actually generated, which is the point a child's data could have gone stale relative to. Because the batch writes each depth level before starting the level above it, a parent's page already reflects every child recalculated in the same batch.

Against copies of the live DBs:

| community | before | after |
|---|---|---|
| pleblore.bso | 134 | 0 |
| business-and-finance.bso | 138 | 0 |
| weaponized-autism.bso | 839 | 8 |
| 12D3KooWJ7mv... | 39 | 4 |

The residual few are children genuinely updated in a *later* batch than their parent, which is what the clause exists for.

`insertedAt` stays the batch-start stamp for the `direct_updates` vote / edit / moderation / child comparisons, so #211 is not reverted and its regression tests still pass.

### Regression window

`stale_replies` dates to Oct 2025 and was harmless then: `insertedAt` was stamped per-row at build time, after page generation and signing, and parents build after their children so the comparison was never true. `49ddc9015` (#211) moved the stamp to batch start and silently inverted that ordering.

### Known residual edge case

`calculateNewCommentUpdate` bumps `updatedAt` to `stored.updatedAt + 1` when a comment is updated twice within the same second, so a child can land 1 second ahead of its parent and cost one extra loop. That is self-limiting rather than permanent, so it is left alone here.

## Tests

Two regression tests, **both verified red against unmodified `src/`**:

1. `commentsToUpdate.db.community.test.ts` — a db-level case: a parent and child written by one batch (shared `insertedAt`, child's `updatedAt` stamped 2s in, parent's 5s in) must not requeue the parent. Fails on `master` with `expected [ 'QmTest0000' ] to be empty`.

2. `commentsToUpdate.batch-span-loop.community.test.ts` (new) — an end-to-end case driving a real `updateCommentsThatNeedToBeUpdated()` batch over a reply chain with page generation slowed past the one-second boundary, then asserting the queue drains. Fails on `master` with 3 comments requeued despite nothing having changed. It asserts the precondition (at least one row stamped in a later second than the batch start) so it cannot pass vacuously, and marks the rows as published to MFS so it cannot pass for the wrong reason.

A chain rather than a flat post-with-replies is what makes the second test reproduce: `updatedAt` is stamped when a comment's calculation *starts*, so only accumulated work from deeper levels can push a child's `updatedAt` past the batch's start second.

## Test runs

All against `--pkc-config "local-kubo-rpc"`:

- `commentsToUpdate.{db,batch-span-loop,insertedat-race}` — 28 passed (the #209 race suite is the one most at risk from this change)
- `page-generation/`, `modqueue/`, `commentUpdate.fields.db`, `authorPublicationCounts.db` — 746 passed
- `local-community/`, `postUpdates`, `updateCid`, `unique.publishing`, `purge-postupdates-sync-race`, `republishing` — 139 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed comment update tracking to prevent already-processed replies from being repeatedly flagged as stale.
  * Ensured parent comments are not requeued when related replies are regenerated within the same update batch.
  * Improved consistency when comment updates span multiple seconds.

* **Tests**
  * Added regression coverage for multi-level reply chains and batch processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->