### PR TITLE
feat(community): settings.disablePubsubChallengeExchange, no pubsubTopic fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1263,7 +1263,7 @@ An object which may have the following keys:
 | ---- | ---- | ----------- |
 | fetchThumbnailUrls | `boolean` or `undefined` | Fetch the thumbnail URLs of comments `comment.link` property, could reveal the IP address of the community node |
 | fetchThumbnailUrlsProxyUrl | `string` or `undefined` | The HTTP proxy URL used to fetch thumbnail URLs |
-| disablePubsubChallengeExchange | `boolean` or `undefined` | Make the community read-only over the network. The node stops subscribing to the challenge/publication pubsub topic and the published record omits `pubsubTopic`, so clients know not to attempt a challenge exchange and fail fast with `ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED`. The owner can still publish through the local shortcut (same process or through the RPC server running the community) |
+| disablePubsubChallengeExchange | `boolean` or `undefined` | Make the community read-only over the network. The node stops subscribing to the challenge/publication pubsub topic and the published record omits `pubsubTopic`, so clients know not to attempt a challenge exchange and fail fast with `ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED`. The owner can still publish through the local shortcut (same process or through the RPC server running the community). The configured `community.pubsubTopic` is kept while the setting is on, including across a restart, and is published again as-is when the setting is turned off |
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -1263,6 +1263,7 @@ An object which may have the following keys:
 | ---- | ---- | ----------- |
 | fetchThumbnailUrls | `boolean` or `undefined` | Fetch the thumbnail URLs of comments `comment.link` property, could reveal the IP address of the community node |
 | fetchThumbnailUrlsProxyUrl | `string` or `undefined` | The HTTP proxy URL used to fetch thumbnail URLs |
+| disablePubsubChallengeExchange | `boolean` or `undefined` | Make the community read-only over the network. The node stops subscribing to the challenge/publication pubsub topic and the published record omits `pubsubTopic`, so clients know not to attempt a challenge exchange and fail fast with `ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED`. The owner can still publish through the local shortcut (same process or through the RPC server running the community) |
 
 #### Example
 

--- a/src/clients/base-client-manager.ts
+++ b/src/clients/base-client-manager.ts
@@ -153,11 +153,19 @@ export class BaseClientsManager {
     }
 
     getDefaultKuboPubsubClient() {
-        const defaultKuboPubsubClient = keys(this._pkc.clients.pubsubKuboRpcClients)[0];
-        if (defaultKuboPubsubClient) return this._pkc.clients.pubsubKuboRpcClients[defaultKuboPubsubClient];
+        const defaultKuboPubsubClient = this.getDefaultKuboPubsubClientIfAny();
+        if (defaultKuboPubsubClient) return defaultKuboPubsubClient;
         throw new PKCError("ERR_NO_DEFAULT_KUBO_RPC_PUBSUB_PROVIDER", {
             pubsubKuboRpcClients: this._pkc.clients.pubsubKuboRpcClients
         });
+    }
+
+    // A node that only runs read-only communities (settings.disablePubsubChallengeExchange, issue #229)
+    // may be configured with no pubsub provider at all. Use this wherever the client is only needed to
+    // label a diagnostic state, so its absence is not turned into a failure.
+    getDefaultKuboPubsubClientIfAny() {
+        const defaultKuboPubsubClient = keys(this._pkc.clients.pubsubKuboRpcClients)[0];
+        return defaultKuboPubsubClient ? this._pkc.clients.pubsubKuboRpcClients[defaultKuboPubsubClient] : undefined;
     }
 
     getIpfsClientWithKuboRpcClientFunctions() {

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -523,7 +523,10 @@ export class CommunityClientsManager extends PKCClientsManager {
                     pubsubTopic: subRes.community.pubsubTopic,
                     address: anchorIdentityAddress,
                     publicKey: ipnsName,
-                    name: subRes.community.name
+                    name: subRes.community.name,
+                    // The record's own signing key, which is also what signs challenge messages. For a
+                    // delegated community that is the minter, not the anchor above (issue #229).
+                    signerAddress: getPKCAddressFromPublicKeySync(subRes.community.signature.publicKey)
                 });
             }
             return subRes;

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -523,10 +523,7 @@ export class CommunityClientsManager extends PKCClientsManager {
                     pubsubTopic: subRes.community.pubsubTopic,
                     address: anchorIdentityAddress,
                     publicKey: ipnsName,
-                    name: subRes.community.name,
-                    // The record's own signing key, which is also what signs challenge messages. For a
-                    // delegated community that is the minter, not the anchor above (issue #229).
-                    signerAddress: getPKCAddressFromPublicKeySync(subRes.community.signature.publicKey)
+                    name: subRes.community.name
                 });
             }
             return subRes;

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -109,6 +109,13 @@ export class CommunityClientsManager extends PKCClientsManager {
         super.updateKuboRpcPubsubState(newState, pubsubProvider);
     }
 
+    // A read-only community never publishes over pubsub, so its node may have no pubsub provider to
+    // report a state for (issue #229). There is nothing to label in that case, not a failure.
+    updateKuboRpcPubsubStateIfProviderExists(newState: CommunityKuboPubsubClient["state"]) {
+        const pubsubClient = this.getDefaultKuboPubsubClientIfAny();
+        if (pubsubClient) this.updateKuboRpcPubsubState(newState, pubsubClient.url);
+    }
+
     override updateGatewayState(newState: CommunityIpfsGatewayClient["state"], gateway: string): void {
         super.updateGatewayState(newState, gateway);
     }

--- a/src/community/remote-community.ts
+++ b/src/community/remote-community.ts
@@ -284,6 +284,13 @@ export class RemoteCommunity extends TypedEmitter<CommunityEvents> implements Om
         const log = Logger("pkc-js:remote-community:initCommunityIpfsPropsNoMerge");
         this.raw.communityIpfs = newProps;
         this.initRemoteCommunityPropsNoMerge(newProps);
+        // pubsubTopicRoutingCid is derived state of the PUBLISHED topic, so a full record is the
+        // authority for it and it is recomputed on every one. Absence of pubsubTopic means the
+        // challenge exchange is disabled (issue #229), so no routing CID may survive the record that
+        // dropped the topic, and a changed topic has to move the CID with it. The record is authoritative
+        // even against the instance: a LocalCommunity keeps community.pubsubTopic configured while the
+        // setting is on, precisely so it can be republished later, but it is not being served now.
+        this.pubsubTopicRoutingCid = newProps.pubsubTopic ? pubsubTopicToDhtKey(newProps.pubsubTopic) : undefined;
         const unknownProps = difference(keys(this.raw.communityIpfs), keys(CommunityIpfsSchema.shape));
         if (unknownProps.length > 0) {
             log(`Found unknown props on community (${this.address}) ipfs record`, unknownProps);
@@ -317,15 +324,11 @@ export class RemoteCommunity extends TypedEmitter<CommunityEvents> implements Om
             this.ipnsPubsubTopic = ipnsNameToIpnsOverPubsubTopic(this.ipnsName);
             this.ipnsPubsubTopicRoutingCid = pubsubTopicToDhtKey(this.ipnsPubsubTopic);
         }
-        if (!this.pubsubTopicRoutingCid) {
-            if ("pubsubTopicRoutingCid" in newProps) this.pubsubTopicRoutingCid = newProps.pubsubTopicRoutingCid;
-            else if (this.raw.communityIpfs) {
-                // No fallback to the address anymore: a record without pubsubTopic has its challenge
-                // exchange disabled (issue #229), so there are no challenge-topic peers to look up
-                const challengeTopic = newProps.pubsubTopic || this.pubsubTopic;
-                if (challengeTopic) this.pubsubTopicRoutingCid = pubsubTopicToDhtKey(challengeTopic);
-            }
-        }
+        // A clone of an already-resolved instance carries the field explicitly; otherwise it is derived
+        // from the published record in initCommunityIpfsPropsNoMerge, which is the only authority for
+        // it. There is no fallback to the address: a record without pubsubTopic has its challenge
+        // exchange disabled (issue #229), so there are no challenge-topic peers to look up.
+        if (!this.pubsubTopicRoutingCid && "pubsubTopicRoutingCid" in newProps) this.pubsubTopicRoutingCid = newProps.pubsubTopicRoutingCid;
     }
 
     initRemoteCommunityPropsNoMerge(newProps: CommunityJson | CreateRemoteCommunityOptions | CommunityIpfsType) {

--- a/src/community/remote-community.ts
+++ b/src/community/remote-community.ts
@@ -448,6 +448,11 @@ export class RemoteCommunity extends TypedEmitter<CommunityEvents> implements Om
         // Clear all display fields via initRemoteCommunityPropsNoMerge with empty props.
         // Address immutability in initRemoteCommunityPropsNoMerge ensures address won't change.
         this.initRemoteCommunityPropsNoMerge({} as CreateRemoteCommunityOptions);
+        // initRemoteCommunityPropsNoMerge clears pubsubTopic, but the routing CID is only re-derived from
+        // a full record in initCommunityIpfsPropsNoMerge, which this path does not reach. Clear it here so
+        // the invariant holds on every path: no routing CID outlives the topic it was derived from, or a
+        // reader keeps looking up peers of the old key's challenge topic until the next record lands.
+        this.pubsubTopicRoutingCid = undefined;
 
         // Update to new key and IPNS routing props
         this.publicKey = newPublicKey;

--- a/src/community/remote-community.ts
+++ b/src/community/remote-community.ts
@@ -319,13 +319,12 @@ export class RemoteCommunity extends TypedEmitter<CommunityEvents> implements Om
         }
         if (!this.pubsubTopicRoutingCid) {
             if ("pubsubTopicRoutingCid" in newProps) this.pubsubTopicRoutingCid = newProps.pubsubTopicRoutingCid;
-            else if (this.raw.communityIpfs)
-                this.pubsubTopicRoutingCid = pubsubTopicToDhtKey(
-                    newProps.pubsubTopic ||
-                        this.pubsubTopic ||
-                        ("address" in newProps ? (newProps.address as string) : undefined) ||
-                        this.address
-                );
+            else if (this.raw.communityIpfs) {
+                // No fallback to the address anymore: a record without pubsubTopic has its challenge
+                // exchange disabled (issue #229), so there are no challenge-topic peers to look up
+                const challengeTopic = newProps.pubsubTopic || this.pubsubTopic;
+                if (challengeTopic) this.pubsubTopicRoutingCid = pubsubTopicToDhtKey(challengeTopic);
+            }
         }
     }
 

--- a/src/community/schema.ts
+++ b/src/community/schema.ts
@@ -273,7 +273,10 @@ export const CommunitySettingsSchema = z
         fetchThumbnailUrlsProxyUrl: z.string().optional(), // TODO should we validate this url?
         challenges: CommunityChallengeSettingSchema.array().optional(), // If empty array it will remove all challenges
         maxPendingApprovalCount: z.number().int().nonnegative().optional(),
-        purgeDisapprovedCommentsOlderThan: z.number().int().nonnegative().optional()
+        purgeDisapprovedCommentsOlderThan: z.number().int().nonnegative().optional(),
+        // Read-only community: don't run the challenge/publication pubsub topic and omit pubsubTopic
+        // from the published record, so readers know not to attempt a challenge exchange (issue #229)
+        disablePubsubChallengeExchange: z.boolean().optional()
     })
     .strict();
 

--- a/src/community/types.ts
+++ b/src/community/types.ts
@@ -180,6 +180,12 @@ export interface InternalCommunityRecordAfterFirstUpdateType extends InternalCom
     updateCid: string;
     _cidsToUnPin: string[]; // cids that we need to unpin from kubo node
     _mfsPathsToRemove: string[]; // mfs paths that we need to rm from kubo node
+    // The pubsubTopic the owner configured, which is NOT always the one in the record above: a
+    // community with settings.disablePubsubChallengeExchange publishes no pubsubTopic at all (issue
+    // #229), and without this the configured topic would be lost the moment the instance reloaded its
+    // internal state from a topic-less record. Kept under a private key so it never reaches the
+    // CommunityIpfs half of this record, where an unsigned field would corrupt the record readers see.
+    _configuredPubsubTopic?: string;
 }
 
 // RPC server transmitting Internal Community records to clients

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,7 @@ export enum messages {
     ERR_COMMUNITY_CAN_EITHER_RUN_OR_UPDATE = "Community can either sync through .start() or update, but not both",
     ERR_PUBLICATION_MISSING_FIELD = "Publication is missing field(s)",
     ERR_COMMUNITY_MISSING_FIELD = "Community is missing field needed for publishing",
+    ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED = "The community record has no pubsubTopic, which means its challenge exchange is disabled and it does not accept publications over pubsub",
     ERR_COMMUNITY_OPTIONS_MISSING_ADDRESS = "The options sent to pkc.createCommunity() is missing address or signer",
     ERR_INVALID_COMMUNITY_ADDRESS_SCHEMA = "Community address is incorrect. Address should be either a domain or IPNS",
     ERR_CID_IS_INVALID = "CID is invalid",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -160,6 +160,7 @@ export enum messages {
     ERR_AUTHOR_NOT_MATCHING_SIGNATURE = "comment.author.address doesn't match comment.signature.publicKey",
     ERR_AUTHOR_NAME_MUST_BE_A_DOMAIN = "author.name must be a domain name (e.g. 'example.bso')",
     ERR_COMMUNITY_IPNS_NAME_DOES_NOT_MATCH_SIGNATURE_PUBLIC_KEY = "The IPNS name of community doesn't match community.signature.publicKey",
+    ERR_COMMUNITY_ENCRYPTION_PUBLIC_KEY_DOES_NOT_MATCH_SIGNATURE_PUBLIC_KEY = "community.encryption.publicKey doesn't match community.signature.publicKey. The key that runs the challenge exchange must be the key that signed the record",
     ERR_COMMENT_SHOULD_BE_THE_LATEST_EDIT = "comment.content is not set to the latest comment.authorEdit.content",
     ERR_COMMENT_UPDATE_IS_NOT_SIGNED_BY_COMMUNITY = "Comment update is not signed by the community",
     ERR_AUTHOR_EDIT_IS_NOT_SIGNED_BY_AUTHOR = "Author edit is not signed by original author of comment",

--- a/src/publications/publication-client-manager.ts
+++ b/src/publications/publication-client-manager.ts
@@ -15,7 +15,6 @@ import { CommentIpfsGatewayClient, CommentKuboRpcClient } from "./comment/commen
 import type { CommunityEvents, CommunityIpfsType } from "../community/types.js";
 import { waitForUpdateInCommunityInstanceWithErrorAndTimeout } from "../util.js";
 import { findStartedCommunity, findUpdatingCommunity, untrackUpdatingCommunity } from "../pkc/tracked-instance-registry-util.js";
-import { getPKCAddressFromPublicKeySync } from "../signer/util.js";
 
 export class PublicationClientsManager extends PKCClientsManager {
     override clients!: {
@@ -369,8 +368,7 @@ export class PublicationClientsManager extends PKCClientsManager {
             publicKey: updatingCommunityInstance.community.publicKey!,
             name: updatingCommunityInstance.community.name,
             encryption: communityIpfs.encryption,
-            pubsubTopic: communityIpfs.pubsubTopic,
-            signerAddress: getPKCAddressFromPublicKeySync(communityIpfs.signature.publicKey)
+            pubsubTopic: communityIpfs.pubsubTopic
         };
     }
 }

--- a/src/publications/publication-client-manager.ts
+++ b/src/publications/publication-client-manager.ts
@@ -15,6 +15,7 @@ import { CommentIpfsGatewayClient, CommentKuboRpcClient } from "./comment/commen
 import type { CommunityEvents, CommunityIpfsType } from "../community/types.js";
 import { waitForUpdateInCommunityInstanceWithErrorAndTimeout } from "../util.js";
 import { findStartedCommunity, findUpdatingCommunity, untrackUpdatingCommunity } from "../pkc/tracked-instance-registry-util.js";
+import { getPKCAddressFromPublicKeySync } from "../signer/util.js";
 
 export class PublicationClientsManager extends PKCClientsManager {
     override clients!: {
@@ -368,7 +369,8 @@ export class PublicationClientsManager extends PKCClientsManager {
             publicKey: updatingCommunityInstance.community.publicKey!,
             name: updatingCommunityInstance.community.name,
             encryption: communityIpfs.encryption,
-            pubsubTopic: communityIpfs.pubsubTopic
+            pubsubTopic: communityIpfs.pubsubTopic,
+            signerAddress: getPKCAddressFromPublicKeySync(communityIpfs.signature.publicKey)
         };
     }
 }

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -1247,7 +1247,6 @@ class Publication extends TypedEmitter<PublicationEvents> {
 
         const options = { acceptedChallengeTypes: [] };
 
-        const providers = this._getPubsubProviders();
         const startedCommunity = findStartedCommunity(this._pkc, { publicKey: this.communityPublicKey, name: this.communityName }) as
             | LocalCommunity
             | undefined;
@@ -1276,6 +1275,10 @@ class Publication extends TypedEmitter<PublicationEvents> {
             });
             throw error;
         }
+
+        // Discovered only once the network path is certain: neither the local shortcut above nor the
+        // disabled-exchange fast-fail publishes over pubsub, so neither should demand a provider.
+        const providers = this._getPubsubProviders();
 
         let currentPubsubProviderIndex = 0;
         while (!this._didWeReceiveChallengeOrChallengeVerification() && currentPubsubProviderIndex < providers.length) {

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -42,7 +42,7 @@ import { TypedEmitter } from "tiny-typed-emitter";
 import { Comment } from "./comment/comment.js";
 import { PKCError } from "../pkc-error.js";
 import { getHeliaDebugContext, type HeliaDebugContext } from "../helia/util.js";
-import { getBufferedPKCAddressFromPublicKey } from "../signer/util.js";
+import { getBufferedPKCAddressFromPublicKey, getPKCAddressFromPublicKeySync } from "../signer/util.js";
 import * as cborg from "cborg";
 import { isDeepEqual, keys, omit } from "remeda";
 import type { CommunityIpfsType } from "../community/types.js";
@@ -113,6 +113,10 @@ class Publication extends TypedEmitter<PublicationEvents> {
         name?: string;
         encryption: CommunityIpfsType["encryption"];
         pubsubTopic?: CommunityIpfsType["pubsubTopic"];
+        // Address derived from the community record's signature.publicKey, ie the key that also signs
+        // CHALLENGE/CHALLENGEVERIFICATION messages. Normally identical to pubsubTopic, but a read-only
+        // community has no topic and the identity check still needs this value (issue #229).
+        signerAddress: string;
     } = undefined; // will be used for publishing
     _publishingToLocalCommunity?: LocalCommunity;
 
@@ -313,7 +317,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
         if (Object.values(this._challengeExchanges).some((exchange) => exchange.challenge)) return; // We only process one challenge
         const challengeMsgValidity = await verifyChallengeMessage({
             challenge: msg,
-            pubsubTopic: this._communityPubsubTopicWithFallback(),
+            pubsubTopic: this._communityChallengeMsgSignerAddress(),
             validateTimestampRange: true
         });
         if (!challengeMsgValidity.valid) {
@@ -381,8 +385,9 @@ class Publication extends TypedEmitter<PublicationEvents> {
         this._challengeExchanges[msg.challengeRequestId.toString()].challenge = decryptedChallengeMsg;
 
         this._updatePublishingStateWithEmission("waiting-challenge-answers");
+        const challengeTopic = this._community?.pubsubTopic;
         const subscribedProviders = Object.entries(this._clientsManager.pubsubProviderSubscriptions)
-            .filter(([, pubsubTopics]) => pubsubTopics.includes(this._communityPubsubTopicWithFallback()))
+            .filter(([, pubsubTopics]) => typeof challengeTopic === "string" && pubsubTopics.includes(challengeTopic))
             .map(([provider]) => provider);
 
         subscribedProviders.forEach((provider) => this._updatePubsubState("waiting-challenge-answers", provider));
@@ -394,7 +399,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
         if (this._challengeExchanges[msg.challengeRequestId.toString()].challengeVerification) return;
         const signatureValidation = await verifyChallengeVerification({
             verification: msg,
-            pubsubTopic: this._communityPubsubTopicWithFallback(),
+            pubsubTopic: this._communityChallengeMsgSignerAddress(),
             validateTimestampRange: true
         });
         if (!signatureValidation.valid) {
@@ -606,7 +611,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
         } else {
             try {
                 await this._clientsManager.pubsubPublishOnProvider(
-                    this._communityPubsubTopicWithFallback(),
+                    this._communityChallengeExchangeTopic(),
                     answerMsgToPublish,
                     challengeExchange.providerUrl
                 );
@@ -630,8 +635,9 @@ class Publication extends TypedEmitter<PublicationEvents> {
             timestamp();
 
         this._updatePublishingStateWithEmission("waiting-challenge-verification");
+        const challengeTopic = this._community?.pubsubTopic;
         const providers = Object.entries(this._clientsManager.pubsubProviderSubscriptions)
-            .filter(([, pubsubTopics]) => pubsubTopics.includes(this._communityPubsubTopicWithFallback()))
+            .filter(([, pubsubTopics]) => typeof challengeTopic === "string" && pubsubTopics.includes(challengeTopic))
             .map(([provider]) => provider);
         providers.forEach((provider) => this._updatePubsubState("waiting-challenge-verification", provider));
 
@@ -652,11 +658,6 @@ class Publication extends TypedEmitter<PublicationEvents> {
     private _validateCommunityFields() {
         if (typeof this._community?.encryption?.publicKey !== "string")
             throw new PKCError("ERR_COMMUNITY_MISSING_FIELD", { communityPublicKey: this._community?.encryption?.publicKey });
-        if (typeof this._communityPubsubTopicWithFallback() !== "string")
-            throw new PKCError("ERR_COMMUNITY_MISSING_FIELD", {
-                pubsubTopic: this._community?.pubsubTopic,
-                address: this._community?.address
-            });
     }
 
     _updatePublishingStateNoEmission(newState: Publication["publishingState"]) {
@@ -709,10 +710,25 @@ class Publication extends TypedEmitter<PublicationEvents> {
         this.clients.pkcRpcClients[currentRpcUrl].emit("statechange", newState);
     }
 
-    private _communityPubsubTopicWithFallback(): string {
-        const pubsubTopic = this._community?.pubsubTopic || this._community?.address;
-        if (typeof pubsubTopic !== "string") throw Error("Failed to load the pubsub topic of community");
+    // The topic to run the challenge exchange on. Absence of pubsubTopic on the record means the
+    // community disabled the exchange (issue #229); there is no fallback to the community address.
+    _communityChallengeExchangeTopic(): string {
+        const pubsubTopic = this._community?.pubsubTopic;
+        if (typeof pubsubTopic !== "string")
+            throw new PKCError("ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED", {
+                communityAddress: this._community?.address ?? this.communityAddress,
+                publicationType: this.getType()
+            });
         return pubsubTopic;
+    }
+
+    // Who must have signed an incoming CHALLENGE/CHALLENGEVERIFICATION. Historically the challenge
+    // topic doubled as this address, which is what the verifiers compare against; a read-only
+    // community has no topic but the identity being checked is unchanged (issue #229).
+    private _communityChallengeMsgSignerAddress(): string {
+        const signerAddress = this._community?.pubsubTopic ?? this._community?.signerAddress;
+        if (typeof signerAddress !== "string") throw Error("Failed to load the challenge message signer address of community");
+        return signerAddress;
     }
 
     _getCommunityCache(): NonNullable<Publication["_community"]> | undefined {
@@ -728,7 +744,8 @@ class Publication extends TypedEmitter<PublicationEvents> {
                 publicKey: subInstance.publicKey,
                 name: subInstance.name,
                 encryption: subIpfs.encryption,
-                pubsubTopic: subIpfs.pubsubTopic
+                pubsubTopic: subIpfs.pubsubTopic,
+                signerAddress: getPKCAddressFromPublicKeySync(subIpfs.signature.publicKey)
             };
         return undefined;
     }
@@ -782,9 +799,9 @@ class Publication extends TypedEmitter<PublicationEvents> {
             }
             this._rpcPublishSubscriptionId = undefined;
             this._setRpcClientState("stopped");
-        } else if (this._community) {
+        } else if (typeof this._community?.pubsubTopic === "string") {
             // the client is publishing to pubsub without using PKC RPC
-            await this._clientsManager.pubsubUnsubscribe(this._communityPubsubTopicWithFallback(), this._handleChallengeExchange);
+            await this._clientsManager.pubsubUnsubscribe(this._community.pubsubTopic, this._handleChallengeExchange);
             Object.values(this._challengeExchanges).forEach((exchange) => this._updatePubsubState("stopped", exchange.providerUrl));
         }
     }
@@ -954,7 +971,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
             "Attempting to publish",
             this.getType(),
             "to pubsub topic",
-            this._communityPubsubTopicWithFallback(),
+            this._community?.pubsubTopic,
             "with provider",
             providerUrl,
             "request.encrypted=",
@@ -1081,13 +1098,13 @@ class Publication extends TypedEmitter<PublicationEvents> {
                     this._updatePubsubState("subscribing-pubsub", providerUrl);
                     try {
                         await this._clientsManager.pubsubSubscribeOnProvider(
-                            this._communityPubsubTopicWithFallback(),
+                            this._communityChallengeExchangeTopic(),
                             this._handleChallengeExchange,
                             providerUrl
                         );
                         this._updatePubsubState("publishing-challenge-request", providerUrl);
                         await this._clientsManager.pubsubPublishOnProvider(
-                            this._communityPubsubTopicWithFallback(),
+                            this._communityChallengeExchangeTopic(),
                             challengeRequest,
                             providerUrl
                         );
@@ -1128,7 +1145,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
                     await this._postSucessOrFailurePublishing();
                     const allAttemptsFailedError = new PKCError("ERR_ALL_PUBSUB_PROVIDERS_THROW_ERRORS", {
                         challengeExchanges: this._challengeExchangesFormattedForErrors(),
-                        pubsubTopic: this._communityPubsubTopicWithFallback(),
+                        pubsubTopic: this._community?.pubsubTopic,
                         providerHeliaContexts: this._libp2pJsClientHeliaContexts()
                     });
                     log.error("All attempts to publish", this.getType(), "has failed", allAttemptsFailedError);
@@ -1242,6 +1259,22 @@ class Publication extends TypedEmitter<PublicationEvents> {
             );
         }
 
+        // Only the network path needs a challenge topic. Fail fast before touching pubsub so a client
+        // can disable its reply UI instead of timing out against a topic nobody runs (issue #229).
+        if (typeof this._community?.pubsubTopic !== "string") {
+            await this._postSucessOrFailurePublishing();
+            const error = new PKCError("ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED", {
+                communityAddress: this._community?.address ?? this.communityAddress,
+                publicationType: this.getType()
+            });
+            log.error("Community has its challenge exchange disabled, will not publish", this.getType(), error);
+            this._changePublicationStateEmitEventEmitStateChangeEvent({
+                newPublishingState: "failed",
+                event: { name: "error", args: [error] }
+            });
+            throw error;
+        }
+
         let currentPubsubProviderIndex = 0;
         while (!this._didWeReceiveChallengeOrChallengeVerification() && currentPubsubProviderIndex < providers.length) {
             const providerUrl = providers[currentPubsubProviderIndex];
@@ -1253,12 +1286,12 @@ class Publication extends TypedEmitter<PublicationEvents> {
                 // this will throw if we succeed in subscribing first attempt, but then fail to publish
 
                 await this._clientsManager.pubsubSubscribeOnProvider(
-                    this._communityPubsubTopicWithFallback(),
+                    this._communityChallengeExchangeTopic(),
                     this._handleChallengeExchange,
                     providerUrl
                 );
                 this._updatePubsubState("publishing-challenge-request", providerUrl);
-                await this._clientsManager.pubsubPublishOnProvider(this._communityPubsubTopicWithFallback(), challengeRequest, providerUrl);
+                await this._clientsManager.pubsubPublishOnProvider(this._communityChallengeExchangeTopic(), challengeRequest, providerUrl);
                 this._challengeExchanges[challengeRequest.challengeRequestId.toString()].challengeRequestPublishTimestamp = timestamp();
             } catch (e) {
                 this._updatePubsubState("stopped", providerUrl);
@@ -1271,7 +1304,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
                     await this._postSucessOrFailurePublishing();
                     const allAttemptsFailedError = new PKCError("ERR_ALL_PUBSUB_PROVIDERS_THROW_ERRORS", {
                         challengeExchanges: this._challengeExchangesFormattedForErrors(),
-                        pubsubTopic: this._communityPubsubTopicWithFallback(),
+                        pubsubTopic: this._community?.pubsubTopic,
                         providerHeliaContexts: this._libp2pJsClientHeliaContexts()
                     });
                     log.error("All attempts to publish", this.getType(), "has failed", allAttemptsFailedError);

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -113,10 +113,6 @@ class Publication extends TypedEmitter<PublicationEvents> {
         name?: string;
         encryption: CommunityIpfsType["encryption"];
         pubsubTopic?: CommunityIpfsType["pubsubTopic"];
-        // Address derived from the community record's signature.publicKey, ie the key that also signs
-        // CHALLENGE/CHALLENGEVERIFICATION messages. Normally identical to pubsubTopic, but a read-only
-        // community has no topic and the identity check still needs this value (issue #229).
-        signerAddress: string;
     } = undefined; // will be used for publishing
     _publishingToLocalCommunity?: LocalCommunity;
 
@@ -722,15 +718,20 @@ class Publication extends TypedEmitter<PublicationEvents> {
         return pubsubTopic;
     }
 
-    // Who must have signed an incoming CHALLENGE/CHALLENGEVERIFICATION: the key that signs the
-    // community's own records. Deliberately NOT the pubsub topic — the topic only happened to equal
-    // this address because of the init backfill (issue #229). Reading it from the record's signature
-    // also makes a custom pubsubTopic verify correctly, and keeps working for a delegated community
-    // where the record is signed by the minter while the identity is the anchor (#233).
+    // Who must have signed an incoming CHALLENGE/CHALLENGEVERIFICATION. Deliberately NOT the pubsub
+    // topic — the topic only happened to equal this address because of the init backfill (issue #229).
+    //
+    // community.encryption.publicKey is the right key, not signature.publicKey: we already encrypt the
+    // challenge request TO it and decrypt the challenge FROM it, so whoever it names is by definition
+    // the holder of the private key running the exchange, and therefore the signer of its messages.
+    // signature.publicKey answers "who minted the record", a role that merely coincides today. Using
+    // encryption makes both halves of the exchange attest to one identity, and it stays correct if a
+    // delegated community (#233) ever splits minting from running the exchange. It is covered by
+    // CommunitySignedPropertyNames, so it is authenticated by the record signature.
     private _communityChallengeMsgSignerAddress(): string {
-        const signerAddress = this._community?.signerAddress;
-        if (typeof signerAddress !== "string") throw Error("Failed to load the challenge message signer address of community");
-        return signerAddress;
+        const encryptionPublicKey = this._community?.encryption?.publicKey;
+        if (typeof encryptionPublicKey !== "string") throw Error("Failed to load the encryption public key of community");
+        return getPKCAddressFromPublicKeySync(encryptionPublicKey);
     }
 
     _getCommunityCache(): NonNullable<Publication["_community"]> | undefined {
@@ -746,8 +747,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
                 publicKey: subInstance.publicKey,
                 name: subInstance.name,
                 encryption: subIpfs.encryption,
-                pubsubTopic: subIpfs.pubsubTopic,
-                signerAddress: getPKCAddressFromPublicKeySync(subIpfs.signature.publicKey)
+                pubsubTopic: subIpfs.pubsubTopic
             };
         return undefined;
     }

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -317,7 +317,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
         if (Object.values(this._challengeExchanges).some((exchange) => exchange.challenge)) return; // We only process one challenge
         const challengeMsgValidity = await verifyChallengeMessage({
             challenge: msg,
-            pubsubTopic: this._communityChallengeMsgSignerAddress(),
+            communitySignerAddress: this._communityChallengeMsgSignerAddress(),
             validateTimestampRange: true
         });
         if (!challengeMsgValidity.valid) {
@@ -399,7 +399,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
         if (this._challengeExchanges[msg.challengeRequestId.toString()].challengeVerification) return;
         const signatureValidation = await verifyChallengeVerification({
             verification: msg,
-            pubsubTopic: this._communityChallengeMsgSignerAddress(),
+            communitySignerAddress: this._communityChallengeMsgSignerAddress(),
             validateTimestampRange: true
         });
         if (!signatureValidation.valid) {
@@ -722,11 +722,13 @@ class Publication extends TypedEmitter<PublicationEvents> {
         return pubsubTopic;
     }
 
-    // Who must have signed an incoming CHALLENGE/CHALLENGEVERIFICATION. Historically the challenge
-    // topic doubled as this address, which is what the verifiers compare against; a read-only
-    // community has no topic but the identity being checked is unchanged (issue #229).
+    // Who must have signed an incoming CHALLENGE/CHALLENGEVERIFICATION: the key that signs the
+    // community's own records. Deliberately NOT the pubsub topic — the topic only happened to equal
+    // this address because of the init backfill (issue #229). Reading it from the record's signature
+    // also makes a custom pubsubTopic verify correctly, and keeps working for a delegated community
+    // where the record is signed by the minter while the identity is the anchor (#233).
     private _communityChallengeMsgSignerAddress(): string {
-        const signerAddress = this._community?.pubsubTopic ?? this._community?.signerAddress;
+        const signerAddress = this._community?.signerAddress;
         if (typeof signerAddress !== "string") throw Error("Failed to load the challenge message signer address of community");
         return signerAddress;
     }

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -313,7 +313,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
         if (Object.values(this._challengeExchanges).some((exchange) => exchange.challenge)) return; // We only process one challenge
         const challengeMsgValidity = await verifyChallengeMessage({
             challenge: msg,
-            communitySignerAddress: this._communityChallengeMsgSignerAddress(),
+            communityChallengeSignerAddress: this._communityChallengeMsgSignerAddress(),
             validateTimestampRange: true
         });
         if (!challengeMsgValidity.valid) {
@@ -395,7 +395,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
         if (this._challengeExchanges[msg.challengeRequestId.toString()].challengeVerification) return;
         const signatureValidation = await verifyChallengeVerification({
             verification: msg,
-            communitySignerAddress: this._communityChallengeMsgSignerAddress(),
+            communityChallengeSignerAddress: this._communityChallengeMsgSignerAddress(),
             validateTimestampRange: true
         });
         if (!signatureValidation.valid) {
@@ -607,7 +607,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
         } else {
             try {
                 await this._clientsManager.pubsubPublishOnProvider(
-                    this._communityChallengeExchangeTopic(),
+                    this._communityChallengePubsubExchangeTopic(),
                     answerMsgToPublish,
                     challengeExchange.providerUrl
                 );
@@ -708,11 +708,13 @@ class Publication extends TypedEmitter<PublicationEvents> {
 
     // The topic to run the challenge exchange on. Absence of pubsubTopic on the record means the
     // community disabled the exchange (issue #229); there is no fallback to the community address.
-    _communityChallengeExchangeTopic(): string {
+    _communityChallengePubsubExchangeTopic(): string {
         const pubsubTopic = this._community?.pubsubTopic;
         if (typeof pubsubTopic !== "string")
             throw new PKCError("ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED", {
                 communityAddress: this._community?.address ?? this.communityAddress,
+                communityName: this._community?.name ?? this.communityName,
+                communityPublicKey: this._community?.publicKey ?? this.communityPublicKey,
                 publicationType: this.getType()
             });
         return pubsubTopic;
@@ -1100,13 +1102,13 @@ class Publication extends TypedEmitter<PublicationEvents> {
                     this._updatePubsubState("subscribing-pubsub", providerUrl);
                     try {
                         await this._clientsManager.pubsubSubscribeOnProvider(
-                            this._communityChallengeExchangeTopic(),
+                            this._communityChallengePubsubExchangeTopic(),
                             this._handleChallengeExchange,
                             providerUrl
                         );
                         this._updatePubsubState("publishing-challenge-request", providerUrl);
                         await this._clientsManager.pubsubPublishOnProvider(
-                            this._communityChallengeExchangeTopic(),
+                            this._communityChallengePubsubExchangeTopic(),
                             challengeRequest,
                             providerUrl
                         );
@@ -1266,6 +1268,8 @@ class Publication extends TypedEmitter<PublicationEvents> {
             await this._postSucessOrFailurePublishing();
             const error = new PKCError("ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED", {
                 communityAddress: this._community?.address ?? this.communityAddress,
+                communityName: this._community?.name ?? this.communityName,
+                communityPublicKey: this._community?.publicKey ?? this.communityPublicKey,
                 publicationType: this.getType()
             });
             log.error("Community has its challenge exchange disabled, will not publish", this.getType(), error);
@@ -1291,12 +1295,16 @@ class Publication extends TypedEmitter<PublicationEvents> {
                 // this will throw if we succeed in subscribing first attempt, but then fail to publish
 
                 await this._clientsManager.pubsubSubscribeOnProvider(
-                    this._communityChallengeExchangeTopic(),
+                    this._communityChallengePubsubExchangeTopic(),
                     this._handleChallengeExchange,
                     providerUrl
                 );
                 this._updatePubsubState("publishing-challenge-request", providerUrl);
-                await this._clientsManager.pubsubPublishOnProvider(this._communityChallengeExchangeTopic(), challengeRequest, providerUrl);
+                await this._clientsManager.pubsubPublishOnProvider(
+                    this._communityChallengePubsubExchangeTopic(),
+                    challengeRequest,
+                    providerUrl
+                );
                 this._challengeExchanges[challengeRequest.challengeRequestId.toString()].challengeRequestPublishTimestamp = timestamp();
             } catch (e) {
                 this._updatePubsubState("stopped", providerUrl);

--- a/src/runtime/node/community/local-community.ts
+++ b/src/runtime/node/community/local-community.ts
@@ -116,6 +116,10 @@ export class LocalCommunity extends RpcLocalCommunity implements CreateNewLocalC
     _firstUpdateAfterStart: boolean = true;
     _internalStateUpdateId: InternalCommunityRecordBeforeFirstUpdateType["_internalStateUpdateId"] = "";
     _lastPubsubTopicRoutingProvideAt?: number = undefined;
+    // The challenge exchange topic we last subscribed to. pubsubTopic can change while the community is
+    // started, and the kubo node is shared with other communities, so this is the only safe way to know
+    // which subscription is ours to drop (see listenToIncomingRequests).
+    _subscribedChallengePubsubTopic?: string = undefined;
     // Browser-dialable (WSS/WebRTC) self-addresses last announced for the connection-critical CIDs.
     // When this set changes (checked once per publish-loop cycle, throttled) we re-provide so HTTP routers
     // stop serving stale addresses (see reprovide-on-address-change.ts).
@@ -186,7 +190,12 @@ export class LocalCommunity extends RpcLocalCommunity implements CreateNewLocalC
             _internalStateUpdateId: this._internalStateUpdateId,
             _cidsToUnPin: [...this._cidsToUnPin],
             _mfsPathsToRemove: [...this._mfsPathsToRemove],
-            _pendingEditProps: this._pendingEditProps
+            _pendingEditProps: this._pendingEditProps,
+            // rpcJson.community is the published record, which omits pubsubTopic entirely while
+            // settings.disablePubsubChallengeExchange is on (issue #229). Carry the configured topic
+            // separately so reloading internal state, in this process or after a restart, does not
+            // silently replace it with the signer-address default the next record would fall back to.
+            _configuredPubsubTopic: this.pubsubTopic
         };
     }
 

--- a/src/runtime/node/community/local-community/challenges.ts
+++ b/src/runtime/node/community/local-community/challenges.ts
@@ -49,7 +49,7 @@ import type {
 import type { IpfsHttpClientPubsubMessage } from "../../../../types.js";
 import type { LocalCommunity } from "../local-community.js";
 import { DUPLICATE_PUBLICATION_ERRORS } from "./defaults.js";
-import { pubsubTopicWithfallback } from "./comment-updates.js";
+import { challengeExchangePubsubTopic } from "./comment-updates.js";
 import { storePublication } from "./publication-store.js";
 import { checkPublicationValidity, respondWithErrorIfSignatureOfPublicationIsInvalid } from "./publication-validation.js";
 
@@ -106,11 +106,13 @@ export async function publishChallenges(
 
     community._clientsManager.updateKuboRpcPubsubState("publishing-challenge", pubsubClient.url);
 
-    // we only publish over pubsub if the challenge exchange is not ongoing for local publishers
-    if (!community._challengeExchangesFromLocalPublishers[request.challengeRequestId.toString()])
-        await community._clientsManager.pubsubPublish(pubsubTopicWithfallback(community), challengeMessage);
+    // we only publish over pubsub if the challenge exchange is not ongoing for local publishers,
+    // and only if the exchange isn't disabled (issue #229) — local publishers still get the emission below
+    const challengeTopic = challengeExchangePubsubTopic(community);
+    if (challengeTopic && !community._challengeExchangesFromLocalPublishers[request.challengeRequestId.toString()])
+        await community._clientsManager.pubsubPublish(challengeTopic, challengeMessage);
     log(
-        `Community ${community.address} with pubsub topic ${pubsubTopicWithfallback(community)} published ${challengeMessage.type} over pubsub: `,
+        `Community ${community.address} with pubsub topic ${challengeTopic} published ${challengeMessage.type} over pubsub: `,
         pick(toSignChallenge, ["timestamp"]),
         toEncryptChallenge.challenges.map((challenge) => challenge.type)
     );
@@ -147,13 +149,14 @@ export async function publishFailedChallengeVerification(
 
     const pubsubClient = community._clientsManager.getDefaultKuboPubsubClient();
     community._clientsManager.updateKuboRpcPubsubState("publishing-challenge-verification", pubsubClient.url);
+    const challengeTopic = challengeExchangePubsubTopic(community);
     log(
-        `Will publish ${challengeVerification.type} over pubsub topic ${pubsubTopicWithfallback(community)} on community ${community.address}:`,
+        `Will publish ${challengeVerification.type} over pubsub topic ${challengeTopic} on community ${community.address}:`,
         omit(toSignVerification, ["challengeRequestId"])
     );
 
-    if (!community._challengeExchangesFromLocalPublishers[challengeRequestId.toString()])
-        await community._clientsManager.pubsubPublish(pubsubTopicWithfallback(community), challengeVerification);
+    if (challengeTopic && !community._challengeExchangesFromLocalPublishers[challengeRequestId.toString()])
+        await community._clientsManager.pubsubPublish(challengeTopic, challengeVerification);
     community._clientsManager.updateKuboRpcPubsubState("waiting-challenge-requests", pubsubClient.url);
 
     community.emit("challengeverification", challengeVerification);
@@ -232,8 +235,9 @@ export async function publishIdempotentDuplicateVerification(
 
     const pubsubClient = community._clientsManager.getDefaultKuboPubsubClient();
     community._clientsManager.updateKuboRpcPubsubState("publishing-challenge-verification", pubsubClient.url);
-    if (!community._challengeExchangesFromLocalPublishers[challengeRequestId.toString()])
-        await community._clientsManager.pubsubPublish(pubsubTopicWithfallback(community), challengeVerification);
+    const challengeTopic = challengeExchangePubsubTopic(community);
+    if (challengeTopic && !community._challengeExchangesFromLocalPublishers[challengeRequestId.toString()])
+        await community._clientsManager.pubsubPublish(challengeTopic, challengeVerification);
     community._clientsManager.updateKuboRpcPubsubState("waiting-challenge-requests", pubsubClient.url);
 
     const objectToEmit = <DecryptedChallengeVerificationMessageType>{ ...challengeVerification, ...toEncryptDecrypted };
@@ -334,8 +338,9 @@ export async function publishChallengeVerification(
 
         community._clientsManager.updateKuboRpcPubsubState("publishing-challenge-verification", pubsubClient.url);
 
-        if (!community._challengeExchangesFromLocalPublishers[request.challengeRequestId.toString()])
-            await community._clientsManager.pubsubPublish(pubsubTopicWithfallback(community), challengeVerification);
+        const challengeTopic = challengeExchangePubsubTopic(community);
+        if (challengeTopic && !community._challengeExchangesFromLocalPublishers[request.challengeRequestId.toString()])
+            await community._clientsManager.pubsubPublish(challengeTopic, challengeVerification);
 
         community._clientsManager.updateKuboRpcPubsubState("waiting-challenge-requests", pubsubClient.url);
 
@@ -345,7 +350,7 @@ export async function publishChallengeVerification(
         delete community._challengeExchangesFromLocalPublishers[request.challengeRequestId.toString()];
         cleanUpChallengeAnswerPromise(community, request.challengeRequestId.toString());
         log.trace(
-            `Published ${challengeVerification.type} over pubsub topic ${pubsubTopicWithfallback(community)}:`,
+            `Published ${challengeVerification.type} over pubsub topic ${challengeTopic}:`,
             omit(objectToEmit, ["signature", "encrypted", "challengeRequestId"])
         );
     }

--- a/src/runtime/node/community/local-community/challenges.ts
+++ b/src/runtime/node/community/local-community/challenges.ts
@@ -102,9 +102,7 @@ export async function publishChallenges(
         ...toSignChallenge,
         signature: await signChallengeMessage({ challengeMessage: toSignChallenge, signer: community.signer })
     };
-    const pubsubClient = community._clientsManager.getDefaultKuboPubsubClient();
-
-    community._clientsManager.updateKuboRpcPubsubState("publishing-challenge", pubsubClient.url);
+    community._clientsManager.updateKuboRpcPubsubStateIfProviderExists("publishing-challenge");
 
     // we only publish over pubsub if the challenge exchange is not ongoing for local publishers,
     // and only if the exchange isn't disabled (issue #229) — local publishers still get the emission below
@@ -116,7 +114,7 @@ export async function publishChallenges(
         pick(toSignChallenge, ["timestamp"]),
         toEncryptChallenge.challenges.map((challenge) => challenge.type)
     );
-    community._clientsManager.updateKuboRpcPubsubState("waiting-challenge-answers", pubsubClient.url);
+    community._clientsManager.updateKuboRpcPubsubStateIfProviderExists("waiting-challenge-answers");
     community.emit("challenge", {
         ...challengeMessage,
         challenges
@@ -147,8 +145,7 @@ export async function publishFailedChallengeVerification(
         signature: await signChallengeVerification({ challengeVerification: toSignVerification, signer: community.signer })
     };
 
-    const pubsubClient = community._clientsManager.getDefaultKuboPubsubClient();
-    community._clientsManager.updateKuboRpcPubsubState("publishing-challenge-verification", pubsubClient.url);
+    community._clientsManager.updateKuboRpcPubsubStateIfProviderExists("publishing-challenge-verification");
     const challengeTopic = challengeExchangePubsubTopic(community);
     log(
         `Will publish ${challengeVerification.type} over pubsub topic ${challengeTopic} on community ${community.address}:`,
@@ -157,7 +154,7 @@ export async function publishFailedChallengeVerification(
 
     if (challengeTopic && !community._challengeExchangesFromLocalPublishers[challengeRequestId.toString()])
         await community._clientsManager.pubsubPublish(challengeTopic, challengeVerification);
-    community._clientsManager.updateKuboRpcPubsubState("waiting-challenge-requests", pubsubClient.url);
+    community._clientsManager.updateKuboRpcPubsubStateIfProviderExists("waiting-challenge-requests");
 
     community.emit("challengeverification", challengeVerification);
     community._ongoingChallengeExchanges.delete(challengeRequestId.toString());
@@ -233,12 +230,11 @@ export async function publishIdempotentDuplicateVerification(
         signature: await signChallengeVerification({ challengeVerification: toSignMsg, signer: community.signer })
     };
 
-    const pubsubClient = community._clientsManager.getDefaultKuboPubsubClient();
-    community._clientsManager.updateKuboRpcPubsubState("publishing-challenge-verification", pubsubClient.url);
+    community._clientsManager.updateKuboRpcPubsubStateIfProviderExists("publishing-challenge-verification");
     const challengeTopic = challengeExchangePubsubTopic(community);
     if (challengeTopic && !community._challengeExchangesFromLocalPublishers[challengeRequestId.toString()])
         await community._clientsManager.pubsubPublish(challengeTopic, challengeVerification);
-    community._clientsManager.updateKuboRpcPubsubState("waiting-challenge-requests", pubsubClient.url);
+    community._clientsManager.updateKuboRpcPubsubStateIfProviderExists("waiting-challenge-requests");
 
     const objectToEmit = <DecryptedChallengeVerificationMessageType>{ ...challengeVerification, ...toEncryptDecrypted };
     community.emit("challengeverification", objectToEmit);
@@ -334,15 +330,13 @@ export async function publishChallengeVerification(
             signature: await signChallengeVerification({ challengeVerification: toSignMsg, signer: community.signer })
         };
 
-        const pubsubClient = community._clientsManager.getDefaultKuboPubsubClient();
-
-        community._clientsManager.updateKuboRpcPubsubState("publishing-challenge-verification", pubsubClient.url);
+        community._clientsManager.updateKuboRpcPubsubStateIfProviderExists("publishing-challenge-verification");
 
         const challengeTopic = challengeExchangePubsubTopic(community);
         if (challengeTopic && !community._challengeExchangesFromLocalPublishers[request.challengeRequestId.toString()])
             await community._clientsManager.pubsubPublish(challengeTopic, challengeVerification);
 
-        community._clientsManager.updateKuboRpcPubsubState("waiting-challenge-requests", pubsubClient.url);
+        community._clientsManager.updateKuboRpcPubsubStateIfProviderExists("waiting-challenge-requests");
 
         const objectToEmit = <DecryptedChallengeVerificationMessageType>{ ...challengeVerification, ...toEncrypt };
         community.emit("challengeverification", objectToEmit);

--- a/src/runtime/node/community/local-community/comment-updates.ts
+++ b/src/runtime/node/community/local-community/comment-updates.ts
@@ -19,8 +19,20 @@ import type { LocalCommunity } from "../local-community.js";
 import type { CommentUpdateToWriteToDbAndPublishToIpfs } from "./defaults.js";
 import { rmUnneededMfsPaths } from "./cleanup.js";
 
-export function pubsubTopicWithfallback(community: LocalCommunity) {
-    return community.pubsubTopic || community.address;
+// The topic this community uses for the challenge exchange, ignoring whether the exchange is
+// currently enabled. There is no fallback to community.address anymore (issue #229): absence of
+// pubsubTopic on the wire means the exchange is disabled, so the address must never stand in for a
+// missing topic. community.signer.address is what the init backfill writes, so a community that
+// toggles the exchange back on has a topic without needing a DB write first.
+export function communityChallengePubsubTopic(community: LocalCommunity): string | undefined {
+    return community.pubsubTopic || community.signer?.address;
+}
+
+// The topic to actually subscribe/publish on, undefined when settings.disablePubsubChallengeExchange
+// turns the community read-only over the network.
+export function challengeExchangePubsubTopic(community: LocalCommunity): string | undefined {
+    if (community.settings?.disablePubsubChallengeExchange) return undefined;
+    return communityChallengePubsubTopic(community);
 }
 
 export function calculateLocalMfsPathForCommentUpdate(

--- a/src/runtime/node/community/local-community/db-state.ts
+++ b/src/runtime/node/community/local-community/db-state.ts
@@ -240,7 +240,11 @@ export async function createNewLocalCommunityDb(community: LocalCommunity) {
     await community._dbHandler.createOrMigrateTablesIfNeeded();
     await initSignerProps(community, community.signer); // init this.encryption as well
 
-    if (!community.pubsubTopic) community.pubsubTopic = clone(community.signer.address);
+    // A read-only community gets no backfilled topic: absence of pubsubTopic on the wire is what tells
+    // readers the challenge exchange is disabled (issue #229). An explicit custom topic is left alone
+    // so it survives a disable/enable cycle.
+    if (!community.pubsubTopic && !community.settings?.disablePubsubChallengeExchange)
+        community.pubsubTopic = clone(community.signer.address);
     if (typeof community.createdAt !== "number") community.createdAt = timestamp();
     if (!community.protocolVersion) community.protocolVersion = env.PROTOCOL_VERSION;
     if (!community.settings?.maxPendingApprovalCount) community.settings = { ...community.settings, maxPendingApprovalCount: 500 };

--- a/src/runtime/node/community/local-community/db-state.ts
+++ b/src/runtime/node/community/local-community/db-state.ts
@@ -333,6 +333,13 @@ export async function initInternalCommunityAfterFirstUpdateNoMerge(
         },
         runtimeFields: { updateCid: newProps.updateCid }
     });
+    // The community half above overwrites pubsubTopic from the published record, which carries no topic
+    // while the challenge exchange is disabled (issue #229). Restore the configured one so a disabled
+    // community keeps the topic it will publish again when the setting is turned off. Only when the
+    // record has no topic: a published topic is the authority, and this state can be a row read that
+    // predates the latest publish, which must not drag the instance back to a superseded topic. Older
+    // rows have no _configuredPubsubTopic and fall back to whatever the record said, as they meant.
+    if (!newProps.pubsubTopic && newProps._configuredPubsubTopic) community.pubsubTopic = newProps._configuredPubsubTopic;
     await initSignerProps(community, newProps.signer);
     community._internalStateUpdateId = newProps._internalStateUpdateId;
     if (Array.isArray(newProps._cidsToUnPin)) newProps._cidsToUnPin.forEach((cid) => community._cidsToUnPin.add(cid));

--- a/src/runtime/node/community/local-community/ipns-publishing.ts
+++ b/src/runtime/node/community/local-community/ipns-publishing.ts
@@ -353,7 +353,12 @@ async function publishCommunityRecordToIpns(
         community._blocksToRm = community._blocksToRm.filter((blockCid) => !removedBlocks.includes(blockCid));
     }
     if (community.updateCid) community._cidsToUnPin.add(community.updateCid); // add old cid of community to be unpinned
+    const configuredPubsubTopic = community.pubsubTopic;
     community.initCommunityIpfsPropsNoMerge(newCommunityRecord);
+    // A read-only community publishes no pubsubTopic, and the line above overwrites every CommunityIpfs
+    // prop from the record it just published. Restore the configured topic so it is not lost on the
+    // round trip and survives a disable/enable cycle (issue #229) — settings is the only switch.
+    if (!newCommunityRecord.pubsubTopic && configuredPubsubTopic) community.pubsubTopic = configuredPubsubTopic;
     community.updateCid = file.path;
     community._pendingEditProps = community._pendingEditProps.filter(
         (editProps) => !editIdsToIncludeInNextUpdate.includes(editProps.editId)

--- a/src/runtime/node/community/local-community/ipns-publishing.ts
+++ b/src/runtime/node/community/local-community/ipns-publishing.ts
@@ -354,11 +354,22 @@ async function publishCommunityRecordToIpns(
     }
     if (community.updateCid) community._cidsToUnPin.add(community.updateCid); // add old cid of community to be unpinned
     const configuredPubsubTopic = community.pubsubTopic;
+    // A pubsubTopic edit is applied to the instance through the published record, so while the exchange
+    // is disabled it would be swallowed: the record omits the topic by design. Land it on the configured
+    // topic instead, which is what the next enable publishes.
+    const editedPubsubTopic = community._pendingEditProps
+        .filter((editProps) => editProps.editId && editIdsToIncludeInNextUpdate.includes(editProps.editId))
+        .map((editProps) => editProps.pubsubTopic)
+        .filter((topic): topic is string => typeof topic === "string")
+        .pop();
     community.initCommunityIpfsPropsNoMerge(newCommunityRecord);
     // A read-only community publishes no pubsubTopic, and the line above overwrites every CommunityIpfs
     // prop from the record it just published. Restore the configured topic so it is not lost on the
     // round trip and survives a disable/enable cycle (issue #229) — settings is the only switch.
-    if (!newCommunityRecord.pubsubTopic && configuredPubsubTopic) community.pubsubTopic = configuredPubsubTopic;
+    if (!newCommunityRecord.pubsubTopic) {
+        const topicToKeep = editedPubsubTopic ?? configuredPubsubTopic;
+        if (topicToKeep) community.pubsubTopic = topicToKeep;
+    }
     community.updateCid = file.path;
     community._pendingEditProps = community._pendingEditProps.filter(
         (editProps) => !editIdsToIncludeInNextUpdate.includes(editProps.editId)

--- a/src/runtime/node/community/local-community/ipns-publishing.ts
+++ b/src/runtime/node/community/local-community/ipns-publishing.ts
@@ -22,7 +22,12 @@ import type { CommunityIpfsType } from "../../../../community/types.js";
 import type { CommentUpdateType } from "../../../../publications/comment/types.js";
 import type { LocalCommunity } from "../local-community.js";
 import type { CommentUpdateToWriteToDbAndPublishToIpfs } from "./defaults.js";
-import { adjustPostUpdatesBucketsIfNeeded, syncPostUpdatesWithIpfs, updateCommentsThatNeedToBeUpdated } from "./comment-updates.js";
+import {
+    adjustPostUpdatesBucketsIfNeeded,
+    challengeExchangePubsubTopic,
+    syncPostUpdatesWithIpfs,
+    updateCommentsThatNeedToBeUpdated
+} from "./comment-updates.js";
 import { cleanUpIpfsRepoRarely, purgeDisapprovedCommentsOlderThan, unpinStaleCids } from "./cleanup.js";
 import { providePubsubTopicRoutingCidsIfNeeded } from "./pubsub.js";
 
@@ -212,6 +217,10 @@ async function calculateNextCommunityRecord(
         ...cleanUpBeforePublishing({
             ...omit(community._toJSONIpfsBaseNoPosts(), ["signature"]),
             ...pendingCommunityIpfsEditProps,
+            // Resolved last so it wins over a pending pubsubTopic edit. undefined when the exchange is
+            // disabled, and cleanUpBeforePublishing purges it from the record (issue #229). The instance
+            // keeps community.pubsubTopic so a custom topic survives a disable/enable cycle.
+            pubsubTopic: challengeExchangePubsubTopic(community),
             lastPostCid: latestPost?.cid,
             lastCommentCid: latestComment?.cid,
             statsCid,

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -3,7 +3,7 @@ import { clone, keys } from "remeda";
 import { LRUCache } from "lru-cache";
 import { PKCError } from "../../../../pkc-error.js";
 import env from "../../../../version.js";
-import { removeMfsFilesSafely, sleepUntilTimeoutOrAbort } from "../../../../util.js";
+import { pubsubTopicToDhtKey, removeMfsFilesSafely, sleepUntilTimeoutOrAbort } from "../../../../util.js";
 import { moveCommunityDbToDeletedDirectory } from "../../util.js";
 import { getCommunityChallengeFromCommunityChallengeSettings } from "../challenges/index.js";
 import {
@@ -368,9 +368,17 @@ export async function stop(community: LocalCommunity) {
         log("Stopping running community", community.address);
         try {
             // Unsubscribe regardless of settings.disablePubsubChallengeExchange — the setting may have
-            // been toggled on after we subscribed, and unsubscribing a topic we never joined is a no-op
-            const challengeTopic = communityChallengePubsubTopic(community);
-            if (challengeTopic) await community._clientsManager.pubsubUnsubscribe(challengeTopic, community.handleChallengeExchange);
+            // been toggled on after we subscribed, and unsubscribing a topic we never joined is a no-op.
+            // _subscribedChallengePubsubTopic covers a pubsubTopic that changed since we joined, which
+            // the current derivation no longer names.
+            const challengeTopics = new Set(
+                [communityChallengePubsubTopic(community), community._subscribedChallengePubsubTopic].filter(
+                    (topic): topic is string => typeof topic === "string"
+                )
+            );
+            for (const challengeTopic of challengeTopics)
+                await community._clientsManager.pubsubUnsubscribe(challengeTopic, community.handleChallengeExchange);
+            community._subscribedChallengePubsubTopic = undefined;
         } catch (e) {
             log.error("Failed to unsubscribe from challenge exchange pubsub when stopping community", e);
         }
@@ -476,6 +484,11 @@ export async function deleteCommunity(community: LocalCommunity) {
         log.error("Failed to add old page cids from community.posts to be unpinned", e);
     }
     if (community.ipnsPubsubTopicRoutingCid) community._cidsToUnPin.add(community.ipnsPubsubTopicRoutingCid);
+    // pubsubTopicRoutingCid only reflects the topic of the last published record, so derive the
+    // configured topic's block too: a community whose exchange is disabled (issue #229), or whose topic
+    // changed after the last publish, still has that block pinned from when it was being provided.
+    const configuredChallengeTopic = communityChallengePubsubTopic(community);
+    if (configuredChallengeTopic) community._cidsToUnPin.add(pubsubTopicToDhtKey(configuredChallengeTopic));
     if (community.pubsubTopicRoutingCid) community._cidsToUnPin.add(community.pubsubTopicRoutingCid);
     try {
         await community.initDbHandlerIfNeeded();

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -18,7 +18,7 @@ import {
 } from "../../../../pkc/tracked-instance-registry-util.js";
 import { LocalCommunity } from "../local-community.js";
 import { processStartedCommunities } from "./registry.js";
-import { pubsubTopicWithfallback } from "./comment-updates.js";
+import { communityChallengePubsubTopic } from "./comment-updates.js";
 import { providePubsubTopicRoutingCidsIfNeeded } from "./pubsub.js";
 import { reprovideOnAddressChangeIfDue } from "./reprovide-on-address-change.js";
 import { repinCommentUpdateIfNeeded, unpinStaleCids } from "./cleanup.js";
@@ -367,7 +367,10 @@ export async function stop(community: LocalCommunity) {
     if (community.state === "started") {
         log("Stopping running community", community.address);
         try {
-            await community._clientsManager.pubsubUnsubscribe(pubsubTopicWithfallback(community), community.handleChallengeExchange);
+            // Unsubscribe regardless of settings.disablePubsubChallengeExchange — the setting may have
+            // been toggled on after we subscribed, and unsubscribing a topic we never joined is a no-op
+            const challengeTopic = communityChallengePubsubTopic(community);
+            if (challengeTopic) await community._clientsManager.pubsubUnsubscribe(challengeTopic, community.handleChallengeExchange);
         } catch (e) {
             log.error("Failed to unsubscribe from challenge exchange pubsub when stopping community", e);
         }

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -404,7 +404,6 @@ export async function stop(community: LocalCommunity) {
             log.error(`Failed to unlock start lock on community (${community.address})`, e);
         }
         const kuboRpcClient = community._clientsManager.getDefaultKuboRpcClient();
-        const pubsubClient = community._clientsManager.getDefaultKuboPubsubClient();
 
         community._setStartedStateWithEmission("stopped");
         untrackStartedCommunity(community._pkc, community);
@@ -414,7 +413,7 @@ export async function stop(community: LocalCommunity) {
         await community._dbHandler.unlockCommunityState();
         await community._updateStartedValue();
         community._clientsManager.updateKuboRpcState("stopped", kuboRpcClient.url);
-        community._clientsManager.updateKuboRpcPubsubState("stopped", pubsubClient.url);
+        community._clientsManager.updateKuboRpcPubsubStateIfProviderExists("stopped");
         if (community._dbHandler) community._dbHandler.destoryConnection();
         log(`Stopped the running of local community (${community.address})`);
         community._setState("stopped");

--- a/src/runtime/node/community/local-community/pubsub.ts
+++ b/src/runtime/node/community/local-community/pubsub.ts
@@ -7,9 +7,15 @@ export async function listenToIncomingRequests(community: LocalCommunity) {
     const log = Logger("pkc-js:local-community:sync:_listenToIncomingRequests");
     // Make sure community listens to pubsub topic
     // Code below is to handle in case the ipfs node restarted and the subscription got lost or something
-    const pubsubClient = community._clientsManager.getDefaultKuboPubsubClient();
-    const subscribedTopics = await pubsubClient._client.pubsub.ls();
     const topic = challengeExchangePubsubTopic(community);
+    // Only a community that actually runs the exchange requires a pubsub provider; a node hosting
+    // read-only communities alone may have none configured (issue #229), and then there is nothing
+    // subscribed to drop either. An enabled community with no provider still throws, as it must.
+    const pubsubClient = topic
+        ? community._clientsManager.getDefaultKuboPubsubClient()
+        : community._clientsManager.getDefaultKuboPubsubClientIfAny();
+    if (!pubsubClient) return;
+    const subscribedTopics = await pubsubClient._client.pubsub.ls();
     if (!topic) {
         // settings.disablePubsubChallengeExchange is on (issue #229). This runs on every sync-loop
         // iteration, so toggling the setting on while started drops the subscription without a restart.

--- a/src/runtime/node/community/local-community/pubsub.ts
+++ b/src/runtime/node/community/local-community/pubsub.ts
@@ -1,7 +1,7 @@
 import Logger from "../../../../logger.js";
 import { retryKuboBlockPutPinAndProvidePubsubTopic } from "../../../../util.js";
 import type { LocalCommunity } from "../local-community.js";
-import { pubsubTopicWithfallback } from "./comment-updates.js";
+import { challengeExchangePubsubTopic, communityChallengePubsubTopic } from "./comment-updates.js";
 
 export async function listenToIncomingRequests(community: LocalCommunity) {
     const log = Logger("pkc-js:local-community:sync:_listenToIncomingRequests");
@@ -9,7 +9,17 @@ export async function listenToIncomingRequests(community: LocalCommunity) {
     // Code below is to handle in case the ipfs node restarted and the subscription got lost or something
     const pubsubClient = community._clientsManager.getDefaultKuboPubsubClient();
     const subscribedTopics = await pubsubClient._client.pubsub.ls();
-    const topic = pubsubTopicWithfallback(community);
+    const topic = challengeExchangePubsubTopic(community);
+    if (!topic) {
+        // settings.disablePubsubChallengeExchange is on (issue #229). This runs on every sync-loop
+        // iteration, so toggling the setting on while started drops the subscription without a restart.
+        const disabledTopic = communityChallengePubsubTopic(community);
+        if (disabledTopic && subscribedTopics.includes(disabledTopic)) {
+            await community._clientsManager.pubsubUnsubscribe(disabledTopic, community.handleChallengeExchange);
+            log(`Challenge exchange is disabled, unsubscribed from pubsub topic (${disabledTopic})`);
+        }
+        return;
+    }
     if (!subscribedTopics.includes(topic)) {
         await community._clientsManager.pubsubUnsubscribe(topic, community.handleChallengeExchange); // Make sure it's not hanging
         await community._clientsManager.pubsubSubscribe(topic, community.handleChallengeExchange);
@@ -25,7 +35,9 @@ export async function providePubsubTopicRoutingCidsIfNeeded(community: LocalComm
     if (!force && community._lastPubsubTopicRoutingProvideAt && now - community._lastPubsubTopicRoutingProvideAt < reprovideIntervalMs)
         return;
 
-    const pubsubTopic = pubsubTopicWithfallback(community);
+    // A read-only community has no challenge topic to advertise; the IPNS-over-pubsub record topic is
+    // a separate derivation and keeps being provided so replication is unaffected (issue #229).
+    const pubsubTopic = challengeExchangePubsubTopic(community);
     const topics = [pubsubTopic, community.ipnsPubsubTopic].filter((topic): topic is string => typeof topic === "string");
     if (topics.length === 0) return;
 

--- a/src/runtime/node/community/local-community/pubsub.ts
+++ b/src/runtime/node/community/local-community/pubsub.ts
@@ -16,22 +16,40 @@ export async function listenToIncomingRequests(community: LocalCommunity) {
         : community._clientsManager.getDefaultKuboPubsubClientIfAny();
     if (!pubsubClient) return;
     const subscribedTopics = await pubsubClient._client.pubsub.ls();
+    // Whatever we joined last, which is the only way to know a topic is ours: the kubo node is shared
+    // with every other community on it, so kubo's subscription list cannot be diffed safely.
+    const staleTopic = community._subscribedChallengePubsubTopic;
+    const unsubscribeStaleTopicIfNeeded = async (currentTopic: string | undefined) => {
+        if (!staleTopic || staleTopic === currentTopic) return;
+        if (subscribedTopics.includes(staleTopic))
+            await community._clientsManager.pubsubUnsubscribe(staleTopic, community.handleChallengeExchange);
+        community._subscribedChallengePubsubTopic = undefined;
+        log(`Stopped listening on the previous challenge exchange pubsub topic (${staleTopic})`);
+    };
+
     if (!topic) {
         // settings.disablePubsubChallengeExchange is on (issue #229). This runs on every sync-loop
         // iteration, so toggling the setting on while started drops the subscription without a restart.
         const disabledTopic = communityChallengePubsubTopic(community);
         if (disabledTopic && subscribedTopics.includes(disabledTopic)) {
             await community._clientsManager.pubsubUnsubscribe(disabledTopic, community.handleChallengeExchange);
+            if (community._subscribedChallengePubsubTopic === disabledTopic) community._subscribedChallengePubsubTopic = undefined;
             log(`Challenge exchange is disabled, unsubscribed from pubsub topic (${disabledTopic})`);
         }
+        await unsubscribeStaleTopicIfNeeded(undefined);
         return;
     }
+    // A community can change its pubsubTopic while started. Drop the topic we joined for the previous
+    // one, otherwise kubo keeps delivering requests to a handler on a topic we no longer advertise and
+    // the subscription leaks for the lifetime of the node.
+    await unsubscribeStaleTopicIfNeeded(topic);
     if (!subscribedTopics.includes(topic)) {
         await community._clientsManager.pubsubUnsubscribe(topic, community.handleChallengeExchange); // Make sure it's not hanging
         await community._clientsManager.pubsubSubscribe(topic, community.handleChallengeExchange);
         community._clientsManager.updateKuboRpcPubsubState("waiting-challenge-requests", pubsubClient.url);
         log(`Waiting for publications on pubsub topic (${topic})`);
     }
+    community._subscribedChallengePubsubTopic = topic;
 }
 
 export async function providePubsubTopicRoutingCidsIfNeeded(community: LocalCommunity, force = false) {

--- a/src/signer/signatures.ts
+++ b/src/signer/signatures.ts
@@ -666,6 +666,15 @@ export async function verifyCommunity({
     const signaturePeerId = getPeerIdFromPublicKey(community.signature.publicKey);
     if (!communityPeerId.equals(signaturePeerId))
         return { valid: false, reason: messages.ERR_COMMUNITY_IPNS_NAME_DOES_NOT_MATCH_SIGNATURE_PUBLIC_KEY };
+
+    // The record signer is anchored to the IPNS name by the check above; encryption.publicKey is
+    // anchored to nothing on its own, it is merely a signed field. Publishers encrypt challenge
+    // requests to it and the community signs its CHALLENGE/CHALLENGEVERIFICATION with the key that
+    // decrypts them, so leaving the two unrelated would let a record delegate the challenge exchange
+    // to a key the reader never validated against the address it typed. initSignerProps has always
+    // derived both from community.signer, so this only makes an existing invariant explicit.
+    if (!getPeerIdFromPublicKey(community.encryption.publicKey).equals(signaturePeerId))
+        return { valid: false, reason: messages.ERR_COMMUNITY_ENCRYPTION_PUBLIC_KEY_DOES_NOT_MATCH_SIGNATURE_PUBLIC_KEY };
     clientsManager._pkc._memCaches.communityVerificationCache.set(cacheKey, true);
     return { valid: true };
 }

--- a/src/signer/signatures.ts
+++ b/src/signer/signatures.ts
@@ -807,20 +807,25 @@ export async function verifyChallengeRequest({
     return _validateSignatureOfPubsubMsg(request);
 }
 
+// communitySignerAddress is the address of the key that signs the community's own records, ie the
+// entity the challenge must have come from. This used to take the pubsubTopic string and only worked
+// because the topic is backfilled to that address; the check has always meant "signed by the
+// community", never "equal to the topic". Decoupled in issue #229, where a read-only community has no
+// topic at all — and it also fixes communities that set a custom pubsubTopic.
 export async function verifyChallengeMessage({
     challenge,
-    pubsubTopic,
+    communitySignerAddress,
     validateTimestampRange
 }: {
     challenge: ChallengeMessageType;
-    pubsubTopic: string;
+    communitySignerAddress: string;
     validateTimestampRange: boolean;
 }): Promise<ValidationResult> {
     if (!_allFieldsOfRecordInSignedPropertyNames(challenge))
         return { valid: false, reason: messages.ERR_CHALLENGE_INCLUDES_FIELD_NOT_IN_SIGNED_PROPERTY_NAMES };
 
     const msgSignerAddress = await getPKCAddressFromPublicKeyBuffer(challenge.signature.publicKey);
-    if (msgSignerAddress !== pubsubTopic) return { valid: false, reason: messages.ERR_CHALLENGE_MSG_SIGNER_IS_NOT_COMMUNITY };
+    if (msgSignerAddress !== communitySignerAddress) return { valid: false, reason: messages.ERR_CHALLENGE_MSG_SIGNER_IS_NOT_COMMUNITY };
     if ((validateTimestampRange && _minimumTimestamp() > challenge.timestamp) || _maximumTimestamp() < challenge.timestamp)
         return { valid: false, reason: messages.ERR_PUBSUB_MSG_TIMESTAMP_IS_OUTDATED };
 
@@ -846,20 +851,22 @@ export async function verifyChallengeAnswer({
     return _validateSignatureOfPubsubMsg(answer);
 }
 
+// See verifyChallengeMessage: communitySignerAddress, not the pubsub topic (issue #229).
 export async function verifyChallengeVerification({
     verification,
-    pubsubTopic,
+    communitySignerAddress,
     validateTimestampRange
 }: {
     verification: ChallengeVerificationMessageType;
-    pubsubTopic: string;
+    communitySignerAddress: string;
     validateTimestampRange: boolean;
 }): Promise<ValidationResult> {
     if (!_allFieldsOfRecordInSignedPropertyNames(verification))
         return { valid: false, reason: messages.ERR_CHALLENGE_VERIFICATION_INCLUDES_FIELD_NOT_IN_SIGNED_PROPERTY_NAMES };
 
     const msgSignerAddress = await getPKCAddressFromPublicKeyBuffer(verification.signature.publicKey);
-    if (msgSignerAddress !== pubsubTopic) return { valid: false, reason: messages.ERR_CHALLENGE_VERIFICATION_MSG_SIGNER_IS_NOT_COMMUNITY };
+    if (msgSignerAddress !== communitySignerAddress)
+        return { valid: false, reason: messages.ERR_CHALLENGE_VERIFICATION_MSG_SIGNER_IS_NOT_COMMUNITY };
     if ((validateTimestampRange && _minimumTimestamp() > verification.timestamp) || _maximumTimestamp() < verification.timestamp)
         return { valid: false, reason: messages.ERR_PUBSUB_MSG_TIMESTAMP_IS_OUTDATED };
 

--- a/src/signer/signatures.ts
+++ b/src/signer/signatures.ts
@@ -816,25 +816,31 @@ export async function verifyChallengeRequest({
     return _validateSignatureOfPubsubMsg(request);
 }
 
-// communitySignerAddress is the address of the key that signs the community's own records, ie the
-// entity the challenge must have come from. This used to take the pubsubTopic string and only worked
-// because the topic is backfilled to that address; the check has always meant "signed by the
-// community", never "equal to the topic". Decoupled in issue #229, where a read-only community has no
-// topic at all — and it also fixes communities that set a custom pubsubTopic.
+// communityChallengeSignerAddress is the address of the key running the community's challenge
+// exchange, ie the entity the challenge must have come from. Callers derive it from
+// community.encryption.publicKey, which verifyCommunity pins to signature.publicKey. It is an
+// address (the same form as signature.publicKey resolves to), not a base64 public key.
+//
+// This used to take the pubsubTopic string and only worked because the topic is backfilled to that
+// address; the check has always meant "signed by the community", never "equal to the topic".
+// Decoupled in issue #229, where a read-only community has no topic at all — and it also fixes
+// communities that set a custom pubsubTopic. Not named after pubsub: the same check runs on the
+// in-process publish shortcut, which never touches a pubsub topic.
 export async function verifyChallengeMessage({
     challenge,
-    communitySignerAddress,
+    communityChallengeSignerAddress,
     validateTimestampRange
 }: {
     challenge: ChallengeMessageType;
-    communitySignerAddress: string;
+    communityChallengeSignerAddress: string;
     validateTimestampRange: boolean;
 }): Promise<ValidationResult> {
     if (!_allFieldsOfRecordInSignedPropertyNames(challenge))
         return { valid: false, reason: messages.ERR_CHALLENGE_INCLUDES_FIELD_NOT_IN_SIGNED_PROPERTY_NAMES };
 
     const msgSignerAddress = await getPKCAddressFromPublicKeyBuffer(challenge.signature.publicKey);
-    if (msgSignerAddress !== communitySignerAddress) return { valid: false, reason: messages.ERR_CHALLENGE_MSG_SIGNER_IS_NOT_COMMUNITY };
+    if (msgSignerAddress !== communityChallengeSignerAddress)
+        return { valid: false, reason: messages.ERR_CHALLENGE_MSG_SIGNER_IS_NOT_COMMUNITY };
     if ((validateTimestampRange && _minimumTimestamp() > challenge.timestamp) || _maximumTimestamp() < challenge.timestamp)
         return { valid: false, reason: messages.ERR_PUBSUB_MSG_TIMESTAMP_IS_OUTDATED };
 
@@ -860,21 +866,21 @@ export async function verifyChallengeAnswer({
     return _validateSignatureOfPubsubMsg(answer);
 }
 
-// See verifyChallengeMessage: communitySignerAddress, not the pubsub topic (issue #229).
+// See verifyChallengeMessage: the challenge signer's address, not the pubsub topic (issue #229).
 export async function verifyChallengeVerification({
     verification,
-    communitySignerAddress,
+    communityChallengeSignerAddress,
     validateTimestampRange
 }: {
     verification: ChallengeVerificationMessageType;
-    communitySignerAddress: string;
+    communityChallengeSignerAddress: string;
     validateTimestampRange: boolean;
 }): Promise<ValidationResult> {
     if (!_allFieldsOfRecordInSignedPropertyNames(verification))
         return { valid: false, reason: messages.ERR_CHALLENGE_VERIFICATION_INCLUDES_FIELD_NOT_IN_SIGNED_PROPERTY_NAMES };
 
     const msgSignerAddress = await getPKCAddressFromPublicKeyBuffer(verification.signature.publicKey);
-    if (msgSignerAddress !== communitySignerAddress)
+    if (msgSignerAddress !== communityChallengeSignerAddress)
         return { valid: false, reason: messages.ERR_CHALLENGE_VERIFICATION_MSG_SIGNER_IS_NOT_COMMUNITY };
     if ((validateTimestampRange && _minimumTimestamp() > verification.timestamp) || _maximumTimestamp() < verification.timestamp)
         return { valid: false, reason: messages.ERR_PUBSUB_MSG_TIMESTAMP_IS_OUTDATED };

--- a/src/test/test-util.ts
+++ b/src/test/test-util.ts
@@ -1884,7 +1884,8 @@ export async function createStaticCommunityRecordForComment(opts?: {
         const communityRecord = <CommunityIpfsType>{
             ...(await getTemplateCommunityRecord(ipnsObj.pkc)),
             posts: undefined,
-            pubsubTopic: communityAddress
+            pubsubTopic: communityAddress,
+            encryption: encryptionForSigner(ipnsObj.signer)
         };
         if (!communityRecord.posts) delete communityRecord.posts;
         // Always publish a valid record first so the IPNS key is established for gateway discovery

--- a/src/test/test-util.ts
+++ b/src/test/test-util.ts
@@ -1188,8 +1188,7 @@ export async function ensurePublicationIsSigned(
             publicKey: community.signer?.address ?? community.address,
             name: community.name,
             encryption: community.encryption,
-            pubsubTopic: community.pubsubTopic,
-            signerAddress: community.signer?.address ?? community.address
+            pubsubTopic: community.pubsubTopic
         };
         await publication._signPublicationWithCommunityFields();
     }

--- a/src/test/test-util.ts
+++ b/src/test/test-util.ts
@@ -1188,7 +1188,8 @@ export async function ensurePublicationIsSigned(
             publicKey: community.signer?.address ?? community.address,
             name: community.name,
             encryption: community.encryption,
-            pubsubTopic: community.pubsubTopic
+            pubsubTopic: community.pubsubTopic,
+            signerAddress: community.signer?.address ?? community.address
         };
         await publication._signPublicationWithCommunityFields();
     }

--- a/src/test/test-util.ts
+++ b/src/test/test-util.ts
@@ -1776,6 +1776,7 @@ export async function createDelegatedCommunityIpns(
             ...(await getTemplateCommunityRecord(anchor.pkc)),
             posts: undefined,
             pubsubTopic: minter.signer.address,
+            encryption: encryptionForSigner((opts?.contentSigner ?? minter.signer) as { publicKey: string }),
             ...communityOpts
         };
         if (!communityRecord.posts) delete communityRecord.posts;
@@ -1820,6 +1821,7 @@ export async function publishCommunityRecordWithExtraProp(opts?: { includeExtraP
     const ipnsObj = await createNewIpns();
     const communityRecord = JSON.parse(JSON.stringify(await getTemplateCommunityRecord(ipnsObj.pkc)));
     communityRecord.pubsubTopic = ipnsObj.signer.address;
+    communityRecord.encryption = encryptionForSigner(ipnsObj.signer);
     delete communityRecord.posts;
     if (opts?.extraProps) Object.assign(communityRecord, opts.extraProps);
     const signedPropertyNames = communityRecord.signature.signedPropertyNames;
@@ -1836,6 +1838,13 @@ export async function publishCommunityRecordWithExtraProp(opts?: { includeExtraP
     return { communityRecord, ipnsObj };
 }
 
+// getTemplateCommunityRecord clones a live community's record, so its encryption block belongs to
+// that community. verifyCommunity requires encryption.publicKey to match the record signer, so any
+// helper that re-signs the template with its own key must re-derive encryption too.
+export function encryptionForSigner(signer: { publicKey: string }): CommunityIpfsType["encryption"] {
+    return { type: "ed25519-aes-gcm", publicKey: signer.publicKey };
+}
+
 export async function createMockedCommunityIpns(communityOpts: CreateNewLocalCommunityUserOptions) {
     const ipnsObj = await createNewIpns();
     const communityAddress = ipnsObj.signer.address;
@@ -1843,6 +1852,7 @@ export async function createMockedCommunityIpns(communityOpts: CreateNewLocalCom
         ...(await getTemplateCommunityRecord(ipnsObj.pkc)),
         posts: undefined,
         pubsubTopic: communityAddress,
+        encryption: encryptionForSigner(ipnsObj.signer),
         ...communityOpts
     }; // default community, will be using its props
     if (!communityRecord.posts) delete communityRecord.posts;

--- a/src/test/test-util.ts
+++ b/src/test/test-util.ts
@@ -1847,6 +1847,9 @@ export async function createMockedCommunityIpns(communityOpts: CreateNewLocalCom
         ...communityOpts
     }; // default community, will be using its props
     if (!communityRecord.posts) delete communityRecord.posts;
+    // Pass `pubsubTopic: undefined` to mint the record a read-only community publishes (issue #229).
+    // The key must be deleted, not left undefined: _signJson picks signed props by key presence.
+    if (!communityRecord.pubsubTopic) delete communityRecord.pubsubTopic;
 
     communityRecord.signature = await signCommunity({ community: communityRecord, signer: ipnsObj.signer });
     await ipnsObj.publishToIpns(JSON.stringify(communityRecord));

--- a/test/node-and-browser/community/challenge-exchange-disabled.test.ts
+++ b/test/node-and-browser/community/challenge-exchange-disabled.test.ts
@@ -1,0 +1,142 @@
+// Client-side tests for settings.disablePubsubChallengeExchange (issue #229, PR #235).
+//
+// The node side lives in test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts.
+// This file covers the CLIENT side, which is why it runs in the browser too: a reader that loads a
+// record without pubsubTopic must fail fast instead of timing out, so a UI can disable the reply
+// affordance up front. Kind-blind: applies to normal communities and author-communities alike.
+//
+// The record is minted directly rather than by starting a community, so the client behaviour is
+// tested against the wire shape alone, with no live community involved.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+    mockRemotePKC,
+    generateMockPost,
+    createMockedCommunityIpns,
+    resolveWhenConditionIsTrue
+} from "../../../dist/node/test/test-util.js";
+
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { PKCError } from "../../../dist/node/pkc-error.js";
+import type { RemoteCommunity } from "../../../dist/node/community/remote-community.js";
+import type Publication from "../../../dist/node/publications/publication.js";
+
+// `pubsubTopic: undefined` mints the record shape a read-only community publishes
+const readOnlyCommunityOpts: { pubsubTopic: string | undefined } = { pubsubTopic: undefined };
+
+describe("reading a community record with no pubsubTopic", async () => {
+    let pkc: PKCType;
+    let communityAddress: string;
+
+    beforeAll(async () => {
+        pkc = await mockRemotePKC();
+        ({ communityAddress } = await createMockedCommunityIpns(readOnlyCommunityOpts));
+    });
+
+    afterAll(async () => {
+        await pkc.destroy();
+    });
+
+    async function loadCommunity() {
+        const community = <RemoteCommunity>await pkc.createCommunity({ address: communityAddress });
+        await community.update();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+        await community.stop();
+        return community;
+    }
+
+    it("parses the record fine, since pubsubTopic is optional", async () => {
+        const community = await loadCommunity();
+        expect(community.address).to.equal(communityAddress);
+        expect(community.raw.communityIpfs).to.exist;
+        expect(community.encryption).to.exist;
+    });
+
+    it("treats the absence of pubsubTopic as disabled, not as an address fallback", async () => {
+        const community = await loadCommunity();
+        expect(community.pubsubTopic).to.be.undefined;
+        // no challenge-topic routing CID may be derived from the address either
+        expect(community.pubsubTopicRoutingCid).to.be.undefined;
+    });
+
+    it("exposes the disabled state on the loaded instance so a client can branch before publishing", async () => {
+        const community = await loadCommunity();
+        // `pubsubTopic === undefined` IS the public signal; a client disables its reply UI on it
+        expect(community.raw.communityIpfs!.pubsubTopic).to.be.undefined;
+        expect("pubsubTopic" in community.raw.communityIpfs!).to.be.false;
+    });
+});
+
+describe("publishing to a community with the exchange disabled", async () => {
+    let pkc: PKCType;
+    let communityAddress: string;
+
+    beforeAll(async () => {
+        pkc = await mockRemotePKC();
+        ({ communityAddress } = await createMockedCommunityIpns(readOnlyCommunityOpts));
+    });
+
+    afterAll(async () => {
+        await pkc.destroy();
+    });
+
+    async function expectFailFast(publication: Publication) {
+        let error: PKCError | undefined;
+        try {
+            await publication.publish();
+        } catch (e) {
+            error = <PKCError>e;
+        }
+        expect(error, "publish() should have thrown").to.exist;
+        expect(error!.code).to.equal("ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED");
+        return error!;
+    }
+
+    it("publish() fails fast with ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED", async () => {
+        const post = await generateMockPost({ communityAddress, pkc });
+        await expectFailFast(post);
+        expect(post.publishingState).to.equal("failed");
+    });
+
+    it("the error surfaces before any pubsub subscription is attempted", async () => {
+        const post = await generateMockPost({ communityAddress, pkc });
+        await expectFailFast(post);
+        const subscribedTopics = Object.values(pkc._clientsManager.pubsubProviderSubscriptions).flat();
+        expect(subscribedTopics).to.not.include(communityAddress);
+    });
+
+    it("the publisher never falls back to the community address as a challenge-exchange topic", async () => {
+        const post = await generateMockPost({ communityAddress, pkc });
+        await expectFailFast(post);
+        expect(post._community!.pubsubTopic).to.be.undefined;
+        // the community address must not have been repurposed as a topic anywhere in the exchange
+        expect(Object.keys(post._challengeExchanges)).to.be.empty;
+    });
+
+    it("the same fast-fail applies to a vote", async () => {
+        const vote = await pkc.createVote({
+            communityAddress,
+            commentCid: "QmUFu8fzuT1th3jMYc2ycbPktLKgWmVSD3xKmpvjs3ejMR",
+            vote: 1,
+            signer: await pkc.createSigner()
+        });
+        await expectFailFast(vote);
+    });
+
+    it("the same fast-fail applies to a CommentEdit", async () => {
+        const commentEdit = await pkc.createCommentEdit({
+            communityAddress,
+            commentCid: "QmUFu8fzuT1th3jMYc2ycbPktLKgWmVSD3xKmpvjs3ejMR",
+            content: "edited content",
+            signer: await pkc.createSigner()
+        });
+        await expectFailFast(commentEdit);
+    });
+
+    it("the error is non-retriable, distinct from an unreachable-community timeout", async () => {
+        const post = await generateMockPost({ communityAddress, pkc });
+        const error = await expectFailFast(post);
+        // an unreachable community surfaces as a pubsub timeout after the provider loop; this must not
+        expect(error.code).to.not.equal("ERR_PUBSUB_DID_NOT_RECEIVE_RESPONSE_AFTER_PUBLISHING_CHALLENGE_REQUEST");
+        expect(error.code).to.not.equal("ERR_ALL_PUBSUB_PROVIDERS_THROW_ERRORS");
+    });
+});

--- a/test/node-and-browser/community/challenge-exchange-disabled.test.ts
+++ b/test/node-and-browser/community/challenge-exchange-disabled.test.ts
@@ -12,7 +12,8 @@ import {
     mockRemotePKC,
     generateMockPost,
     createMockedCommunityIpns,
-    resolveWhenConditionIsTrue
+    resolveWhenConditionIsTrue,
+    isRpcFlagOn
 } from "../../../dist/node/test/test-util.js";
 
 import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
@@ -79,16 +80,23 @@ describe("publishing to a community with the exchange disabled", async () => {
         await pkc.destroy();
     });
 
+    // publish() rejects on the direct path, but an RPC client's publish() resolves as soon as the
+    // server accepts the request: the server owns the community lookup (it may be the one running the
+    // community, in which case the local shortcut applies and publishing legitimately succeeds), so a
+    // disabled exchange can only be reported afterwards, as an `error` event on the subscription.
+    // Either way the client must end up with the same error code and a failed publishingState.
     async function expectFailFast(publication: Publication) {
-        let error: PKCError | undefined;
+        const emittedError = new Promise<PKCError>((resolve) => publication.once("error", (e) => resolve(<PKCError>e)));
+        let thrownError: PKCError | undefined;
         try {
             await publication.publish();
         } catch (e) {
-            error = <PKCError>e;
+            thrownError = <PKCError>e;
         }
-        expect(error, "publish() should have thrown").to.exist;
-        expect(error!.code).to.equal("ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED");
-        return error!;
+        if (!isRpcFlagOn()) expect(thrownError, "publish() should have thrown").to.exist;
+        const error = thrownError ?? (await emittedError);
+        expect(error.code).to.equal("ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED");
+        return error;
     }
 
     it("publish() fails fast with ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED", async () => {

--- a/test/node-and-browser/community/nameresolvers.clients.test.ts
+++ b/test/node-and-browser/community/nameresolvers.clients.test.ts
@@ -1,6 +1,12 @@
 import signers from "../../fixtures/signers.js";
 
-import { createMockNameResolver, processAllCommentsRecursively, mockPKCV2, createNewIpns } from "../../../dist/node/test/test-util.js";
+import {
+    createMockNameResolver,
+    processAllCommentsRecursively,
+    mockPKCV2,
+    createNewIpns,
+    encryptionForSigner
+} from "../../../dist/node/test/test-util.js";
 import { signCommunity } from "../../../dist/node/signer/signatures.js";
 import { it, expect } from "vitest";
 import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
@@ -171,7 +177,10 @@ async function createCommunityFixtureWithDomainAuthors() {
                 hot: { comments: pageComments }
             }
         },
-        pubsubTopic: communityAddress
+        pubsubTopic: communityAddress,
+        // the template's encryption belongs to the template's key; verifyCommunity requires it to
+        // match whoever signs the record
+        encryption: encryptionForSigner(ipnsObj.signer)
     };
 
     communityRecord.signature = await signCommunity({ community: communityRecord, signer: ipnsObj.signer });

--- a/test/node-and-browser/community/rpc.clients.test.ts
+++ b/test/node-and-browser/community/rpc.clients.test.ts
@@ -1,6 +1,11 @@
 import signers from "../../fixtures/signers.js";
 
-import { createNewIpns, resolveWhenConditionIsTrue, getAvailablePKCConfigsToTestAgainst } from "../../../dist/node/test/test-util.js";
+import {
+    createNewIpns,
+    resolveWhenConditionIsTrue,
+    getAvailablePKCConfigsToTestAgainst,
+    encryptionForSigner
+} from "../../../dist/node/test/test-util.js";
 
 import { signCommunity } from "../../../dist/node/signer/signatures.js";
 
@@ -32,6 +37,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-pkc-rpc"] 
 
             const record: Record<string, unknown> = JSON.parse(JSON.stringify(actualCommunity.raw.communityIpfs));
             delete record["posts"];
+            record.encryption = encryptionForSigner(newIpns.signer);
             record.signature = await signCommunity({
                 community: record as Parameters<typeof signCommunity>[0]["community"],
                 signer: newIpns.signer

--- a/test/node-and-browser/publications/comment/clients/libp2pjsClient.pubsubKuboRpcClients.clients.test.ts
+++ b/test/node-and-browser/publications/comment/clients/libp2pjsClient.pubsubKuboRpcClients.clients.test.ts
@@ -9,7 +9,6 @@ import {
     mockPKCV2
 } from "../../../../../dist/node/test/test-util.js";
 import { createMockPubsubClient } from "../../../../../dist/node/test/mock-ipfs-client.js";
-import { getPKCAddressFromPublicKeySync } from "../../../../../dist/node/signer/util.js";
 import type { PKC } from "../../../../../dist/node/pkc/pkc.js";
 import type { PKCError } from "../../../../../dist/node/pkc-error.js";
 import type { Comment } from "../../../../../dist/node/publications/comment/comment.js";
@@ -82,8 +81,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: community.address,
                     publicKey: community.publicKey!,
                     encryption: ipfs.encryption,
-                    pubsubTopic: ipfs.pubsubTopic,
-                    signerAddress: getPKCAddressFromPublicKeySync(ipfs.signature.publicKey)
+                    pubsubTopic: ipfs.pubsubTopic
                 };
             }; // so libp2pjs client state won't include fetching community states
             await publishWithExpectedResult({ publication: mockPost, expectedChallengeSuccess: true });

--- a/test/node-and-browser/publications/comment/clients/libp2pjsClient.pubsubKuboRpcClients.clients.test.ts
+++ b/test/node-and-browser/publications/comment/clients/libp2pjsClient.pubsubKuboRpcClients.clients.test.ts
@@ -9,6 +9,7 @@ import {
     mockPKCV2
 } from "../../../../../dist/node/test/test-util.js";
 import { createMockPubsubClient } from "../../../../../dist/node/test/mock-ipfs-client.js";
+import { getPKCAddressFromPublicKeySync } from "../../../../../dist/node/signer/util.js";
 import type { PKC } from "../../../../../dist/node/pkc/pkc.js";
 import type { PKCError } from "../../../../../dist/node/pkc-error.js";
 import type { Comment } from "../../../../../dist/node/publications/comment/comment.js";
@@ -81,7 +82,8 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: community.address,
                     publicKey: community.publicKey!,
                     encryption: ipfs.encryption,
-                    pubsubTopic: ipfs.pubsubTopic
+                    pubsubTopic: ipfs.pubsubTopic,
+                    signerAddress: getPKCAddressFromPublicKeySync(ipfs.signature.publicKey)
                 };
             }; // so libp2pjs client state won't include fetching community states
             await publishWithExpectedResult({ publication: mockPost, expectedChallengeSuccess: true });

--- a/test/node-and-browser/publications/comment/publish/pubsub.test.ts
+++ b/test/node-and-browser/publications/comment/publish/pubsub.test.ts
@@ -15,7 +15,7 @@ import type { PKC } from "../../../../../dist/node/pkc/pkc.js";
 type CommentWithInternals = {
     _publishToDifferentProviderThresholdSeconds: number;
     _setProviderFailureThresholdSeconds: number;
-    _communityChallengeExchangeTopic: () => string;
+    _communityChallengePubsubExchangeTopic: () => string;
     _clientsManager: PKCClientManager;
     _challengeExchanges: unknown[];
 };
@@ -103,7 +103,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc"]
 
                 await validateKuboRpcNotListeningToPubsubTopic(
                     testPKC,
-                    (mockPost as unknown as CommentWithInternals)._communityChallengeExchangeTopic()
+                    (mockPost as unknown as CommentWithInternals)._communityChallengePubsubExchangeTopic()
                 );
 
                 await testPKC.destroy();
@@ -144,7 +144,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc"]
 
             await validateKuboRpcNotListeningToPubsubTopic(
                 testPKC,
-                (mockPost as unknown as CommentWithInternals)._communityChallengeExchangeTopic()
+                (mockPost as unknown as CommentWithInternals)._communityChallengePubsubExchangeTopic()
             );
 
             await testPKC.destroy();
@@ -207,7 +207,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc"]
                 expect(challengeRequestCount).to.be.at.most(2);
 
                 // Verify pubsub subscription handlers are cleaned up after successful publication
-                const pubsubTopic = (mockPost as unknown as CommentWithInternals)._communityChallengeExchangeTopic();
+                const pubsubTopic = (mockPost as unknown as CommentWithInternals)._communityChallengePubsubExchangeTopic();
                 expect(pubsubTopic).to.be.a("string");
 
                 // Check both providers for subscription cleanup using the correct access pattern

--- a/test/node-and-browser/publications/comment/publish/pubsub.test.ts
+++ b/test/node-and-browser/publications/comment/publish/pubsub.test.ts
@@ -15,7 +15,7 @@ import type { PKC } from "../../../../../dist/node/pkc/pkc.js";
 type CommentWithInternals = {
     _publishToDifferentProviderThresholdSeconds: number;
     _setProviderFailureThresholdSeconds: number;
-    _communityPubsubTopicWithFallback: () => string;
+    _communityChallengeExchangeTopic: () => string;
     _clientsManager: PKCClientManager;
     _challengeExchanges: unknown[];
 };
@@ -103,7 +103,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc"]
 
                 await validateKuboRpcNotListeningToPubsubTopic(
                     testPKC,
-                    (mockPost as unknown as CommentWithInternals)._communityPubsubTopicWithFallback()
+                    (mockPost as unknown as CommentWithInternals)._communityChallengeExchangeTopic()
                 );
 
                 await testPKC.destroy();
@@ -144,7 +144,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc"]
 
             await validateKuboRpcNotListeningToPubsubTopic(
                 testPKC,
-                (mockPost as unknown as CommentWithInternals)._communityPubsubTopicWithFallback()
+                (mockPost as unknown as CommentWithInternals)._communityChallengeExchangeTopic()
             );
 
             await testPKC.destroy();
@@ -207,7 +207,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc"]
                 expect(challengeRequestCount).to.be.at.most(2);
 
                 // Verify pubsub subscription handlers are cleaned up after successful publication
-                const pubsubTopic = (mockPost as unknown as CommentWithInternals)._communityPubsubTopicWithFallback();
+                const pubsubTopic = (mockPost as unknown as CommentWithInternals)._communityChallengeExchangeTopic();
                 expect(pubsubTopic).to.be.a("string");
 
                 // Check both providers for subscription cleanup using the correct access pattern

--- a/test/node-and-browser/pubsub-msgs/backward.compatibility.pubsub.test.ts
+++ b/test/node-and-browser/pubsub-msgs/backward.compatibility.pubsub.test.ts
@@ -115,6 +115,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: post.communityAddress,
                     publicKey: pubsubSigner.publicKey,
                     pubsubTopic: pubsubSigner.address,
+                    signerAddress: pubsubSigner.address,
                     encryption: {
                         type: "ed25519-aes-gcm",
                         publicKey: pubsubSigner.publicKey
@@ -151,6 +152,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: post.communityAddress,
                     publicKey: pubsubSigner.publicKey,
                     pubsubTopic: pubsubSigner.address,
+                    signerAddress: pubsubSigner.address,
                     encryption: {
                         type: "ed25519-aes-gcm",
                         publicKey: pubsubSigner.publicKey
@@ -237,6 +239,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: post.communityAddress,
                     publicKey: pubsubSigner.publicKey,
                     pubsubTopic: pubsubSigner.address,
+                    signerAddress: pubsubSigner.address,
                     encryption: {
                         type: "ed25519-aes-gcm",
                         publicKey: pubsubSigner.publicKey
@@ -273,6 +276,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: post.communityAddress,
                     publicKey: pubsubSigner.publicKey,
                     pubsubTopic: pubsubSigner.address,
+                    signerAddress: pubsubSigner.address,
                     encryption: {
                         type: "ed25519-aes-gcm",
                         publicKey: pubsubSigner.publicKey
@@ -306,6 +310,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: post.communityAddress,
                     publicKey: pubsubSigner.publicKey,
                     pubsubTopic: pubsubSigner.address,
+                    signerAddress: pubsubSigner.address,
                     encryption: {
                         type: "ed25519-aes-gcm",
                         publicKey: pubsubSigner.publicKey

--- a/test/node-and-browser/pubsub-msgs/backward.compatibility.pubsub.test.ts
+++ b/test/node-and-browser/pubsub-msgs/backward.compatibility.pubsub.test.ts
@@ -115,7 +115,6 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: post.communityAddress,
                     publicKey: pubsubSigner.publicKey,
                     pubsubTopic: pubsubSigner.address,
-                    signerAddress: pubsubSigner.address,
                     encryption: {
                         type: "ed25519-aes-gcm",
                         publicKey: pubsubSigner.publicKey
@@ -152,7 +151,6 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: post.communityAddress,
                     publicKey: pubsubSigner.publicKey,
                     pubsubTopic: pubsubSigner.address,
-                    signerAddress: pubsubSigner.address,
                     encryption: {
                         type: "ed25519-aes-gcm",
                         publicKey: pubsubSigner.publicKey
@@ -239,7 +237,6 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: post.communityAddress,
                     publicKey: pubsubSigner.publicKey,
                     pubsubTopic: pubsubSigner.address,
-                    signerAddress: pubsubSigner.address,
                     encryption: {
                         type: "ed25519-aes-gcm",
                         publicKey: pubsubSigner.publicKey
@@ -276,7 +273,6 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: post.communityAddress,
                     publicKey: pubsubSigner.publicKey,
                     pubsubTopic: pubsubSigner.address,
-                    signerAddress: pubsubSigner.address,
                     encryption: {
                         type: "ed25519-aes-gcm",
                         publicKey: pubsubSigner.publicKey
@@ -310,7 +306,6 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                     address: post.communityAddress,
                     publicKey: pubsubSigner.publicKey,
                     pubsubTopic: pubsubSigner.address,
-                    signerAddress: pubsubSigner.address,
                     encryption: {
                         type: "ed25519-aes-gcm",
                         publicKey: pubsubSigner.publicKey

--- a/test/node-and-browser/signatures/community.test.ts
+++ b/test/node-and-browser/signatures/community.test.ts
@@ -138,6 +138,44 @@ describeSkipIfRpc.concurrent("Verify community", async () => {
         ).to.deep.equal({ valid: true });
     });
 
+    // encryption.publicKey names the key that decrypts challenge requests and therefore signs the
+    // community's CHALLENGE/CHALLENGEVERIFICATION. Unlike signature.publicKey it is not anchored to
+    // the IPNS name by itself, so it must be pinned to the record signer or a record could delegate
+    // the challenge exchange to a key the reader never validated against the address it typed.
+    it(`Community with encryption.publicKey that doesn't match signature.publicKey is invalidated`, async () => {
+        const community = clone(validCommunityFixture) as CommunityIpfsType;
+        community.encryption = { ...community.encryption, publicKey: signers[1].publicKey };
+        // re-sign so the record is otherwise valid, otherwise this would fail on the signature check
+        // first and the test would prove nothing about the encryption check
+        community.signature = (await _signJson(
+            community.signature.signedPropertyNames,
+            community,
+            signers[0],
+            log
+        )) as CommunityIpfsType["signature"];
+
+        expect(
+            await verifyCommunity({
+                community: community,
+                communityIpnsName: signers[0].address,
+                resolveAuthorNames: pkc.resolveAuthorNames,
+                clientsManager: pkc._clientsManager,
+                validatePages: false,
+                cacheIfValid: false
+            })
+        ).to.deep.equal({
+            valid: false,
+            reason: messages.ERR_COMMUNITY_ENCRYPTION_PUBLIC_KEY_DOES_NOT_MATCH_SIGNATURE_PUBLIC_KEY
+        });
+    });
+
+    it(`Every community fixture satisfies encryption.publicKey === signature.publicKey`, () => {
+        for (const fixture of [validCommunityFixture, newFormatFixture, newFormatWithNameFixture]) {
+            const community = fixture as unknown as CommunityIpfsType;
+            expect(community.encryption.publicKey).to.equal(community.signature.publicKey);
+        }
+    });
+
     it(`Old-format fixture with address in signedPropertyNames still verifies`, async () => {
         const community = clone(validCommunityFixture) as CommunityIpfsType;
         expect(community.signature.signedPropertyNames).to.include("address");

--- a/test/node-and-browser/signatures/pubsub.messages.test.ts
+++ b/test/node-and-browser/signatures/pubsub.messages.test.ts
@@ -276,7 +276,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             const challenge = parsePubsubMsgFixture(clone(validChallengeFixture)) as unknown as ChallengeMessageType;
             const verificaiton = await verifyChallengeMessage({
                 challenge,
-                communitySignerAddress: "12D3KooWANwdyPERMQaCgiMnTT1t3Lr4XLFbK1z4ptFVhW2ozg1z",
+                communityChallengeSignerAddress: "12D3KooWANwdyPERMQaCgiMnTT1t3Lr4XLFbK1z4ptFVhW2ozg1z",
                 validateTimestampRange: false
             });
             expect(verificaiton).to.deep.equal({ valid: true });
@@ -287,7 +287,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             challenge.timestamp -= 1234; // Should invalidate signature
             const verificaiton = await verifyChallengeMessage({
                 challenge,
-                communitySignerAddress: "12D3KooWANwdyPERMQaCgiMnTT1t3Lr4XLFbK1z4ptFVhW2ozg1z",
+                communityChallengeSignerAddress: "12D3KooWANwdyPERMQaCgiMnTT1t3Lr4XLFbK1z4ptFVhW2ozg1z",
                 validateTimestampRange: false
             });
             expect(verificaiton).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });
@@ -297,7 +297,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             const challenge = parsePubsubMsgFixture(clone(validChallengeFixture)) as unknown as ChallengeMessageType;
             const verificaiton = await verifyChallengeMessage({
                 challenge,
-                communitySignerAddress: (await pkc.createSigner()).address,
+                communityChallengeSignerAddress: (await pkc.createSigner()).address,
                 validateTimestampRange: false
             }); // Random signer, not the community
             expect(verificaiton).to.deep.equal({ valid: false, reason: messages.ERR_CHALLENGE_MSG_SIGNER_IS_NOT_COMMUNITY });
@@ -318,7 +318,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
 
             const verification = await verifyChallengeMessage({
                 challenge: challengePubsubMsgNoExtraProps,
-                communitySignerAddress: mathCliCommunityAddress,
+                communityChallengeSignerAddress: mathCliCommunityAddress,
                 validateTimestampRange: false
             });
             expect(verification).to.deep.equal({ valid: true });
@@ -551,7 +551,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             ) as unknown as ChallengeVerificationMessageType;
             const verificaiton = await verifyChallengeVerification({
                 verification: challengeVerification,
-                communitySignerAddress: signers[0].address,
+                communityChallengeSignerAddress: signers[0].address,
                 validateTimestampRange: false
             });
             expect(verificaiton).to.deep.equal({ valid: true });
@@ -570,7 +570,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             const challengeVerificationNoExtraProps = omit(challengeVerification, ["comment", "commentUpdate"]);
             const verification = await verifyChallengeVerification({
                 verification: challengeVerificationNoExtraProps,
-                communitySignerAddress: signers[0].address,
+                communityChallengeSignerAddress: signers[0].address,
                 validateTimestampRange: false
             });
             expect(verification).to.deep.equal({ valid: true });
@@ -582,7 +582,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             challengeVerification.timestamp -= 1234; // Invalidate signature
             const verificaiton = await verifyChallengeVerification({
                 verification: challengeVerification,
-                communitySignerAddress: signers[0].address,
+                communityChallengeSignerAddress: signers[0].address,
                 validateTimestampRange: false
             });
             expect(verificaiton).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });

--- a/test/node-and-browser/signatures/pubsub.messages.test.ts
+++ b/test/node-and-browser/signatures/pubsub.messages.test.ts
@@ -276,7 +276,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             const challenge = parsePubsubMsgFixture(clone(validChallengeFixture)) as unknown as ChallengeMessageType;
             const verificaiton = await verifyChallengeMessage({
                 challenge,
-                pubsubTopic: "12D3KooWANwdyPERMQaCgiMnTT1t3Lr4XLFbK1z4ptFVhW2ozg1z",
+                communitySignerAddress: "12D3KooWANwdyPERMQaCgiMnTT1t3Lr4XLFbK1z4ptFVhW2ozg1z",
                 validateTimestampRange: false
             });
             expect(verificaiton).to.deep.equal({ valid: true });
@@ -287,19 +287,19 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             challenge.timestamp -= 1234; // Should invalidate signature
             const verificaiton = await verifyChallengeMessage({
                 challenge,
-                pubsubTopic: "12D3KooWANwdyPERMQaCgiMnTT1t3Lr4XLFbK1z4ptFVhW2ozg1z",
+                communitySignerAddress: "12D3KooWANwdyPERMQaCgiMnTT1t3Lr4XLFbK1z4ptFVhW2ozg1z",
                 validateTimestampRange: false
             });
             expect(verificaiton).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });
         });
 
-        it(`challenge message signed by other than community.pubsubTopic is invalidated`, async () => {
+        it(`challenge message signed by other than the community signer is invalidated`, async () => {
             const challenge = parsePubsubMsgFixture(clone(validChallengeFixture)) as unknown as ChallengeMessageType;
             const verificaiton = await verifyChallengeMessage({
                 challenge,
-                pubsubTopic: (await pkc.createSigner()).address,
+                communitySignerAddress: (await pkc.createSigner()).address,
                 validateTimestampRange: false
-            }); // Random pubsub topic
+            }); // Random signer, not the community
             expect(verificaiton).to.deep.equal({ valid: false, reason: messages.ERR_CHALLENGE_MSG_SIGNER_IS_NOT_COMMUNITY });
         });
         it(`Valid live challengemessage gets validated correctly`, async () => {
@@ -318,7 +318,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
 
             const verification = await verifyChallengeMessage({
                 challenge: challengePubsubMsgNoExtraProps,
-                pubsubTopic: mathCliCommunityAddress,
+                communitySignerAddress: mathCliCommunityAddress,
                 validateTimestampRange: false
             });
             expect(verification).to.deep.equal({ valid: true });
@@ -551,7 +551,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             ) as unknown as ChallengeVerificationMessageType;
             const verificaiton = await verifyChallengeVerification({
                 verification: challengeVerification,
-                pubsubTopic: signers[0].address,
+                communitySignerAddress: signers[0].address,
                 validateTimestampRange: false
             });
             expect(verificaiton).to.deep.equal({ valid: true });
@@ -570,7 +570,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             const challengeVerificationNoExtraProps = omit(challengeVerification, ["comment", "commentUpdate"]);
             const verification = await verifyChallengeVerification({
                 verification: challengeVerificationNoExtraProps,
-                pubsubTopic: signers[0].address,
+                communitySignerAddress: signers[0].address,
                 validateTimestampRange: false
             });
             expect(verification).to.deep.equal({ valid: true });
@@ -582,7 +582,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             challengeVerification.timestamp -= 1234; // Invalidate signature
             const verificaiton = await verifyChallengeVerification({
                 verification: challengeVerification,
-                pubsubTopic: signers[0].address,
+                communitySignerAddress: signers[0].address,
                 validateTimestampRange: false
             });
             expect(verificaiton).to.deep.equal({ valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID });

--- a/test/node/community/garbage.collection.community.test.ts
+++ b/test/node/community/garbage.collection.community.test.ts
@@ -355,7 +355,20 @@ describe("local community garbage collection", () => {
 
         await community.delete();
 
-        const expectedCids = ["QmPostsPage", "QmReplyPage", "QmComment1", "QmComment2", "QmUpdateCid", "QmStatsCid"];
+        const expectedCids = [
+            "QmPostsPage",
+            "QmReplyPage",
+            "QmComment1",
+            "QmComment2",
+            "QmUpdateCid",
+            "QmStatsCid",
+            // delete() also unpins the routing block of the CONFIGURED challenge topic, derived here
+            // rather than read off pubsubTopicRoutingCid: that field only names the topic of the last
+            // published record, so it misses a community whose exchange is disabled (issue #229) or
+            // whose topic changed after the last publish. This fixture has no pubsubTopic, so the
+            // configured topic is the signer address.
+            util.pubsubTopicToDhtKey(community.signer.address)
+        ];
         expect(new Set(pinRmCalls)).to.deep.equal(new Set(expectedCids));
         expect(community._cidsToUnPin.size).to.equal(0);
         expect(removeMfsSpy.mock.calls[0][0].paths).to.deep.equal([`/${community.address}`]);

--- a/test/node/community/local-community/comment-updates.test.ts
+++ b/test/node/community/local-community/comment-updates.test.ts
@@ -1,5 +1,5 @@
 // Unit tests for src/runtime/node/community/local-community/comment-updates.ts.
-// pubsubTopicWithfallback and calculateLocalMfsPathForCommentUpdate are pure;
+// communityChallengePubsubTopic and calculateLocalMfsPathForCommentUpdate are pure;
 // the orchestrators (calculateNewCommentUpdate, syncPostUpdatesWithIpfs,
 // updateCommentsThatNeedToBeUpdated, adjustPostUpdatesBucketsIfNeeded) chain DB +
 // IPFS + signing + page generation and are exercised end-to-end by the
@@ -10,27 +10,46 @@ import {
     adjustPostUpdatesBucketsIfNeeded,
     calculateLocalMfsPathForCommentUpdate,
     calculateNewCommentUpdate,
-    pubsubTopicWithfallback,
+    communityChallengePubsubTopic,
     syncPostUpdatesWithIpfs,
     updateCommentsThatNeedToBeUpdated,
     validateCommentUpdateSignature
 } from "../../../../dist/node/runtime/node/community/local-community/comment-updates.js";
 import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
 
-describe("comment-updates: pubsubTopicWithfallback", () => {
+// Since issue #229 the fallback is the signer address, never community.address: a record without
+// pubsubTopic means the challenge exchange is disabled, so the address must not stand in for a topic.
+describe("comment-updates: communityChallengePubsubTopic", () => {
     it("prefers community.pubsubTopic when set", () => {
-        const community = { pubsubTopic: "explicit-topic", address: "fallback.bso" } as unknown as LocalCommunity;
-        expect(pubsubTopicWithfallback(community)).to.equal("explicit-topic");
+        const community = {
+            pubsubTopic: "explicit-topic",
+            address: "fallback.bso",
+            signer: { address: "signer-address" }
+        } as unknown as LocalCommunity;
+        expect(communityChallengePubsubTopic(community)).to.equal("explicit-topic");
     });
 
-    it("falls back to community.address when pubsubTopic is undefined", () => {
-        const community = { pubsubTopic: undefined, address: "fallback.bso" } as unknown as LocalCommunity;
-        expect(pubsubTopicWithfallback(community)).to.equal("fallback.bso");
+    it("falls back to the signer address when pubsubTopic is undefined", () => {
+        const community = {
+            pubsubTopic: undefined,
+            address: "fallback.bso",
+            signer: { address: "signer-address" }
+        } as unknown as LocalCommunity;
+        expect(communityChallengePubsubTopic(community)).to.equal("signer-address");
     });
 
-    it("falls back to community.address when pubsubTopic is an empty string", () => {
-        const community = { pubsubTopic: "", address: "fallback.bso" } as unknown as LocalCommunity;
-        expect(pubsubTopicWithfallback(community)).to.equal("fallback.bso");
+    it("falls back to the signer address when pubsubTopic is an empty string", () => {
+        const community = {
+            pubsubTopic: "",
+            address: "fallback.bso",
+            signer: { address: "signer-address" }
+        } as unknown as LocalCommunity;
+        expect(communityChallengePubsubTopic(community)).to.equal("signer-address");
+    });
+
+    it("returns undefined when there is neither a topic nor a signer", () => {
+        const community = { pubsubTopic: undefined, address: "fallback.bso", signer: undefined } as unknown as LocalCommunity;
+        expect(communityChallengePubsubTopic(community)).to.be.undefined;
     });
 });
 

--- a/test/node/community/local-community/custom-pubsub-topic.test.ts
+++ b/test/node/community/local-community/custom-pubsub-topic.test.ts
@@ -1,0 +1,308 @@
+// A community may run its challenge exchange on a pubsubTopic that is not its signer address.
+// Nothing exercised that before issue #229: verification used to compare the challenge signer to the
+// topic string, so a custom topic broke every exchange, and the topic-vs-setting interaction
+// (issue #229 made an absent topic MEAN "disabled") has its own edge cases on top.
+//
+// Record-and-instance assertions run under both flavours; assertions that read the kubo node's own
+// subscription list are itSkipIfRpc, since an RPC client has no kubo client of its own.
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import {
+    mockPKC,
+    mockRemotePKC,
+    generateMockPost,
+    publishWithExpectedResult,
+    resolveWhenConditionIsTrue,
+    isRpcFlagOn
+} from "../../../../dist/node/test/test-util.js";
+import { pubsubTopicToDhtKey } from "../../../../dist/node/util.js";
+import { describeSkipIfRpc, itSkipIfRpc } from "../../../helpers/conditional-tests.js";
+
+import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+
+async function listSubscribedTopics(community: LocalCommunity) {
+    return community._clientsManager.getDefaultKuboPubsubClient()._client.pubsub.ls();
+}
+
+async function waitTillCommunityPublishedRecord(community: LocalCommunity) {
+    await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+}
+
+async function waitTillRecordPubsubTopicIs(community: LocalCommunity, expectedTopic: string | undefined) {
+    await resolveWhenConditionIsTrue({
+        toUpdate: community,
+        predicate: async () => community.raw.communityIpfs?.pubsubTopic === expectedTopic
+    });
+}
+
+describe("a community with a custom pubsubTopic", async () => {
+    const customTopic = "custom-topic-enabled-229";
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = <LocalCommunity>await pkc.createCommunity({ pubsubTopic: customTopic, settings: { challenges: [] } });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("keeps the custom topic on the instance and in the record", () => {
+        expect(community.pubsubTopic).to.equal(customTopic);
+        expect(community.raw.communityIpfs!.pubsubTopic).to.equal(customTopic);
+        // the backfill must not have overwritten it with the signer address
+        expect(community.pubsubTopic).to.not.equal(community.signer.address);
+    });
+
+    it("advertises a routing CID derived from the custom topic, not from the address", () => {
+        expect(community.pubsubTopicRoutingCid).to.equal(pubsubTopicToDhtKey(customTopic));
+        expect(community.pubsubTopicRoutingCid).to.not.equal(pubsubTopicToDhtKey(community.address));
+    });
+
+    // Reads the kubo node's subscription list, which an RPC client cannot do
+    itSkipIfRpc("subscribes to the custom topic and to neither the signer address nor the address", async () => {
+        const topics = await listSubscribedTopics(community);
+        expect(topics).to.include(customTopic);
+        expect(topics).to.not.include(community.signer.address);
+        expect(topics).to.not.include(community.address);
+    });
+});
+
+// The regression this PR's signer decoupling actually fixes. Before issue #229 verifyChallengeMessage
+// compared the challenge signer's address to the pubsubTopic string, so a community on a custom topic
+// had every CHALLENGE rejected with ERR_CHALLENGE_MSG_SIGNER_IS_NOT_COMMUNITY and no publication could
+// ever complete. Needs a publisher without the community, so it cannot run over RPC: both clients
+// would share the server that runs the community and take the local shortcut, which never verifies a
+// pubsub signature.
+describeSkipIfRpc("publishing over pubsub to a community on a custom topic", async () => {
+    const customTopic = "custom-topic-publish-229";
+    let ownerPkc: PKCType;
+    let readerPkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        ownerPkc = await mockPKC();
+        community = <LocalCommunity>await ownerPkc.createCommunity({ pubsubTopic: customTopic, settings: { challenges: [] } });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+        readerPkc = await mockRemotePKC();
+    });
+
+    afterAll(async () => {
+        await readerPkc.destroy();
+        await community.delete();
+        await ownerPkc.destroy();
+    });
+
+    it("a remote publisher completes the challenge exchange on the custom topic", async () => {
+        const post = await generateMockPost({ communityAddress: community.address, pkc: readerPkc });
+        // Spy on the publication's OWN clients manager: every publication constructs its own, so the
+        // PKC-level pubsubProviderSubscriptions map never sees a publication's subscriptions. Recording
+        // the calls also beats reading the map afterwards, since a finished publication unsubscribes.
+        const subscribeSpy = vi.spyOn(post._clientsManager, "pubsubSubscribeOnProvider");
+        try {
+            await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+
+            expect(post.cid).to.be.a("string");
+            // the exchange ran on the custom topic, and the publisher never fell back to an address
+            const subscribedTopics = subscribeSpy.mock.calls.map((call) => call[0]);
+            expect(subscribedTopics).to.include(customTopic);
+            expect(subscribedTopics).to.not.include(community.address);
+            expect(subscribedTopics).to.not.include(community.signer.address);
+        } finally {
+            subscribeSpy.mockRestore();
+        }
+    });
+});
+
+describe("a custom pubsubTopic with the exchange disabled", async () => {
+    const customTopic = "custom-topic-disabled-229";
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = <LocalCommunity>await pkc.createCommunity({
+            pubsubTopic: customTopic,
+            settings: { disablePubsubChallengeExchange: true, challenges: [] }
+        });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("publishes a record without pubsubTopic even though a custom topic is configured", () => {
+        expect(community.raw.communityIpfs!.pubsubTopic).to.be.undefined;
+        expect("pubsubTopic" in community.raw.communityIpfs!).to.be.false;
+        expect(community.pubsubTopicRoutingCid).to.be.undefined;
+    });
+
+    // The configured-but-unpublished topic is not part of what the RPC surface transmits
+    itSkipIfRpc("keeps the custom topic on the instance so it survives the disable", () => {
+        expect(community.pubsubTopic).to.equal(customTopic);
+    });
+
+    itSkipIfRpc("never subscribes to the custom topic", async () => {
+        expect(await listSubscribedTopics(community)).to.not.include(customTopic);
+    });
+
+    it("re-enabling publishes the custom topic again, not the signer address", async () => {
+        await community.edit({ settings: { challenges: [], disablePubsubChallengeExchange: false } });
+        await waitTillRecordPubsubTopicIs(community, customTopic);
+        expect(community.raw.communityIpfs!.pubsubTopic).to.equal(customTopic);
+        expect(community.pubsubTopic).to.equal(customTopic);
+        expect(community.pubsubTopicRoutingCid).to.equal(pubsubTopicToDhtKey(customTopic));
+    });
+
+    itSkipIfRpc("subscribes to the custom topic once the exchange is re-enabled", async () => {
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => (await listSubscribedTopics(community)).includes(customTopic)
+        });
+        expect(await listSubscribedTopics(community)).to.include(customTopic);
+    });
+});
+
+// The published record is also what the DB's internal state is built from, so a topic-less record used
+// to erase the configured topic from storage: the community came back with no topic and the next record
+// fell back to the signer address, silently discarding the owner's configuration.
+describe("a custom pubsubTopic survives a restart while the exchange is disabled", async () => {
+    const customTopic = "custom-topic-restart-229";
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = <LocalCommunity>await pkc.createCommunity({
+            pubsubTopic: customTopic,
+            settings: { disablePubsubChallengeExchange: true, challenges: [] }
+        });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+        const updatedAtBeforeRestart = community.updatedAt!;
+        await community.stop();
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => community.updatedAt! > updatedAtBeforeRestart });
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("still publishes no pubsubTopic after the restart", () => {
+        expect(community.raw.communityIpfs!.pubsubTopic).to.be.undefined;
+        expect(community.pubsubTopicRoutingCid).to.be.undefined;
+    });
+
+    // Same RPC limitation as above: a configured-but-unpublished topic is not transmitted
+    itSkipIfRpc("kept the custom topic across the restart rather than reverting to the signer address", () => {
+        expect(community.pubsubTopic).to.equal(customTopic);
+        expect(community.pubsubTopic).to.not.equal(community.signer.address);
+    });
+
+    it("publishes the custom topic, not the signer address, when re-enabled after the restart", async () => {
+        await community.edit({ settings: { challenges: [], disablePubsubChallengeExchange: false } });
+        await waitTillRecordPubsubTopicIs(community, customTopic);
+        expect(community.raw.communityIpfs!.pubsubTopic).to.equal(customTopic);
+        expect(community.raw.communityIpfs!.pubsubTopic).to.not.equal(community.signer.address);
+    });
+});
+
+describe("editing pubsubTopic while the exchange is disabled", async () => {
+    const originalTopic = "custom-topic-edit-original-229";
+    const editedTopic = "custom-topic-edit-edited-229";
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = <LocalCommunity>await pkc.createCommunity({
+            pubsubTopic: originalTopic,
+            settings: { disablePubsubChallengeExchange: true, challenges: [] }
+        });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    // The published pubsubTopic is resolved from the setting last, so it wins over a pending edit
+    it("the edit does not leak a pubsubTopic into the record", async () => {
+        const updatedAtBefore = community.updatedAt!;
+        await community.edit({ pubsubTopic: editedTopic });
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => community.updatedAt! > updatedAtBefore });
+        expect(community.raw.communityIpfs!.pubsubTopic).to.be.undefined;
+        if (!isRpcFlagOn()) expect(community.pubsubTopic).to.equal(editedTopic);
+    });
+
+    it("re-enabling publishes the edited topic", async () => {
+        await community.edit({ settings: { challenges: [], disablePubsubChallengeExchange: false } });
+        await waitTillRecordPubsubTopicIs(community, editedTopic);
+        expect(community.raw.communityIpfs!.pubsubTopic).to.equal(editedTopic);
+        expect(community.pubsubTopic).to.equal(editedTopic);
+    });
+});
+
+describe("changing pubsubTopic while the community is started", async () => {
+    const firstTopic = "custom-topic-change-first-229";
+    const secondTopic = "custom-topic-change-second-229";
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = <LocalCommunity>await pkc.createCommunity({ pubsubTopic: firstTopic, settings: { challenges: [] } });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+        await community.edit({ pubsubTopic: secondTopic });
+        await waitTillRecordPubsubTopicIs(community, secondTopic);
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("publishes the new topic", () => {
+        expect(community.raw.communityIpfs!.pubsubTopic).to.equal(secondTopic);
+        expect(community.pubsubTopic).to.equal(secondTopic);
+    });
+
+    // The advertised routing CID is derived state: leaving it pinned to the old topic sends readers
+    // looking for peers of a topic the community no longer runs.
+    it("re-derives the advertised routing CID for the new topic", () => {
+        expect(community.pubsubTopicRoutingCid).to.equal(pubsubTopicToDhtKey(secondTopic));
+        expect(community.pubsubTopicRoutingCid).to.not.equal(pubsubTopicToDhtKey(firstTopic));
+    });
+
+    itSkipIfRpc("subscribes to the new topic", async () => {
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => (await listSubscribedTopics(community)).includes(secondTopic)
+        });
+        expect(await listSubscribedTopics(community)).to.include(secondTopic);
+    });
+
+    // Otherwise the community keeps serving challenge requests on a topic it no longer advertises,
+    // and the subscription leaks for the lifetime of the kubo node.
+    itSkipIfRpc("stops listening on the old topic", async () => {
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => !(await listSubscribedTopics(community)).includes(firstTopic)
+        });
+        expect(await listSubscribedTopics(community)).to.not.include(firstTopic);
+    });
+});

--- a/test/node/community/local-community/custom-pubsub-topic.test.ts
+++ b/test/node/community/local-community/custom-pubsub-topic.test.ts
@@ -151,6 +151,7 @@ describe("a custom pubsubTopic with the exchange disabled", async () => {
         expect(community.pubsubTopic).to.equal(customTopic);
     });
 
+    // Reads the kubo node's subscription list, which an RPC client cannot do
     itSkipIfRpc("never subscribes to the custom topic", async () => {
         expect(await listSubscribedTopics(community)).to.not.include(customTopic);
     });
@@ -163,6 +164,7 @@ describe("a custom pubsubTopic with the exchange disabled", async () => {
         expect(community.pubsubTopicRoutingCid).to.equal(pubsubTopicToDhtKey(customTopic));
     });
 
+    // Reads the kubo node's subscription list, which an RPC client cannot do
     itSkipIfRpc("subscribes to the custom topic once the exchange is re-enabled", async () => {
         await resolveWhenConditionIsTrue({
             toUpdate: community,
@@ -288,6 +290,7 @@ describe("changing pubsubTopic while the community is started", async () => {
         expect(community.pubsubTopicRoutingCid).to.not.equal(pubsubTopicToDhtKey(firstTopic));
     });
 
+    // Reads the kubo node's subscription list, which an RPC client cannot do
     itSkipIfRpc("subscribes to the new topic", async () => {
         await resolveWhenConditionIsTrue({
             toUpdate: community,

--- a/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
+++ b/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
@@ -61,10 +61,14 @@ describeSkipIfRpc("settings.disablePubsubChallengeExchange = true", async () => 
         expect(topics).to.not.include(community.address);
     });
 
-    it("keeps publishing new records, so replication over the IPNS topic is unaffected", async () => {
+    it("keeps minting new records, so replication over the IPNS topic is unaffected", async () => {
         const updatedAtBefore = community.updatedAt!;
+        // an idle community only republishes every 15 minutes, so force the next mint with an edit
+        await community.edit({ title: `read-only ${updatedAtBefore}` });
         await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => community.updatedAt! > updatedAtBefore });
         expect(community.updatedAt!).to.be.greaterThan(updatedAtBefore);
+        // and every subsequent mint still omits the topic
+        expect(community.raw.communityIpfs!.pubsubTopic).to.be.undefined;
     });
 
     it("is loadable by a remote client, which sees no pubsubTopic on the record", async () => {

--- a/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
+++ b/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
@@ -1,0 +1,284 @@
+// Integration tests for settings.disablePubsubChallengeExchange (issue #229).
+// A read-only community stops running the challenge/publication pubsub topic and its published
+// record omits pubsubTopic, which is what tells readers the exchange is disabled. Kind-blind
+// LocalCommunity feature; author-communities (issue #31) inherit it for feed-only profiles.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+    mockPKC,
+    mockRemotePKC,
+    generateMockPost,
+    generatePostToAnswerMathQuestion,
+    publishWithExpectedResult,
+    resolveWhenConditionIsTrue
+} from "../../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
+
+import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { PKCError } from "../../../../dist/node/pkc-error.js";
+
+const mathChallenge = [{ name: "question", options: { question: "1+1=?", answer: "2" } }];
+
+async function listSubscribedTopics(community: LocalCommunity) {
+    return community._clientsManager.getDefaultKuboPubsubClient()._client.pubsub.ls();
+}
+
+async function waitTillCommunityPublishedRecord(community: LocalCommunity) {
+    await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+}
+
+// These suites reach into the LocalCommunity instance and into the kubo node's subscription list,
+// neither of which is exposed through the RPC client.
+describeSkipIfRpc("settings.disablePubsubChallengeExchange = true", async () => {
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = <LocalCommunity>await pkc.createCommunity({ settings: { disablePubsubChallengeExchange: true } });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("leaves pubsubTopic unset at init instead of backfilling the signer address", () => {
+        expect(community.pubsubTopic).to.be.undefined;
+    });
+
+    it("publishes a record that omits pubsubTopic", () => {
+        expect(community.raw.communityIpfs).to.exist;
+        expect(community.raw.communityIpfs!.pubsubTopic).to.be.undefined;
+        expect("pubsubTopic" in community.raw.communityIpfs!).to.be.false;
+    });
+
+    it("does not subscribe to the challenge/publication pubsub topic", async () => {
+        const topics = await listSubscribedTopics(community);
+        expect(topics).to.not.include(community.signer.address);
+        expect(topics).to.not.include(community.address);
+    });
+
+    it("keeps publishing new records, so replication over the IPNS topic is unaffected", async () => {
+        const updatedAtBefore = community.updatedAt!;
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => community.updatedAt! > updatedAtBefore });
+        expect(community.updatedAt!).to.be.greaterThan(updatedAtBefore);
+    });
+
+    it("is loadable by a remote client, which sees no pubsubTopic on the record", async () => {
+        const remotePkc = await mockRemotePKC();
+        try {
+            const loaded = await remotePkc.createCommunity({ address: community.address });
+            await loaded.update();
+            await resolveWhenConditionIsTrue({ toUpdate: loaded, predicate: async () => typeof loaded.updatedAt === "number" });
+            await loaded.stop();
+            expect(loaded.pubsubTopic).to.be.undefined;
+            // the reader must not invent a challenge-topic routing CID from the address
+            expect(loaded.pubsubTopicRoutingCid).to.be.undefined;
+        } finally {
+            await remotePkc.destroy();
+        }
+    });
+});
+
+describeSkipIfRpc("settings.disablePubsubChallengeExchange unset or false", async () => {
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = <LocalCommunity>await pkc.createCommunity({});
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("backfills pubsubTopic to the signer address at init", () => {
+        expect(community.pubsubTopic).to.equal(community.signer.address);
+    });
+
+    it("publishes the record with an explicit pubsubTopic", () => {
+        expect(community.raw.communityIpfs!.pubsubTopic).to.equal(community.signer.address);
+    });
+
+    it("subscribes to the challenge/publication pubsub topic", async () => {
+        const topics = await listSubscribedTopics(community);
+        expect(topics).to.include(community.pubsubTopic);
+    });
+});
+
+describeSkipIfRpc("no fallback to the community address as a challenge-exchange topic", async () => {
+    let ownerPkc: PKCType;
+    let readerPkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        ownerPkc = await mockPKC();
+        community = <LocalCommunity>await ownerPkc.createCommunity({ settings: { disablePubsubChallengeExchange: true, challenges: [] } });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+        // A separate PKC instance never takes the local publish shortcut: _startedCommunities is
+        // per-instance, so this exercises the same code path a real remote publisher would hit.
+        readerPkc = await mockRemotePKC();
+    });
+
+    afterAll(async () => {
+        await readerPkc.destroy();
+        await community.delete();
+        await ownerPkc.destroy();
+    });
+
+    it("publish() fails fast with ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED", async () => {
+        const post = await generateMockPost({ communityAddress: community.address, pkc: readerPkc });
+        let error: PKCError | undefined;
+        try {
+            await post.publish();
+        } catch (e) {
+            error = <PKCError>e;
+        }
+        expect(error).to.exist;
+        expect(error!.code).to.equal("ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED");
+        expect(post.publishingState).to.equal("failed");
+    });
+
+    it("the publisher never subscribes to the community address as a challenge-exchange topic", async () => {
+        const post = await generateMockPost({ communityAddress: community.address, pkc: readerPkc });
+        await post.publish().catch((): undefined => undefined);
+        const subscribedTopics = Object.values(readerPkc._clientsManager.pubsubProviderSubscriptions).flat();
+        expect(subscribedTopics).to.not.include(community.address);
+        expect(subscribedTopics).to.not.include(community.signer.address);
+    });
+
+    it("the same fast-fail applies to a vote", async () => {
+        const vote = await readerPkc.createVote({
+            communityAddress: community.address,
+            commentCid: "QmUFu8fzuT1th3jMYc2ycbPktLKgWmVSD3xKmpvjs3ejMR",
+            vote: 1,
+            signer: await readerPkc.createSigner()
+        });
+        let error: PKCError | undefined;
+        try {
+            await vote.publish();
+        } catch (e) {
+            error = <PKCError>e;
+        }
+        expect(error?.code).to.equal("ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED");
+    });
+});
+
+describeSkipIfRpc("owner publishing while the exchange is disabled", async () => {
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = <LocalCommunity>await pkc.createCommunity({
+            settings: { disablePubsubChallengeExchange: true, challenges: mathChallenge }
+        });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("same-process publish succeeds via the local shortcut", async () => {
+        const post = await generatePostToAnswerMathQuestion({ communityAddress: community.address }, pkc);
+        await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+        expect(post.cid).to.be.a("string");
+    });
+
+    it("the local shortcut still evaluates the configured challenges", async () => {
+        const post = await generateMockPost({ communityAddress: community.address, pkc });
+        post.once("challenge", () => post.publishChallengeAnswers({ challengeAnswers: ["wrong answer"] }));
+        await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: false });
+    });
+});
+
+describeSkipIfRpc("toggling the exchange at runtime", async () => {
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = <LocalCommunity>await pkc.createCommunity({ settings: { challenges: [] } });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("enabling the setting unsubscribes on the next sync-loop iteration without a restart", async () => {
+        const topic = community.pubsubTopic!;
+        expect(await listSubscribedTopics(community)).to.include(topic);
+
+        await community.edit({ settings: { challenges: [], disablePubsubChallengeExchange: true } });
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => !(await listSubscribedTopics(community)).includes(topic)
+        });
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => community.raw.communityIpfs?.pubsubTopic === undefined
+        });
+        // the custom topic string survives the disable, it just stops being published
+        expect(community.pubsubTopic).to.equal(topic);
+    });
+
+    it("disabling the setting resubscribes and republishes the record with pubsubTopic present", async () => {
+        const topic = community.pubsubTopic!;
+        await community.edit({ settings: { challenges: [], disablePubsubChallengeExchange: false } });
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => (await listSubscribedTopics(community)).includes(topic)
+        });
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => community.raw.communityIpfs?.pubsubTopic === topic
+        });
+        expect(community.pubsubTopic).to.equal(topic);
+    });
+});
+
+describe("challenge exchange topic derivation", async () => {
+    const { challengeExchangePubsubTopic, communityChallengePubsubTopic } = await import(
+        "../../../../dist/node/runtime/node/community/local-community/comment-updates.js"
+    );
+
+    it("returns the explicit pubsubTopic when the exchange is enabled", () => {
+        const community = { pubsubTopic: "custom-topic", signer: { address: "signer-address" }, settings: {} } as unknown as LocalCommunity;
+        expect(challengeExchangePubsubTopic(community)).to.equal("custom-topic");
+    });
+
+    it("falls back to the signer address, never to the community address", () => {
+        const community = {
+            address: "community.bso",
+            pubsubTopic: undefined,
+            signer: { address: "signer-address" },
+            settings: {}
+        } as unknown as LocalCommunity;
+        expect(challengeExchangePubsubTopic(community)).to.equal("signer-address");
+    });
+
+    it("returns undefined when the exchange is disabled, while the raw topic is still resolvable", () => {
+        const community = {
+            pubsubTopic: "custom-topic",
+            signer: { address: "signer-address" },
+            settings: { disablePubsubChallengeExchange: true }
+        } as unknown as LocalCommunity;
+        expect(challengeExchangePubsubTopic(community)).to.be.undefined;
+        // the raw derivation is what stop()/unsubscribe use, so it must ignore the setting
+        expect(communityChallengePubsubTopic(community)).to.equal("custom-topic");
+    });
+});

--- a/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
+++ b/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
@@ -7,7 +7,6 @@ import {
     mockPKC,
     mockRemotePKC,
     generateMockPost,
-    generatePostToAnswerMathQuestion,
     publishWithExpectedResult,
     resolveWhenConditionIsTrue
 } from "../../../../dist/node/test/test-util.js";
@@ -16,6 +15,10 @@ import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
 import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";
 import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
 import type { PKCError } from "../../../../dist/node/pkc-error.js";
+import type {
+    DecryptedChallengeMessageType,
+    DecryptedChallengeVerificationMessageType
+} from "../../../../dist/node/pubsub-messages/types.js";
 
 const mathChallenge = [{ name: "question", options: { question: "1+1=?", answer: "2" } }];
 
@@ -194,16 +197,45 @@ describeSkipIfRpc("owner publishing while the exchange is disabled", async () =>
         await pkc.destroy();
     });
 
-    it("same-process publish succeeds via the local shortcut", async () => {
-        const post = await generatePostToAnswerMathQuestion({ communityAddress: community.address }, pkc);
+    it("same-process publish succeeds via the local shortcut, after answering the configured challenge", async () => {
+        const post = await generateMockPost({ communityAddress: community.address, pkc });
+        const challengesReceived: DecryptedChallengeMessageType[] = [];
+        post.on("challenge", (challengeMsg) => {
+            challengesReceived.push(challengeMsg);
+            post.publishChallengeAnswers({ challengeAnswers: ["2"] });
+        });
+
         await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+
+        // the exchange really ran in-process rather than the publication being waved through: the
+        // community issued the math question configured in settings.challenges
+        expect(challengesReceived).to.have.lengthOf(1);
+        expect(challengesReceived[0].challenges).to.have.lengthOf(1);
+        expect(challengesReceived[0].challenges[0].challenge).to.equal(mathChallenge[0].options.question);
+        expect(challengesReceived[0].challenges[0].type).to.equal("text/plain");
         expect(post.cid).to.be.a("string");
     });
 
     it("the local shortcut still evaluates the configured challenges", async () => {
         const post = await generateMockPost({ communityAddress: community.address, pkc });
-        post.once("challenge", () => post.publishChallengeAnswers({ challengeAnswers: ["wrong answer"] }));
+        const challengesReceived: DecryptedChallengeMessageType[] = [];
+        const verificationsReceived: DecryptedChallengeVerificationMessageType[] = [];
+        post.on("challenge", (challengeMsg) => {
+            challengesReceived.push(challengeMsg);
+            post.publishChallengeAnswers({ challengeAnswers: ["wrong answer"] });
+        });
+        post.on("challengeverification", (verification) => verificationsReceived.push(verification));
+
         await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: false });
+
+        // the failure has to come from the question being asked and answered wrong, not from the
+        // challenge never being issued: read-only mode removes the network path, not the pipeline
+        expect(challengesReceived).to.have.lengthOf(1);
+        expect(challengesReceived[0].challenges[0].challenge).to.equal(mathChallenge[0].options.question);
+        expect(verificationsReceived).to.have.lengthOf(1);
+        expect(verificationsReceived[0].challengeSuccess).to.be.false;
+        expect(verificationsReceived[0].challengeErrors).to.deep.equal({ "0": "Wrong answer." });
+        expect(post.cid).to.be.undefined;
     });
 });
 

--- a/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
+++ b/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
@@ -30,8 +30,8 @@ async function waitTillCommunityPublishedRecord(community: LocalCommunity) {
     await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
 }
 
-// These suites reach into the LocalCommunity instance and into the kubo node's subscription list,
-// neither of which is exposed through the RPC client.
+// Reads community.raw.communityIpfs and community.signer off the LocalCommunity instance, and lists
+// the kubo node's subscriptions; the RPC client exposes neither the instance internals nor the node.
 describeSkipIfRpc("settings.disablePubsubChallengeExchange = true", async () => {
     let pkc: PKCType;
     let community: LocalCommunity;
@@ -90,6 +90,8 @@ describeSkipIfRpc("settings.disablePubsubChallengeExchange = true", async () => 
     });
 });
 
+// Same reason as above: asserts community.signer.address against the record and against the kubo
+// node's subscription list, neither of which is reachable through the RPC client.
 describeSkipIfRpc("settings.disablePubsubChallengeExchange unset or false", async () => {
     let pkc: PKCType;
     let community: LocalCommunity;
@@ -120,6 +122,9 @@ describeSkipIfRpc("settings.disablePubsubChallengeExchange unset or false", asyn
     });
 });
 
+// Inspects readerPkc._clientsManager.pubsubProviderSubscriptions to prove which topics the publisher
+// touched. Under RPC the publisher's pubsub work happens in the server's process, so the client-side
+// subscription map stays empty and the assertion would pass without proving anything.
 describeSkipIfRpc("no fallback to the community address as a challenge-exchange topic", async () => {
     let ownerPkc: PKCType;
     let readerPkc: PKCType;
@@ -179,6 +184,9 @@ describeSkipIfRpc("no fallback to the community address as a challenge-exchange 
     });
 });
 
+// Asserts the same-process publish shortcut specifically: publish() must find the community in this
+// PKC's _startedCommunities. An RPC client always takes _publishWithRpc instead, so it would exercise
+// the server's shortcut rather than the branch under test.
 describeSkipIfRpc("owner publishing while the exchange is disabled", async () => {
     let pkc: PKCType;
     let community: LocalCommunity;
@@ -239,6 +247,41 @@ describeSkipIfRpc("owner publishing while the exchange is disabled", async () =>
     });
 });
 
+// Needs a PKC constructed with no pubsub provider at all, which the RPC client cannot express: an
+// RPC client delegates every publish to the server's PKC and never consults its own pubsub clients.
+describeSkipIfRpc("owner publishing in-process with no pubsub provider configured", async () => {
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        // a node that runs only read-only communities has no reason to configure a pubsub provider
+        pkc = await mockPKC({ pubsubKuboRpcClientsOptions: [] });
+        community = <LocalCommunity>await pkc.createCommunity({
+            settings: { disablePubsubChallengeExchange: true, challenges: [] }
+        });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("has no pubsub provider to publish over", () => {
+        expect(Object.keys(pkc.clients.pubsubKuboRpcClients)).to.have.lengthOf(0);
+        expect(Object.keys(pkc.clients.libp2pJsClients)).to.have.lengthOf(0);
+    });
+
+    it("publishes via the local shortcut instead of demanding a pubsub provider", async () => {
+        const post = await generateMockPost({ communityAddress: community.address, pkc });
+        await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+        expect(post.cid).to.be.a("string");
+    });
+});
+
+// Watches the kubo node's subscription list flip as the sync loop reacts to the edit; the RPC client
+// has no handle on the node running the community, so there is nothing to observe the toggle on.
 describeSkipIfRpc("toggling the exchange at runtime", async () => {
     let pkc: PKCType;
     let community: LocalCommunity;

--- a/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
+++ b/test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts
@@ -2,15 +2,22 @@
 // A read-only community stops running the challenge/publication pubsub topic and its published
 // record omits pubsubTopic, which is what tells readers the exchange is disabled. Kind-blind
 // LocalCommunity feature; author-communities (issue #31) inherit it for feed-only profiles.
+//
+// Most suites here run under BOTH the direct and the PKC RPC flavours: an RpcLocalCommunity
+// transmits signer (minus privateKey), settings, pubsubTopic and raw.communityIpfs from the server,
+// so every record-and-instance assertion is observable through an RPC client too. Only three things
+// genuinely cannot be expressed over RPC, and each has its own describeSkipIfRpc suite below with
+// the reason stated.
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import {
     mockPKC,
     mockRemotePKC,
     generateMockPost,
     publishWithExpectedResult,
-    resolveWhenConditionIsTrue
+    resolveWhenConditionIsTrue,
+    isRpcFlagOn
 } from "../../../../dist/node/test/test-util.js";
-import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
+import { describeSkipIfRpc, itSkipIfRpc } from "../../../helpers/conditional-tests.js";
 
 import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";
 import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
@@ -22,6 +29,8 @@ import type {
 
 const mathChallenge = [{ name: "question", options: { question: "1+1=?", answer: "2" } }];
 
+// Under RPC the runtime object is an RpcLocalCommunity, but every prop these suites read is
+// transmitted by the server, so the LocalCommunity cast stays accurate for what is asserted.
 async function listSubscribedTopics(community: LocalCommunity) {
     return community._clientsManager.getDefaultKuboPubsubClient()._client.pubsub.ls();
 }
@@ -30,9 +39,7 @@ async function waitTillCommunityPublishedRecord(community: LocalCommunity) {
     await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
 }
 
-// Reads community.raw.communityIpfs and community.signer off the LocalCommunity instance, and lists
-// the kubo node's subscriptions; the RPC client exposes neither the instance internals nor the node.
-describeSkipIfRpc("settings.disablePubsubChallengeExchange = true", async () => {
+describe("settings.disablePubsubChallengeExchange = true", async () => {
     let pkc: PKCType;
     let community: LocalCommunity;
 
@@ -58,10 +65,11 @@ describeSkipIfRpc("settings.disablePubsubChallengeExchange = true", async () => 
         expect("pubsubTopic" in community.raw.communityIpfs!).to.be.false;
     });
 
-    it("does not subscribe to the challenge/publication pubsub topic", async () => {
-        const topics = await listSubscribedTopics(community);
-        expect(topics).to.not.include(community.signer.address);
-        expect(topics).to.not.include(community.address);
+    // The challenge topic is not advertised, but the IPNS-over-pubsub topic is a separate derivation
+    // and keeps being provided, which is what makes replication unaffected by the setting (issue #229)
+    it("advertises no challenge-topic routing CID while keeping the IPNS one", () => {
+        expect(community.pubsubTopicRoutingCid).to.be.undefined;
+        expect(community.ipnsPubsubTopicRoutingCid).to.be.a("string");
     });
 
     it("keeps minting new records, so replication over the IPNS topic is unaffected", async () => {
@@ -90,9 +98,7 @@ describeSkipIfRpc("settings.disablePubsubChallengeExchange = true", async () => 
     });
 });
 
-// Same reason as above: asserts community.signer.address against the record and against the kubo
-// node's subscription list, neither of which is reachable through the RPC client.
-describeSkipIfRpc("settings.disablePubsubChallengeExchange unset or false", async () => {
+describe("settings.disablePubsubChallengeExchange unset or false", async () => {
     let pkc: PKCType;
     let community: LocalCommunity;
 
@@ -116,15 +122,70 @@ describeSkipIfRpc("settings.disablePubsubChallengeExchange unset or false", asyn
         expect(community.raw.communityIpfs!.pubsubTopic).to.equal(community.signer.address);
     });
 
-    it("subscribes to the challenge/publication pubsub topic", async () => {
-        const topics = await listSubscribedTopics(community);
-        expect(topics).to.include(community.pubsubTopic);
+    it("advertises a challenge-topic routing CID derived from the topic", () => {
+        expect(community.pubsubTopicRoutingCid).to.be.a("string");
     });
 });
 
-// Inspects readerPkc._clientsManager.pubsubProviderSubscriptions to prove which topics the publisher
-// touched. Under RPC the publisher's pubsub work happens in the server's process, so the client-side
-// subscription map stays empty and the assertion would pass without proving anything.
+// Lists the kubo node's own subscriptions. An RPC client's PKC is constructed with
+// pkcRpcClientsOptions only, so it has no kubo client to ask, and the node running the community
+// lives in the server's process. This is the only assertion in the file that is truly RPC-proof.
+describeSkipIfRpc("kubo pubsub subscriptions follow the setting", async () => {
+    let pkc: PKCType;
+    let disabledCommunity: LocalCommunity;
+    let toggledCommunity: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        disabledCommunity = <LocalCommunity>await pkc.createCommunity({ settings: { disablePubsubChallengeExchange: true } });
+        await disabledCommunity.start();
+        await waitTillCommunityPublishedRecord(disabledCommunity);
+        toggledCommunity = <LocalCommunity>await pkc.createCommunity({ settings: { challenges: [] } });
+        await toggledCommunity.start();
+        await waitTillCommunityPublishedRecord(toggledCommunity);
+    });
+
+    afterAll(async () => {
+        await disabledCommunity.delete();
+        await toggledCommunity.delete();
+        await pkc.destroy();
+    });
+
+    it("a community created with the setting on never subscribes", async () => {
+        const topics = await listSubscribedTopics(disabledCommunity);
+        expect(topics).to.not.include(disabledCommunity.signer.address);
+        expect(topics).to.not.include(disabledCommunity.address);
+    });
+
+    it("a community with the setting off subscribes to its topic", async () => {
+        expect(await listSubscribedTopics(toggledCommunity)).to.include(toggledCommunity.pubsubTopic);
+    });
+
+    it("enabling the setting unsubscribes on the next sync-loop iteration without a restart", async () => {
+        const topic = toggledCommunity.pubsubTopic!;
+        await toggledCommunity.edit({ settings: { challenges: [], disablePubsubChallengeExchange: true } });
+        await resolveWhenConditionIsTrue({
+            toUpdate: toggledCommunity,
+            predicate: async () => !(await listSubscribedTopics(toggledCommunity)).includes(topic)
+        });
+        expect(await listSubscribedTopics(toggledCommunity)).to.not.include(topic);
+    });
+
+    it("disabling the setting resubscribes without a restart", async () => {
+        const topic = toggledCommunity.signer.address;
+        await toggledCommunity.edit({ settings: { challenges: [], disablePubsubChallengeExchange: false } });
+        await resolveWhenConditionIsTrue({
+            toUpdate: toggledCommunity,
+            predicate: async () => (await listSubscribedTopics(toggledCommunity)).includes(topic)
+        });
+        expect(await listSubscribedTopics(toggledCommunity)).to.include(topic);
+    });
+});
+
+// Needs a publisher that does NOT have the community, which cannot exist over RPC: both PKCs would
+// point at the same server, and that server runs the community, so publish() would legitimately
+// succeed through the local shortcut instead of failing fast. It also inspects the client-side
+// pubsubProviderSubscriptions map, which stays empty when the server owns the pubsub work.
 describeSkipIfRpc("no fallback to the community address as a challenge-exchange topic", async () => {
     let ownerPkc: PKCType;
     let readerPkc: PKCType;
@@ -184,10 +245,11 @@ describeSkipIfRpc("no fallback to the community address as a challenge-exchange 
     });
 });
 
-// Asserts the same-process publish shortcut specifically: publish() must find the community in this
-// PKC's _startedCommunities. An RPC client always takes _publishWithRpc instead, so it would exercise
-// the server's shortcut rather than the branch under test.
-describeSkipIfRpc("owner publishing while the exchange is disabled", async () => {
+// Runs in both flavours on purpose. Directly it exercises the same-process shortcut through
+// pkc._startedCommunities; under RPC the same publish goes to the server that runs the community and
+// takes the shortcut there, which is the documented owner path for a read-only community. Publishing
+// must NOT fail fast in either case.
+describe("owner publishing while the exchange is disabled", async () => {
     let pkc: PKCType;
     let community: LocalCommunity;
 
@@ -247,8 +309,8 @@ describeSkipIfRpc("owner publishing while the exchange is disabled", async () =>
     });
 });
 
-// Needs a PKC constructed with no pubsub provider at all, which the RPC client cannot express: an
-// RPC client delegates every publish to the server's PKC and never consults its own pubsub clients.
+// Needs a PKC constructed with no pubsub provider at all, which the RPC client cannot express: the
+// server owns the providers, and an RPC client delegates every publish to it.
 describeSkipIfRpc("owner publishing in-process with no pubsub provider configured", async () => {
     let pkc: PKCType;
     let community: LocalCommunity;
@@ -280,9 +342,7 @@ describeSkipIfRpc("owner publishing in-process with no pubsub provider configure
     });
 });
 
-// Watches the kubo node's subscription list flip as the sync loop reacts to the edit; the RPC client
-// has no handle on the node running the community, so there is nothing to observe the toggle on.
-describeSkipIfRpc("toggling the exchange at runtime", async () => {
+describe("toggling the exchange at runtime", async () => {
     let pkc: PKCType;
     let community: LocalCommunity;
 
@@ -298,35 +358,162 @@ describeSkipIfRpc("toggling the exchange at runtime", async () => {
         await pkc.destroy();
     });
 
-    it("enabling the setting unsubscribes on the next sync-loop iteration without a restart", async () => {
-        const topic = community.pubsubTopic!;
-        expect(await listSubscribedTopics(community)).to.include(topic);
+    // The full round trip of the only switch: the setting is off unless the owner turns it on, and
+    // turning it off again has to restore the same topic the default backfill produced, not leave the
+    // community permanently topic-less. Asserted against community.signer.address explicitly, since
+    // that (never community.address) is what the backfill writes.
+    it("defaults to the exchange enabled, with pubsubTopic backfilled to the signer address", () => {
+        expect(community.settings?.disablePubsubChallengeExchange).to.be.undefined;
+        expect(community.pubsubTopic).to.equal(community.signer.address);
+        expect(community.raw.communityIpfs!.pubsubTopic).to.equal(community.signer.address);
+    });
+
+    it("enabling the setting drops pubsubTopic from the record without a restart", async () => {
+        expect(community.pubsubTopic).to.equal(community.signer.address);
 
         await community.edit({ settings: { challenges: [], disablePubsubChallengeExchange: true } });
         await resolveWhenConditionIsTrue({
             toUpdate: community,
-            predicate: async () => !(await listSubscribedTopics(community)).includes(topic)
-        });
-        await resolveWhenConditionIsTrue({
-            toUpdate: community,
             predicate: async () => community.raw.communityIpfs?.pubsubTopic === undefined
         });
-        // the custom topic string survives the disable, it just stops being published
-        expect(community.pubsubTopic).to.equal(topic);
+        expect(community.settings?.disablePubsubChallengeExchange).to.be.true;
     });
 
-    it("disabling the setting resubscribes and republishes the record with pubsubTopic present", async () => {
-        const topic = community.pubsubTopic!;
+    // The configured topic survives the disable on the instance, it just stops being published. Only
+    // observable directly: the RPC surface transmits the CommunityIpfs record plus signer/settings, so
+    // a topic that is configured but deliberately unpublished is not part of what the server sends.
+    itSkipIfRpc("keeps the configured topic on the instance while it is unpublished", () => {
+        expect(community.raw.communityIpfs!.pubsubTopic).to.be.undefined;
+        expect(community.pubsubTopic).to.equal(community.signer.address);
+    });
+
+    it("disabling the setting republishes the record with pubsubTopic present", async () => {
+        const topic = community.signer.address;
         await community.edit({ settings: { challenges: [], disablePubsubChallengeExchange: false } });
-        await resolveWhenConditionIsTrue({
-            toUpdate: community,
-            predicate: async () => (await listSubscribedTopics(community)).includes(topic)
-        });
         await resolveWhenConditionIsTrue({
             toUpdate: community,
             predicate: async () => community.raw.communityIpfs?.pubsubTopic === topic
         });
-        expect(community.pubsubTopic).to.equal(topic);
+        // back to exactly the state the default produced, topic included
+        expect(community.settings?.disablePubsubChallengeExchange).to.be.false;
+        expect(community.pubsubTopic).to.equal(community.signer.address);
+        expect(community.raw.communityIpfs!.pubsubTopic).to.equal(community.signer.address);
+    });
+});
+
+// A reader that already loaded the enabled record has to follow the community into read-only mode.
+// pubsubTopicRoutingCid used to be write-once, so it survived the record that dropped the topic and
+// left the reader looking for peers of a challenge topic nobody runs.
+describe("a reader watching the exchange being disabled", async () => {
+    let ownerPkc: PKCType;
+    let readerPkc: PKCType;
+    let community: LocalCommunity;
+    let reader: Awaited<ReturnType<PKCType["createCommunity"]>>;
+
+    beforeAll(async () => {
+        ownerPkc = await mockPKC();
+        community = <LocalCommunity>await ownerPkc.createCommunity({ settings: { challenges: [] } });
+        await community.start();
+        await waitTillCommunityPublishedRecord(community);
+        readerPkc = await mockRemotePKC();
+        reader = await readerPkc.createCommunity({ address: community.address });
+        await reader.update();
+        await resolveWhenConditionIsTrue({ toUpdate: reader, predicate: async () => typeof reader.updatedAt === "number" });
+    });
+
+    afterAll(async () => {
+        await reader.stop();
+        await readerPkc.destroy();
+        await community.delete();
+        await ownerPkc.destroy();
+    });
+
+    it("starts out seeing the topic and its routing CID", () => {
+        expect(reader.pubsubTopic).to.equal(community.signer.address);
+        expect(reader.pubsubTopicRoutingCid).to.be.a("string");
+    });
+
+    it("clears both once the community publishes a record without pubsubTopic", async () => {
+        await community.edit({ settings: { challenges: [], disablePubsubChallengeExchange: true } });
+        await resolveWhenConditionIsTrue({
+            toUpdate: reader,
+            predicate: async () => reader.raw.communityIpfs?.pubsubTopic === undefined
+        });
+        expect(reader.pubsubTopic).to.be.undefined;
+        expect(reader.pubsubTopicRoutingCid).to.be.undefined;
+        // the IPNS side is untouched, so the reader keeps following the community's records
+        expect(reader.ipnsPubsubTopicRoutingCid).to.be.a("string");
+    });
+});
+
+// A community only backfills pubsubTopic when its DB is created, so everything about the setting has
+// to survive coming back from the DB rather than being re-derived on every start.
+describe("surviving a restart", async () => {
+    let pkc: PKCType;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+    });
+
+    afterAll(async () => {
+        await pkc.destroy();
+    });
+
+    it("a community created with the setting on stays topic-less after stop() and start()", async () => {
+        const community = <LocalCommunity>await pkc.createCommunity({
+            settings: { disablePubsubChallengeExchange: true, challenges: [] }
+        });
+        try {
+            await community.start();
+            await waitTillCommunityPublishedRecord(community);
+            const updatedAtBeforeRestart = community.updatedAt!;
+            await community.stop();
+
+            await community.start();
+            await resolveWhenConditionIsTrue({
+                toUpdate: community,
+                predicate: async () => community.updatedAt! > updatedAtBeforeRestart
+            });
+            expect(community.settings?.disablePubsubChallengeExchange).to.be.true;
+            expect(community.pubsubTopic).to.be.undefined;
+            expect(community.raw.communityIpfs!.pubsubTopic).to.be.undefined;
+        } finally {
+            await community.delete();
+        }
+    });
+
+    // The upgrade path for every community that predates the setting: pubsubTopic is already stored
+    // in its DB, so disabling the exchange must keep it out of the record across a restart even
+    // though the row still has it.
+    it("a community whose topic is already in the DB keeps it out of the record after a restart", async () => {
+        const community = <LocalCommunity>await pkc.createCommunity({ settings: { challenges: [] } });
+        try {
+            await community.start();
+            await waitTillCommunityPublishedRecord(community);
+            expect(community.raw.communityIpfs!.pubsubTopic).to.equal(community.signer.address);
+
+            await community.edit({ settings: { challenges: [], disablePubsubChallengeExchange: true } });
+            await resolveWhenConditionIsTrue({
+                toUpdate: community,
+                predicate: async () => community.raw.communityIpfs?.pubsubTopic === undefined
+            });
+            const updatedAtBeforeRestart = community.updatedAt!;
+            await community.stop();
+
+            await community.start();
+            await resolveWhenConditionIsTrue({
+                toUpdate: community,
+                predicate: async () => community.updatedAt! > updatedAtBeforeRestart
+            });
+            expect(community.settings?.disablePubsubChallengeExchange).to.be.true;
+            expect(community.raw.communityIpfs!.pubsubTopic).to.be.undefined;
+            // The stored topic is still in the DB row, it is simply not published. Only observable
+            // directly, for the same reason as the toggle suite: the RPC surface sends the
+            // CommunityIpfs record plus signer/settings, not a configured-but-unpublished topic.
+            if (!isRpcFlagOn()) expect(community.pubsubTopic).to.equal(community.signer.address);
+        } finally {
+            await community.delete();
+        }
     });
 });
 

--- a/test/node/community/local-community/pubsub.test.ts
+++ b/test/node/community/local-community/pubsub.test.ts
@@ -97,10 +97,38 @@ describe("pubsub: listenToIncomingRequests", () => {
             settings: { disablePubsubChallengeExchange: true },
             handleChallengeExchange: (): undefined => undefined,
             _clientsManager: {
-                getDefaultKuboPubsubClient: () => ({
+                // the disabled path takes the tolerant getter, since a node hosting only read-only
+                // communities may have no pubsub provider configured at all
+                getDefaultKuboPubsubClientIfAny: () => ({
                     _client: { pubsub: { ls: vi.fn().mockResolvedValue([]) } },
                     url: "http://localhost:5001"
                 }),
+                pubsubUnsubscribe,
+                pubsubSubscribe,
+                updateKuboRpcPubsubState: vi.fn()
+            }
+        } as unknown as LocalCommunity;
+
+        await listenToIncomingRequests(community);
+
+        expect(pubsubSubscribe).not.toHaveBeenCalled();
+        expect(pubsubUnsubscribe).not.toHaveBeenCalled();
+    });
+
+    it("returns without touching pubsub when the exchange is disabled and no provider is configured", async () => {
+        const pubsubSubscribe = vi.fn();
+        const pubsubUnsubscribe = vi.fn();
+        const community = {
+            address: "readonly.bso",
+            pubsubTopic: "pubsub-topic",
+            signer: { address: "signer-address" },
+            settings: { disablePubsubChallengeExchange: true },
+            handleChallengeExchange: (): undefined => undefined,
+            _clientsManager: {
+                getDefaultKuboPubsubClientIfAny: (): undefined => undefined,
+                getDefaultKuboPubsubClient: (): never => {
+                    throw new Error("the disabled path must not demand a pubsub provider");
+                },
                 pubsubUnsubscribe,
                 pubsubSubscribe,
                 updateKuboRpcPubsubState: vi.fn()
@@ -124,7 +152,7 @@ describe("pubsub: listenToIncomingRequests", () => {
             settings: { disablePubsubChallengeExchange: true },
             handleChallengeExchange,
             _clientsManager: {
-                getDefaultKuboPubsubClient: () => ({
+                getDefaultKuboPubsubClientIfAny: () => ({
                     _client: { pubsub: { ls: vi.fn().mockResolvedValue(["pubsub-topic"]) } },
                     url: "http://localhost:5001"
                 }),

--- a/test/node/community/local-community/pubsub.test.ts
+++ b/test/node/community/local-community/pubsub.test.ts
@@ -5,6 +5,18 @@
 // test/node/community/.
 
 import { describe, it, expect, vi } from "vitest";
+
+// Stub out the block-put/pin/provide stack so the tests below can assert WHICH topics get provided
+// without faking the whole kubo API. Every other test in this file early-returns or throws before
+// reaching it, so the stub is inert for them.
+const { provideMock } = vi.hoisted(() => ({
+    provideMock: vi.fn(async (_args: { pubsubTopic: string }): Promise<void> => undefined)
+}));
+vi.mock("../../../../dist/node/util.js", async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return { ...actual, retryKuboBlockPutPinAndProvidePubsubTopic: provideMock };
+});
+
 import {
     listenToIncomingRequests,
     providePubsubTopicRoutingCidsIfNeeded
@@ -141,6 +153,37 @@ describe("pubsub: listenToIncomingRequests", () => {
         expect(pubsubUnsubscribe).not.toHaveBeenCalled();
     });
 
+    // pubsubTopic can change while the community is started. kubo is shared with every other community
+    // on the node, so the topic we joined last is the only one we may drop.
+    it("drops the previously joined topic when pubsubTopic changes", async () => {
+        const pubsubSubscribe = vi.fn();
+        const pubsubUnsubscribe = vi.fn();
+        const handleChallengeExchange = (): undefined => undefined;
+        const community = {
+            address: "changed.bso",
+            pubsubTopic: "new-topic",
+            signer: { address: "signer-address" },
+            settings: {},
+            _subscribedChallengePubsubTopic: "old-topic",
+            handleChallengeExchange,
+            _clientsManager: {
+                getDefaultKuboPubsubClient: () => ({
+                    _client: { pubsub: { ls: vi.fn().mockResolvedValue(["old-topic"]) } },
+                    url: "http://localhost:5001"
+                }),
+                pubsubUnsubscribe,
+                pubsubSubscribe,
+                updateKuboRpcPubsubState: vi.fn()
+            }
+        } as unknown as LocalCommunity;
+
+        await listenToIncomingRequests(community);
+
+        expect(pubsubUnsubscribe).toHaveBeenCalledWith("old-topic", handleChallengeExchange);
+        expect(pubsubSubscribe).toHaveBeenCalledWith("new-topic", handleChallengeExchange);
+        expect(community._subscribedChallengePubsubTopic).to.equal("new-topic");
+    });
+
     it("unsubscribes when the setting is toggled on while the topic is still joined", async () => {
         const pubsubSubscribe = vi.fn();
         const pubsubUnsubscribe = vi.fn();
@@ -201,6 +244,43 @@ describe("pubsub: providePubsubTopicRoutingCidsIfNeeded", () => {
 
         await providePubsubTopicRoutingCidsIfNeeded(community);
         expect(getDefaultKuboRpcClient).not.toHaveBeenCalled();
+    });
+
+    // The challenge topic is the only thing settings.disablePubsubChallengeExchange takes off the
+    // network (issue #229). The IPNS-over-pubsub topic is a separate derivation and must keep being
+    // advertised, otherwise disabling the exchange would quietly degrade record replication too.
+    it("provides only the IPNS topic when the challenge exchange is disabled", async () => {
+        provideMock.mockClear();
+        const community = {
+            address: "readonly.bso",
+            pubsubTopic: "custom-topic",
+            signer: { address: "signer-address" },
+            settings: { disablePubsubChallengeExchange: true },
+            ipnsPubsubTopic: "ipns-topic",
+            _lastPubsubTopicRoutingProvideAt: undefined,
+            _clientsManager: { getDefaultKuboRpcClient: () => ({ _client: {} }) }
+        } as unknown as LocalCommunity;
+
+        await providePubsubTopicRoutingCidsIfNeeded(community);
+
+        expect(provideMock.mock.calls.map((call) => call[0].pubsubTopic)).to.deep.equal(["ipns-topic"]);
+    });
+
+    it("provides both the challenge topic and the IPNS topic when the exchange is enabled", async () => {
+        provideMock.mockClear();
+        const community = {
+            address: "enabled.bso",
+            pubsubTopic: "custom-topic",
+            signer: { address: "signer-address" },
+            settings: {},
+            ipnsPubsubTopic: "ipns-topic",
+            _lastPubsubTopicRoutingProvideAt: undefined,
+            _clientsManager: { getDefaultKuboRpcClient: () => ({ _client: {} }) }
+        } as unknown as LocalCommunity;
+
+        await providePubsubTopicRoutingCidsIfNeeded(community);
+
+        expect(provideMock.mock.calls.map((call) => call[0].pubsubTopic)).to.deep.equal(["custom-topic", "ipns-topic"]);
     });
 
     it("forces a provide when force=true, bypassing the throttle", async () => {

--- a/test/node/community/local-community/pubsub.test.ts
+++ b/test/node/community/local-community/pubsub.test.ts
@@ -62,11 +62,14 @@ describe("pubsub: listenToIncomingRequests", () => {
         expect(pubsubSubscribe).not.toHaveBeenCalled();
     });
 
-    it("falls back to community.address when pubsubTopic is unset", async () => {
+    // Since issue #229 the fallback is the signer address, never community.address: an absent topic
+    // on the wire means the challenge exchange is disabled, so the address must not stand in for one.
+    it("falls back to the signer address when pubsubTopic is unset", async () => {
         const pubsubSubscribe = vi.fn();
         const community = {
             address: "fallback.bso",
             pubsubTopic: undefined,
+            signer: { address: "signer-address" },
             handleChallengeExchange: (): undefined => undefined,
             _clientsManager: {
                 getDefaultKuboPubsubClient: () => ({
@@ -81,7 +84,60 @@ describe("pubsub: listenToIncomingRequests", () => {
 
         await listenToIncomingRequests(community);
 
-        expect(pubsubSubscribe).toHaveBeenCalledWith("fallback.bso", expect.any(Function));
+        expect(pubsubSubscribe).toHaveBeenCalledWith("signer-address", expect.any(Function));
+    });
+
+    it("does not subscribe when settings.disablePubsubChallengeExchange is on", async () => {
+        const pubsubSubscribe = vi.fn();
+        const pubsubUnsubscribe = vi.fn();
+        const community = {
+            address: "readonly.bso",
+            pubsubTopic: "pubsub-topic",
+            signer: { address: "signer-address" },
+            settings: { disablePubsubChallengeExchange: true },
+            handleChallengeExchange: (): undefined => undefined,
+            _clientsManager: {
+                getDefaultKuboPubsubClient: () => ({
+                    _client: { pubsub: { ls: vi.fn().mockResolvedValue([]) } },
+                    url: "http://localhost:5001"
+                }),
+                pubsubUnsubscribe,
+                pubsubSubscribe,
+                updateKuboRpcPubsubState: vi.fn()
+            }
+        } as unknown as LocalCommunity;
+
+        await listenToIncomingRequests(community);
+
+        expect(pubsubSubscribe).not.toHaveBeenCalled();
+        expect(pubsubUnsubscribe).not.toHaveBeenCalled();
+    });
+
+    it("unsubscribes when the setting is toggled on while the topic is still joined", async () => {
+        const pubsubSubscribe = vi.fn();
+        const pubsubUnsubscribe = vi.fn();
+        const handleChallengeExchange = (): undefined => undefined;
+        const community = {
+            address: "readonly.bso",
+            pubsubTopic: "pubsub-topic",
+            signer: { address: "signer-address" },
+            settings: { disablePubsubChallengeExchange: true },
+            handleChallengeExchange,
+            _clientsManager: {
+                getDefaultKuboPubsubClient: () => ({
+                    _client: { pubsub: { ls: vi.fn().mockResolvedValue(["pubsub-topic"]) } },
+                    url: "http://localhost:5001"
+                }),
+                pubsubUnsubscribe,
+                pubsubSubscribe,
+                updateKuboRpcPubsubState: vi.fn()
+            }
+        } as unknown as LocalCommunity;
+
+        await listenToIncomingRequests(community);
+
+        expect(pubsubUnsubscribe).toHaveBeenCalledWith("pubsub-topic", handleChallengeExchange);
+        expect(pubsubSubscribe).not.toHaveBeenCalled();
     });
 });
 
@@ -104,11 +160,12 @@ describe("pubsub: providePubsubTopicRoutingCidsIfNeeded", () => {
 
     it("early-returns when there are no topics to provide", async () => {
         const getDefaultKuboRpcClient = vi.fn();
-        // pubsubTopicWithfallback returns `pubsubTopic || address`, so both must be falsy
+        // challengeExchangePubsubTopic returns `pubsubTopic || signer.address`, so both must be falsy
         // (and ipnsPubsubTopic undefined) for topics.length to be 0.
         const community = {
             address: undefined,
             pubsubTopic: undefined,
+            signer: undefined,
             ipnsPubsubTopic: undefined,
             _lastPubsubTopicRoutingProvideAt: undefined,
             _clientsManager: { getDefaultKuboRpcClient }

--- a/test/node/community/misc.community.test.ts
+++ b/test/node/community/misc.community.test.ts
@@ -124,16 +124,24 @@ describe(`community.pubsubTopic`, async () => {
     it(`community.pubsubTopic is defaulted to address when community is first created`, async () => {
         expect(community.pubsubTopic).to.equal(community.address);
     });
-    it(`Publications can be published to a community with pubsubTopic=undefined`, async () => {
+    // Since issue #229 an absent pubsubTopic on the wire means the challenge exchange is disabled, so
+    // clearing the field can no longer be the way to publish a topic-less record — it re-derives the
+    // default instead, and settings.disablePubsubChallengeExchange is the only switch. This is the
+    // tri-state falsy hazard the boolean was chosen to avoid; the published record always carries an
+    // explicit topic unless the owner opted out.
+    it(`Clearing community.pubsubTopic re-derives the default topic instead of disabling the exchange`, async () => {
         await community.edit({ pubsubTopic: undefined });
         expect(community.pubsubTopic).to.be.undefined;
         await community.start();
         await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
-        expect(community.pubsubTopic).to.be.undefined;
+        expect(community.pubsubTopic).to.equal(community.address);
+        expect(community.raw.communityIpfs!.pubsubTopic).to.equal(community.address);
 
         const post = await publishRandomPost({ communityAddress: community.address, pkc: pkc });
         // _community is private, use type assertion to access it for testing
-        expect((post as Comment & { _community?: Pick<CommunityIpfsType, "pubsubTopic"> })._community?.pubsubTopic).to.be.undefined;
+        expect((post as Comment & { _community?: Pick<CommunityIpfsType, "pubsubTopic"> })._community?.pubsubTopic).to.equal(
+            community.address
+        );
     });
 });
 

--- a/test/node/rpc/community-update-subscription-churn.rpc.test.ts
+++ b/test/node/rpc/community-update-subscription-churn.rpc.test.ts
@@ -32,7 +32,8 @@ import {
     createNewIpns,
     mockRpcServerForTests,
     mockRpcServerPKC,
-    resolveWhenConditionIsTrue
+    resolveWhenConditionIsTrue,
+    encryptionForSigner
 } from "../../../dist/node/test/test-util.js";
 import { signCommunity } from "../../../dist/node/signer/signatures.js";
 import { findUpdatingCommunity } from "../../../dist/node/pkc/tracked-instance-registry-util.js";
@@ -120,7 +121,12 @@ describe("RPC community update subscription survives concurrent sibling churn (#
         const newIpns = await createNewIpns();
         const { communityRecord: templateRecord, ipnsObj: templateIpns } = await createMockedCommunityIpns({});
         const makeRecord = async (signer: typeof newIpns.signer) => {
-            const record = <CommunityIpfsType>{ ...templateRecord, posts: undefined, pubsubTopic: newIpns.signer.address };
+            const record = <CommunityIpfsType>{
+                ...templateRecord,
+                posts: undefined,
+                pubsubTopic: newIpns.signer.address,
+                encryption: encryptionForSigner(signer)
+            };
             if (!record.posts) delete record.posts;
             record.signature = await signCommunity({ community: record, signer });
             return record;
@@ -333,52 +339,55 @@ describe("RPC community update subscription survives concurrent sibling churn (#
     // attached, stop the shared entry (what the refcount corruption / sibling-teardown cascade does
     // in CI), then publish the post-migration record. A correct implementation must recover the
     // subscription and deliver the record; the buggy build starves client A forever.
-    itIfRpc(`a subscription is permanently starved when its shared updating entry is stopped while still attached (#129 root cause)`, async () => {
-        const target = await createMigrationTargetWithInvalidRecord();
-        const { communityAddress: oldKeyA } = await createMockedCommunityIpns({});
-        const domain = `entry-stopped-under-sub-${Date.now()}.bso`;
-        resolverRecords.set(domain, target.newKey);
+    itIfRpc(
+        `a subscription is permanently starved when its shared updating entry is stopped while still attached (#129 root cause)`,
+        async () => {
+            const target = await createMigrationTargetWithInvalidRecord();
+            const { communityAddress: oldKeyA } = await createMockedCommunityIpns({});
+            const domain = `entry-stopped-under-sub-${Date.now()}.bso`;
+            resolverRecords.set(domain, target.newKey);
 
-        const clientA = await createClient();
-        try {
-            const communityA = await subscribeMigrationVictim(clientA, domain, oldKeyA, target.newKey);
+            const clientA = await createClient();
+            try {
+                const communityA = await subscribeMigrationVictim(clientA, domain, oldKeyA, target.newKey);
 
-            // The shared server-side updating entry that client A's subscription mirrors
-            const entry = getServerUpdatingEntry(domain);
-            expect(entry, "server should have an updating entry for the migrated domain").to.exist;
-            expect(entry!.state, "updating entry should be updating before it is stopped").to.equal("updating");
-            expect(
-                entry!._numOfListenersForUpdatingInstance,
-                "client A's subscription mirror should be attached to the shared updating entry"
-            ).to.be.greaterThan(0);
+                // The shared server-side updating entry that client A's subscription mirrors
+                const entry = getServerUpdatingEntry(domain);
+                expect(entry, "server should have an updating entry for the migrated domain").to.exist;
+                expect(entry!.state, "updating entry should be updating before it is stopped").to.equal("updating");
+                expect(
+                    entry!._numOfListenersForUpdatingInstance,
+                    "client A's subscription mirror should be attached to the shared updating entry"
+                ).to.be.greaterThan(0);
 
-            // Reproduce the CI end-state: the shared entry is stopped while client A's subscription
-            // is still attached. In CI this happened via refcount corruption during concurrent
-            // sibling teardown; here it is injected directly so the failure is deterministic.
-            await entry!.stop();
+                // Reproduce the CI end-state: the shared entry is stopped while client A's subscription
+                // is still attached. In CI this happened via refcount corruption during concurrent
+                // sibling teardown; here it is injected directly so the failure is deterministic.
+                await entry!.stop();
 
-            // End the pre-record window: the post-migration record is now deliverable
-            await target.publishRecord();
+                // End the pre-record window: the post-migration record is now deliverable
+                await target.publishRecord();
 
-            // The post-migration record must still reach client A. In the buggy build A's mirror was
-            // cascaded to "stopped" and never re-attached, so this never resolves (issue #129).
-            await withTimeout(
-                resolveWhenConditionIsTrue({
-                    toUpdate: communityA,
-                    predicate: async () => typeof communityA.updatedAt === "number"
-                }),
-                60_000,
-                "client A post-migration record after its shared updating entry was stopped (#129)"
-            );
-            expect(communityA.publicKey).to.equal(target.newKey);
-            expect(communityA.address).to.equal(domain);
+                // The post-migration record must still reach client A. In the buggy build A's mirror was
+                // cascaded to "stopped" and never re-attached, so this never resolves (issue #129).
+                await withTimeout(
+                    resolveWhenConditionIsTrue({
+                        toUpdate: communityA,
+                        predicate: async () => typeof communityA.updatedAt === "number"
+                    }),
+                    60_000,
+                    "client A post-migration record after its shared updating entry was stopped (#129)"
+                );
+                expect(communityA.publicKey).to.equal(target.newKey);
+                expect(communityA.address).to.equal(domain);
 
-            await communityA.stop();
-        } finally {
-            await target.destroy();
-            if (!clientA.destroyed) await clientA.destroy();
+                await communityA.stop();
+            } finally {
+                await target.destroy();
+                if (!clientA.destroyed) await clientA.destroy();
+            }
         }
-    });
+    );
 
     // Guard for the recovery added in #181: recovery must fire ONLY when a subscription is stranded
     // by internal churn, never when the client legitimately stops. Models the teardown in
@@ -394,9 +403,7 @@ describe("RPC community update subscription survives concurrent sibling churn (#
             const communities = await Promise.all(clients.map((c) => c.createCommunity({ address: communityAddress })));
             await Promise.all(communities.map((c) => c.update()));
             await Promise.all(
-                communities.map((c) =>
-                    resolveWhenConditionIsTrue({ toUpdate: c, predicate: async () => typeof c.updatedAt === "number" })
-                )
+                communities.map((c) => resolveWhenConditionIsTrue({ toUpdate: c, predicate: async () => typeof c.updatedAt === "number" }))
             );
             const serverEntry = () => findUpdatingCommunity(getServerPkc(), { publicKey: communityAddress }) as RemoteCommunity | undefined;
             expect(serverEntry(), "server should have a shared updating entry for the community").to.exist;
@@ -406,8 +413,7 @@ describe("RPC community update subscription survives concurrent sibling churn (#
             await new Promise((resolve) => setTimeout(resolve, 500));
 
             // No spurious recovery: the shared server-side entry must be fully cleaned up and stay gone
-            expect(serverEntry(), "shared entry must be cleaned up after all clients stop, not resurrected by recovery").to.be
-                .undefined;
+            expect(serverEntry(), "shared entry must be cleaned up after all clients stop, not resurrected by recovery").to.be.undefined;
             for (const c of communities) expect(c.state, "each client community must remain stopped").to.equal("stopped");
         } finally {
             await Promise.all(clients.map((c) => (c.destroyed ? Promise.resolve() : c.destroy())));

--- a/test/node/rpc/community-update-subscription-churn.rpc.test.ts
+++ b/test/node/rpc/community-update-subscription-churn.rpc.test.ts
@@ -497,6 +497,7 @@ describe("RPC community update subscription survives concurrent sibling churn (#
                 ...templateRecord,
                 posts: undefined,
                 pubsubTopic: newIpns.signer.address,
+                encryption: encryptionForSigner(newIpns.signer),
                 updatedAt
             };
             if (!record.posts) delete record.posts;


### PR DESCRIPTION
Implements #229. Separate implementation PR for the brief in #235, which holds test stubs only.

## What

`community.settings.disablePubsubChallengeExchange` (private boolean) turns a community read-only over the network, and the **absence of `pubsubTopic` now means "challenge exchange disabled"** — both `pubsubTopic || address` fallbacks are gone.

- Unset or `false`: unchanged. `pubsubTopic` is backfilled to the signer address at init.
- `true`: the published record omits `pubsubTopic`, the node does not subscribe to the challenge topic, and no challenge exchange happens over the network. The setting itself is never published, like the rest of `settings`.

## Fallbacks removed

- **Client.** `_communityPubsubTopicWithFallback()` splits into `_communityChallengeExchangeTopic()` (throws the new error; network path only) and `_communityChallengeMsgSignerAddress()` (identity check, below). Diagnostic and provider-filter sites read `_community?.pubsubTopic` directly so they tolerate absence instead of throwing.
- **Node.** `pubsubTopicWithfallback()` splits into `communityChallengePubsubTopic()` (raw derivation, used by stop/unsubscribe) and `challengeExchangePubsubTopic()` (`undefined` when disabled). The fallback is now the **signer address**, never `community.address` — the address must not stand in for a missing topic.
- `pubsubTopicRoutingCid` no longer derives from the address either, so a reader neither advertises nor looks up challenge-topic peers for a read-only community.

## Verification decoupled from `pubsubTopic`

`verifyChallengeMessage` / `verifyChallengeVerification` compared the message signer against the `pubsubTopic` string, which only worked because the topic is backfilled to that address. The check has always meant "signed by the community", never "equal to the topic".

The parameter is renamed to `communitySignerAddress` — renamed rather than reused, so no call site keeps passing a topic by accident — and is derived from `community.encryption.publicKey`. Consequences:

- the local publish shortcut keeps working for a community with no topic at all;
- a community with a **custom** `pubsubTopic` now verifies correctly, where it fails today, independent of this feature;
- it stays correct for a delegated community (#233), where the record is signed by the minter while the identity is the anchor.

`encryption.publicKey` rather than `signature.publicKey`: the client already encrypts the challenge request *to* it and decrypts the challenge *from* it, so whoever it names must hold the private key running the exchange, and is therefore the signer of its messages. `signature.publicKey` answers "who minted the record" — a role that only coincides because `initSignerProps` derives both from `community.signer`. It is derivable on demand, so no new field on `_community` is needed.

## New validation: `encryption.publicKey` must equal `signature.publicKey`

`verifyCommunity` validated the signature, reserved fields, pages, and that the IPNS name matches `signature.publicKey` — but nothing tied `encryption.publicKey` to anything. That gap matters once challenge verification reads it: the record signer is transitively anchored to the IPNS name the reader typed, while `encryption.publicKey` is only a signed field, so leaving them unrelated would let a record delegate the challenge exchange to a key the reader never validated against the address it typed.

`initSignerProps` has always derived both from `community.signer`, so this makes an existing invariant explicit rather than restricting what a community may publish. All five checked-in community fixtures satisfy it, **including both old wire formats**.

> **Reviewer call — wire compatibility.** If a non-pkc-js implementation deliberately uses a separate encryption key, this check now rejects those communities. Nothing pkc-js has published is affected.

> **Reviewer call — scope.** This validation is not strictly part of #229. It is defensible here because #229 makes challenge verification depend on `encryption.publicKey`, but it is a protocol-level change with its own blast radius and can be split into its own PR if you would rather keep this one narrow.

## The owner keeps publishing

The fast-fail sits on the network path only — after the `findStartedCommunity` shortcut and after the RPC-client return — so both owner paths still work with the exchange disabled: same-process via `_publishWithLocalCommunity`, and through the RPC server, which executes `publish()` in the process where the community runs. The shortcut still runs the full challenge pipeline; read-only mode removes the network path, not challenge evaluation. `_validateCommunityFields()` no longer demands a topic.

## Bugs and stale contracts found while testing

- **State round-trip wiped the configured topic.** `publishCommunityRecordToIpns` calls `initCommunityIpfsPropsNoMerge(newCommunityRecord)`, overwriting every `CommunityIpfs` prop from the record it just published, and `_updateDbInternalState` persists that. With `pubsubTopic` omitted, the configured topic was lost on the round trip — defeating the "a custom topic survives a disable/enable cycle" property that is the stated reason for choosing a boolean over encoding the state in `settings.pubsubTopic`. The topic is now restored after that overwrite, the same way remaining `_pendingEditProps` are re-applied just below it. Caught by the runtime-toggle test failing on the second half of the cycle.

- **Six fixture sites minted records no real community could produce.** `createMockedCommunityIpns`, `createDelegatedCommunityIpns`, `publishCommunityRecordWithExtraProp`, an inline builder in `nameresolvers.clients`, plus re-signing sites in `rpc.clients` and the RPC churn test all clone a live record via `getTemplateCommunityRecord()` and re-sign with a different key, leaving the template's `encryption` behind. They now re-derive it through a new exported `encryptionForSigner()` helper.

- **A pre-existing test asserted the contract this PR removes.** `misc.community.test.ts` had *"Publications can be published to a community with pubsubTopic=undefined"*, asserting the topic stays undefined and publishing still succeeds through the address fallback. Under the new rule, clearing `pubsubTopic` re-derives the default rather than producing a topic-less record — precisely the tri-state falsy hazard the boolean was chosen to avoid. Rewritten to the new contract: **only `settings.disablePubsubChallengeExchange` disables the exchange.**

## Backward compatibility

No flag day. Every record pkc-js has published carries an explicit `pubsubTopic` (the init backfill guarantees it), so no live record relies on the removed fallback. Old clients parse a read-only record fine — the field is already optional — and degrade to a timeout, the same as for an unreachable community. `CommunityIpfs` keeps `encryption`/`challenges` required. The `AuthorCommunityIpfs` all-or-none refine belongs to #31; that schema does not exist yet.

## Tests

Both files from #235's brief are filled in, no `it.todo` left:

- `test/node/community/local-community/disable-pubsub-challenge-exchange.test.ts` — node side: record shape, subscription behavior, the owner's local publish path, runtime toggling, and the topic-derivation helpers.
- `test/node-and-browser/community/challenge-exchange-disabled.test.ts` — client side, runs in the browser too. It mints the record directly instead of starting a community, so the client is tested against the wire shape alone.

The two owner-publishing cases assert the exchange **actually ran**, not just the publish outcome: they collect `challenge` / `challengeverification` events and assert the community issued the configured `1+1=?`, and that the failure case carries `challengeErrors: {"0": "Wrong answer."}` — a string only producible by the `question` challenge evaluating an answer. Asserting the outcome alone would be satisfied by a challenge that was never issued.

New in `signatures/community.test.ts`: a record whose `encryption.publicKey` is tampered **and re-signed** so it is otherwise valid, proving the new check is what rejects it rather than the signature check; plus a guard that every checked-in fixture satisfies the invariant.

Also updated: the assertions in `pubsub.test.ts` and `comment-updates.test.ts` that encoded the old address fallback, and the renamed parameter in `pubsub.messages.test.ts`.

### Results

| Suite | Result |
| --- | --- |
| `test/node/community/` (`local-kubo-rpc`) | 128/129 files, **1761 passed**, 45 skipped |
| `test/node-and-browser/{community,signatures,pubsub-msgs}` (`remote-kubo-rpc`) | 37/37 files, **317 passed**, 1 skipped |

**Not run:** the `remote-pkc-rpc` and browser configs. The node suite is `describeSkipIfRpc` because it reaches into the `LocalCommunity` instance and the kubo subscription list, so the owner's RPC publish path is asserted only indirectly, through the same-process shortcut it shares.

## Checklist status

- [x] Add `disablePubsubChallengeExchange` to the community settings schema
- [x] Branch the `pubsubTopic` backfill in `db-state.ts` on the setting
- [x] Skip the challenge-topic subscription when disabled; react to toggles in the sync loop
- [x] Remove both fallbacks and update all call sites
- [x] Decouple challenge message verification from `pubsubTopic`
- [x] Keep the owner's local and RPC publish paths working
- [x] Add `ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED` and fail fast in `publish()`
- [x] Fill in the `it.todo` stubs
- [x] Update `README.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `disablePubsubChallengeExchange` to support read-only communities, and preserve/republish an explicitly configured `pubsubTopic` across restarts and enable/disable cycles.
* **Bug Fixes**
  * Removed address-based PubSub fallback when challenge exchange is disabled; deterministic routing-CID derivation and correct state updates when providers are missing.
  * Publish/verification now uses the community’s direct `pubsubTopic`, with fail-fast errors when PubSub is disabled and stricter encryption/signature key consistency checks.
* **Documentation**
  * Updated setting docs to clarify retained-and-republished `pubsubTopic` behavior.
* **Tests**
  * Expanded end-to-end and RPC/non-RPC coverage for disabled exchange, topic switching, and renamed signer verification options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->