### PR TITLE
feat(community): settings.disablePubsubChallengeExchange, no pubsubTopic fallback

### DIFF
--- a/test/node-and-browser/community/challenge-exchange-disabled.test.ts
+++ b/test/node-and-browser/community/challenge-exchange-disabled.test.ts
@@ -1,0 +1,46 @@
+// Test foundations for settings.disablePubsubChallengeExchange (issue #229,
+// docs/protocol/author-communities.md read-only mode section).
+// Design-only scaffolding: every case is it.todo until the feature is implemented.
+//
+// Node-side behavior lives in test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts.
+// This file covers the CLIENT side, which is why it runs in the browser too: a reader that loads a
+// record without pubsubTopic must fail fast instead of timing out, so a UI can disable the reply
+// affordance up front. Kind-blind: applies to normal communities and author-communities alike.
+import { describe, it } from "vitest";
+
+describe("reading a record with no pubsubTopic", () => {
+    it.todo("parses the record fine (pubsubTopic is optional)");
+    it.todo("treats absence of pubsubTopic as challenge exchange disabled, not as an address fallback");
+    it.todo("exposes the disabled state on the loaded instance so a client can branch before publishing");
+});
+
+describe("publishing to a community with the exchange disabled", () => {
+    it.todo("publish() fails fast with ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED");
+    it.todo("the error surfaces before any pubsub subscription is attempted");
+    it.todo("the publisher never falls back to the community address as a challenge-exchange topic");
+    it.todo("the same fast-fail applies to Vote, CommentEdit, CommentModeration, and CommunityEdit");
+    it.todo("the error is non-retriable (distinct from an unreachable-community timeout)");
+});
+
+// verifyChallengeMessage / verifyChallengeVerification currently compare the message signer's address
+// against the pubsubTopic string, which only works because the topic is backfilled to the signer
+// address. Removing the fallback exposes the conflation: the check means "signed by the community",
+// not "equal to the topic".
+describe("challenge message verification is decoupled from the pubsub topic", () => {
+    it.todo("verifies a challenge message against the community's signing address, not its pubsubTopic");
+    it.todo("verifies a challenge verification the same way");
+    it.todo("a community with a custom pubsubTopic still has its challenge messages verify");
+    it.todo("rejects a challenge message signed by any other key with ERR_CHALLENGE_MSG_SIGNER_IS_NOT_COMMUNITY");
+});
+
+describe("a read-only author-community (feed-only profile)", () => {
+    it.todo("loads and renders its feed with no pubsubTopic, challenges, or encryption present");
+    it.todo("a reply attempt fails fast rather than timing out");
+    it.todo("cross-posts still flow into the feed (they never involve the challenge topic)");
+    it.todo("toggling the exchange back on makes the trio reappear on the next mint");
+});
+
+describe("backward compatibility", () => {
+    it.todo("an old record carrying an explicit pubsubTopic keeps publishing normally (no flag day)");
+    it.todo("a record with pubsubTopic present but encryption absent is rejected rather than half-published");
+});

--- a/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
+++ b/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
@@ -1,0 +1,46 @@
+// Test foundations for settings.disablePubsubChallengeExchange (issue #229,
+// docs/protocol/author-communities.md read-only mode section).
+// Design-only scaffolding: every case is it.todo until the feature is implemented.
+// Kind-blind LocalCommunity feature; author-communities (issue #31) inherit it for feed-only profiles.
+//
+// Client-side behavior lives in test/node-and-browser/community/challenge-exchange-disabled.test.ts.
+import { describe, it } from "vitest";
+
+describe("settings.disablePubsubChallengeExchange = true", () => {
+    it.todo("publishes a record that omits pubsubTopic");
+    it.todo("does not subscribe to the challenge/publication pubsub topic");
+    it.todo("stays subscribed to the IPNS-over-pubsub record topic (replication unaffected)");
+    it.todo("preserves a custom settings pubsubTopic string across a disable/enable cycle");
+    it.todo("never publishes the setting itself (settings stay private, stripped from the record)");
+});
+
+describe("settings.disablePubsubChallengeExchange unset or false", () => {
+    it.todo("backfills pubsubTopic to the signer address at init (current behavior unchanged)");
+    it.todo("publishes the record with an explicit pubsubTopic");
+});
+
+describe("no fallback to address as pubsub topic", () => {
+    it.todo("publish() against a loaded community without pubsubTopic fails fast with ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED");
+    it.todo("the publisher never attempts the community address as a challenge-exchange topic");
+    it.todo("the fast-fail error surfaces before any pubsub subscription is attempted");
+    it.todo("stopping a disabled community does not throw on the challenge-topic unsubscribe (lifecycle.ts)");
+});
+
+// The owner must keep publishing to their own community even with the network path removed.
+// publish() takes the local shortcut when the community is in pkc._startedCommunities, and the RPC
+// server executes publish() in the process where the community runs, so both hit the same shortcut.
+describe("owner publishing while the exchange is disabled", () => {
+    it.todo("same-process publish succeeds via the local shortcut (_publishWithLocalCommunity)");
+    it.todo("publish through the RPC server succeeds (server-side local shortcut)");
+    it.todo("the local shortcut still evaluates configured challenges (network path removed, pipeline kept)");
+    it.todo("_validateCommunityFields does not require a pubsubTopic when publishing to a started community");
+    it.todo("the challenge and challengeverification the local community emits still verify with no pubsubTopic present");
+    it.todo("a Vote, CommentEdit and CommentModeration all publish locally with the exchange disabled");
+    it.todo("a remote publisher still fails fast while the owner's local publish succeeds against the same community");
+});
+
+describe("toggling at runtime", () => {
+    it.todo("enabling the setting unsubscribes from the challenge topic on the next sync-loop iteration without restart");
+    it.todo("disabling the setting resubscribes and republishes the record with pubsubTopic present");
+    it.todo("the setting round-trips through the settings JSON column after a restart");
+});


### PR DESCRIPTION
Implements #229.

**This PR currently contains test stubs only.** No `src/` changes yet. The stubs are the
implementation checklist in executable form, and the description below is the brief.

## What

Add a private boolean `community.settings.disablePubsubChallengeExchange` that turns a community
read-only over the network, and make the **absence of `pubsubTopic` mean "challenge exchange
disabled"** by deleting the `pubsubTopic || address` fallbacks on both sides.

Kind-blind `LocalCommunity` feature. Author-communities (#31) inherit it for feed-only profiles, and
#234 depends on the new wire rule (its create response returns `{ Mn, pubsubTopic, encryption }` or
`{ Mn }` alone, where the bare form means read-only). This is the first of the PRs leading to #31, and
it can land entirely on its own.

## Behavior

- Unset or `false`: unchanged. `pubsubTopic` is backfilled to the signer address at init.
- `true`: the published record omits `pubsubTopic`, the node does not subscribe to the challenge
  topic, and no challenge exchange happens over the network. The setting itself is never published,
  like the rest of `settings`.

A boolean rather than encoding the state in `settings.pubsubTopic` (e.g. `null`): self-describing,
preserves a custom topic string across disable/enable cycles, and avoids a permanent tri-state falsy
hazard at the backfill seam.

## Call sites to remove

More spread out than the issue's checklist suggests.

**Client side.** `_communityPubsubTopicWithFallback()` is defined at
`src/publications/publication.ts:712` and called from **14 sites**: 316, 385, 397, 609, 634, 655, 787,
957, 1084, 1090, 1131, 1256, 1261, 1274. Its generic
`throw Error("Failed to load the pubsub topic of community")` becomes the new dedicated error.

Four of those are reachable when publishing to a **started local community**, so they cannot simply
fail fast: 316 and 397 (challenge and challenge-verification signature checks, reached through the
listeners `_publishWithLocalCommunity` attaches), 655 (`_validateCommunityFields`, which always runs)
and 787 (the cleanup unsubscribe, whose `else if (this._community)` branch covers the local path too).
The remaining ten are network-only. The challenge-answer path is already branched on
`_publishingToLocalCommunity` at line 595, so it needs nothing.

**Node side.** `pubsubTopicWithfallback()` at
`src/runtime/node/community/local-community/comment-updates.ts:22`, called from
`challenges.ts` (7 sites: 111, 113, 151, 156, 236, 338, 348), `pubsub.ts` (12, 28) and the
unsubscribe in `lifecycle.ts:370`. Most of the `challenges.ts` sites are unreachable when the
exchange is disabled, since nothing subscribes and no challenge message is ever produced, so they
want a single non-null assertion at one chokepoint rather than seven guards. The lifecycle unsubscribe
is the one site that genuinely has to tolerate `undefined`.

## The owner must keep publishing

The point of read-only mode is that *others* cannot publish, not that the owner cannot. Two paths
must keep working with the exchange disabled:

- **Same process**: `publish()` takes the local shortcut when the community is found in
  `pkc._startedCommunities` (`src/publications/publication.ts:1232`), which calls
  `_publishWithLocalCommunity` and never touches pubsub.
- **Through the RPC server**: the client returns at `if (this._pkc._pkcRpcClient) return this._publishWithRpc()`,
  and the server then executes `publish()` in the process where the community runs, hitting the same
  shortcut.

Two things block that today and must be handled in this PR:

1. `_validateCommunityFields()` (`src/publications/publication.ts:652`) requires a pubsub topic
   unconditionally, including on the local path. It must not demand one when publishing to a started
   community.
2. `_publishWithLocalCommunity` routes the community's `challenge` and `challengeverification` events
   back through `_handleIncomingChallengePubsubMessage` / `_handleIncomingChallengeVerificationPubsubMessage`,
   which verify with `pubsubTopic: this._communityPubsubTopicWithFallback()`. See below.

## Latent coupling this exposes

`verifyChallengeMessage` and `verifyChallengeVerification` (`src/signer/signatures.ts:823` and `:862`)
compare the message signer's address against the **`pubsubTopic` string**:

```ts
const msgSignerAddress = await getPKCAddressFromPublicKeyBuffer(challenge.signature.publicKey);
if (msgSignerAddress !== pubsubTopic) return { valid: false, reason: messages.ERR_CHALLENGE_MSG_SIGNER_IS_NOT_COMMUNITY };
```

That only works because the topic is backfilled to the signer address. The check means "signed by the
community", not "equal to the topic". Consequences:

- With the fallback removed, the local shortcut breaks for a disabled community, since there is no
  topic string to compare against.
- A community with a **custom** `pubsubTopic` already fails this check today, independent of this
  feature.
- It matters again for delegated communities (#233), where the record identity is the anchor `An`
  while challenge messages are signed by the minter `Ms`. The correct expectation is the record's
  signer, not the community address and not the topic.

Suggested fix in this PR: change the parameter from `pubsubTopic` to the expected community signing
address and pass that at every call site. Rename rather than reuse, so no call site keeps passing a
topic by accident.

## Backward compatibility

No flag day. Every record pkc-js has ever published carries an explicit `pubsubTopic` (the db-state
backfill guarantees it), so no live record relies on the absent-means-address fallback. Old clients
reading a new read-only record parse it fine (the field is already optional) and degrade to a timeout,
the same as for an unreachable community. `CommunityIpfs` keeps `encryption` and `challenges` required
for now; a read-only community publishes them as unused fields until the planned envelope
`protocolVersion` bump relaxes them to optional. The `AuthorCommunityIpfs` all-or-none refine
(`pubsubTopic` absent implies `encryption` and `challenges` absent) belongs to #31, not here.

## Interactions

- `ipnsPubsubTopic` is derived separately and is unaffected: record distribution, seeders and reader
  updates keep working.
- The local publish shortcut still runs the full challenge pipeline in process, so disabling the
  network path does not bypass challenge evaluation for local publishers.
- Toggling takes effect on the next sync-loop iteration (subscribe/unsubscribe), no restart required.

## Checklist

- [ ] Add `disablePubsubChallengeExchange` to the community settings schema (private, stripped from
      the published record like the rest of `settings`).
- [ ] Branch the `pubsubTopic` backfill in `db-state.ts:243` on the setting; leave `pubsubTopic`
      undefined when disabled.
- [ ] Skip the challenge-topic subscription when disabled; react to toggles in the sync loop.
- [ ] Remove both fallbacks and update all call sites listed above.
- [ ] Decouple challenge message verification from `pubsubTopic` (`src/signer/signatures.ts`).
- [ ] Keep the owner's local and RPC publish paths working with the exchange disabled.
- [ ] Add `ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED` (name TBD) and fail fast in `publish()` when the
      loaded community record has no `pubsubTopic` and the community is not started locally.
- [ ] Fill in the `it.todo` stubs in this PR.
- [ ] Update `README.md` if it documents the community settings schema.

## Tests

Two stub files, every case `it.todo`:

- `test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts` covers the node
  side: record shape, subscription behavior, the owner's local and RPC publish paths, runtime
  toggling.
- `test/node-and-browser/community/challenge-exchange-disabled.test.ts` covers the client side, which
  is why it runs in the browser too: fail-fast on publish, the verification decoupling, and read-only
  author-community behavior.

Note: #227 (open, design docs for #31) adds design-stage stubs at these same two paths. The versions
here are a superset, so whichever lands second should take this branch's version.
