### PR TITLE
perf(helia): persist blocks per runtime behind a size-capped LRU blockstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ An object which may have the following keys:
 | pubsubKuboRpcClientsOptions | `(string \| KuboRpcClientOptions)[]` or `undefined` | `[{url: 'https://pubsubprovider.xyz/api/v0'}, {url: 'https://plebpubsub.xyz/api/v0'}]` | Optional URLs or [KuboRpcClientOptions](https://www.npmjs.com/package/kubo-rpc-client#options) used for pubsub publishing when `kuboRpcClientsOptions` isn't available, like in the browser |
 | pkcRpcClientsOptions | `string[]` or `undefined` | `undefined` | Optional websocket URLs of PKC RPC servers, required to run a community from a browser/electron/webview |
 | httpRoutersOptions | `string[]` or `undefined` | `['https://peers.pleb.bot', 'https://routing.lol', 'https://peers.forumindex.com', 'https://peers.plebpubsub.xyz', 'https://routerofbitsocial.xyz', 'https://bsotracker.online']` | URLs of HTTP delegated-routing endpoints used by `libp2pJsClientsOptions` for content/peer routing and IPNS lookups. Each URL must start with `http://` or `https://`. |
-| libp2pJsClientsOptions | `Array<{key: string, libp2pOptions?: Partial<Libp2pOptions>, heliaOptions?: Partial<HeliaOptions>}>` or `undefined` | `undefined` | Optional in-process libp2p/Helia client. When set, replaces `kuboRpcClientsOptions` and `pubsubKuboRpcClientsOptions` (which are then ignored). At most one entry; `key` is a unique identifier. `libp2pOptions` is forwarded to [Helia's libp2p](https://github.com/ipfs/helia) (e.g. `connectionGater`, `services`, transports), `heliaOptions` to [`createHelia`](https://github.com/ipfs/helia) (e.g. `blockstore`, `blockBrokers`). Requires `httpRoutersOptions` to be set. By default WebRTC and WebTransport dials are rejected so nodes (notably in the browser) connect over WebSocket(/WSS); pass your own `libp2pOptions.connectionGater` to override this (it fully replaces the default gater). |
+| libp2pJsClientsOptions | `Array<{key: string, libp2pOptions?: Partial<Libp2pOptions>, heliaOptions?: Partial<HeliaOptions>, blockstoreOptions?: {maxBytes?: number, lowWaterRatio?: number}}>` or `undefined` | `undefined` | Optional in-process libp2p/Helia client. When set, replaces `kuboRpcClientsOptions` and `pubsubKuboRpcClientsOptions` (which are then ignored). At most one entry; `key` is a unique identifier. `libp2pOptions` is forwarded to [Helia's libp2p](https://github.com/ipfs/helia) (e.g. `connectionGater`, `services`, transports), `heliaOptions` to [`createHelia`](https://github.com/ipfs/helia) (e.g. `blockstore`, `blockBrokers`). Requires `httpRoutersOptions` to be set. By default WebRTC and WebTransport dials are rejected so nodes (notably in the browser) connect over WebSocket(/WSS); pass your own `libp2pOptions.connectionGater` to override this (it fully replaces the default gater). `blockstoreOptions` tunes the block cache described below. |
 | dataPath | `string` or `undefined` | `.pkc` folder in the current working directory | (Node only) Optional folder path to create/resume the user and community databases |
 | resolveAuthorNames | `boolean` or `undefined` | `true` | Optionally disable resolving crypto domain author names, which can be done lazily later to save time |
 | nameResolvers | `NameResolver[]` or `undefined` | `undefined` | Custom resolvers for crypto domain names. Each resolver: `{key, resolve, canResolve, provider, destroy?}`. |
@@ -584,6 +584,29 @@ process.on('uncaughtException', (err) => console.error(err))
 Attaching an `'error'` listener directly on a `community`, `comment`, or other publication object stops the bubble-up: in that case the error stays on the child and is not re-emitted on the pkc instance.
 
 ### `pkc.clients.libp2pJsClients[key].heliaNode`
+
+#### Block storage and eviction
+
+The in-process libp2p/Helia client caches every block it fetches. Blocks are persisted per runtime
+(on disk under `dataPath` in Node, in IndexedDB in the browser) so a restart or a page refresh does
+not re-fetch content that was already verified, and the cache is bounded by a size-capped LRU:
+once `maxBytes` is reached the least recently used blocks are evicted down to `lowWaterRatio` of
+the cap.
+
+Defaults are 250MB in the browser and 1GB in Node, which at a measured ~20MB/hour for 65
+communities subscribed and updating is roughly 12 hours and 2 days of continuous use respectively.
+Override with `blockstoreOptions`:
+
+```js
+const pkc = await PKC({
+    libp2pJsClientsOptions: [{ key: 'main', blockstoreOptions: { maxBytes: 50 * 1024 * 1024 } }],
+    httpRoutersOptions: ['https://peers.pleb.bot']
+})
+```
+
+Nothing is pinned: every cached block is refetchable from the network, so eviction is safe and an
+eviction that lands during an in-flight load costs a re-fetch rather than an error. Supplying your
+own `heliaOptions.blockstore` disables all of this and hands block storage to you.
 
 > When the instance runs an in-process libp2p/Helia node (`libp2pJsClientsOptions`), `heliaNode` returns the running [Helia](https://github.com/ipfs/helia) node so libraries that share the node (e.g. [@bitsocial/pubsub-voting](https://github.com/bitsocialnet/pubsub-voting), [bitsocial-seeder](https://github.com/bitsocialnet/bitsocial-seeder)) can drive it directly. This accessor is the public, semver-covered surface for reaching the node — a breaking change to what it returns is a breaking pkc-js release. Do not reach through the private `_helia` field.
 

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -55,12 +55,20 @@ const defaultBrowserInclude = ["test/*browser/**/*.test.{js,ts}"];
 const nodeTestInclude = includeOverride ?? defaultNodeInclude;
 const browserTestInclude = includeOverride ?? defaultBrowserInclude;
 
+// Playwright ships no prebuilt browser for some newer distros (`npx playwright install chromium`
+// fails with "does not support chromium on ubuntu26.04-x64"), so allow pointing it at a browser that
+// is already on the machine. Unset everywhere else, which keeps CI on playwright's own download.
+const browserExecutablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+
 const playwrightProvider = playwright(
     isFirefox
-        ? {}
+        ? browserExecutablePath
+            ? { launchOptions: { executablePath: browserExecutablePath } }
+            : {}
         : {
               launchOptions: {
-                  args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-web-security"]
+                  args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-web-security"],
+                  ...(browserExecutablePath ? { executablePath: browserExecutablePath } : {})
               }
           }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
                 "assert": "2.1.0",
                 "better-sqlite3": "12.9.0",
                 "blockstore-core": "7.0.1",
+                "blockstore-fs": "^4.0.1",
+                "blockstore-idb": "^4.0.1",
                 "buffer": "6.0.3",
                 "cbor": "10.0.11",
                 "cborg": "4.5.8",
@@ -6179,6 +6181,93 @@
             "integrity": "sha512-fz1oJJ36ciGnu2LntAlE6SA97bFZpW7Rnt0uEc1yazzR2nKokZLr8lIRtgnpex4NsmaBcvHF+Z9krljWFy/mmg==",
             "license": "Apache-2.0 OR MIT"
         },
+        "node_modules/blockstore-fs": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/blockstore-fs/-/blockstore-fs-4.0.1.tgz",
+            "integrity": "sha512-UXTG85jT+b4xumiHwqyZBnAqfxCqGgGl5ZszSGpnje7yEIrv2pO3NzttAz9DHwzaZxE2nBPMaPlg+SJ8VGlPrg==",
+            "license": "Apache-2.0 OR MIT",
+            "dependencies": {
+                "abort-error": "^1.0.2",
+                "interface-blockstore": "^7.0.0",
+                "interface-store": "^8.0.0",
+                "it-glob": "^3.0.4",
+                "it-map": "^3.1.4",
+                "it-parallel-batch": "^3.0.9",
+                "multiformats": "^14.0.0",
+                "race-signal": "^2.0.0",
+                "steno": "^4.0.2"
+            }
+        },
+        "node_modules/blockstore-fs/node_modules/interface-blockstore": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-7.0.1.tgz",
+            "integrity": "sha512-a3NsgRXpRppVWtQnJjmZ9jxvjcttY1+WNWqHFWwgKhRcNMMGwWGtFNYpQmcZ+mEnIt5NTJVYzNwLCcALMWPNsA==",
+            "license": "Apache-2.0 OR MIT",
+            "dependencies": {
+                "interface-store": "^8.0.0",
+                "multiformats": "^14.0.0"
+            }
+        },
+        "node_modules/blockstore-fs/node_modules/interface-store": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
+            "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
+            "license": "Apache-2.0 OR MIT",
+            "dependencies": {
+                "abort-error": "^1.0.2"
+            }
+        },
+        "node_modules/blockstore-idb": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/blockstore-idb/-/blockstore-idb-4.0.1.tgz",
+            "integrity": "sha512-ZfqKiJZ7wCokOrWsKtGULypIEYH+58mS/jvLk43wDMMjvNxAUPobzblzGtf+uDEE3qpYELTqjeBbS+5YCGUwFA==",
+            "license": "Apache-2.0 OR MIT",
+            "dependencies": {
+                "abort-error": "^1.0.2",
+                "blockstore-core": "^7.0.0",
+                "idb": "^8.0.3",
+                "interface-blockstore": "^7.0.0",
+                "interface-store": "^8.0.0",
+                "it-all": "^3.0.9",
+                "it-to-buffer": "^5.0.0",
+                "multiformats": "^14.0.0",
+                "race-signal": "^2.0.0"
+            }
+        },
+        "node_modules/blockstore-idb/node_modules/interface-blockstore": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-7.0.1.tgz",
+            "integrity": "sha512-a3NsgRXpRppVWtQnJjmZ9jxvjcttY1+WNWqHFWwgKhRcNMMGwWGtFNYpQmcZ+mEnIt5NTJVYzNwLCcALMWPNsA==",
+            "license": "Apache-2.0 OR MIT",
+            "dependencies": {
+                "interface-store": "^8.0.0",
+                "multiformats": "^14.0.0"
+            }
+        },
+        "node_modules/blockstore-idb/node_modules/interface-store": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-8.0.0.tgz",
+            "integrity": "sha512-e2+s3EEROzM+Wlas4hU3zveTUscvVMf1BOvdsJfpzFm19SoEXLVadpACjWOnM491HqGpvtfFnevyiaN8W+I6Eg==",
+            "license": "Apache-2.0 OR MIT",
+            "dependencies": {
+                "abort-error": "^1.0.2"
+            }
+        },
+        "node_modules/blockstore-idb/node_modules/it-all": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.11.tgz",
+            "integrity": "sha512-Gvqj6MO4GMLnFdtE68HZRpGBskNC+9+GQ+JevTGNYLyhjUuPhjDLU3jN1LpBemXJDW1bRSkczqA/qGyKlPKrcQ==",
+            "license": "Apache-2.0 OR MIT"
+        },
+        "node_modules/blockstore-idb/node_modules/it-to-buffer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-5.0.0.tgz",
+            "integrity": "sha512-DyinWj+79wxFDQNiPZcmV8Fz2PJFOcM3KRRN4GiZiIdEfxO11cCkrZJMfUMrxryy+rLoNhAfh1bpoVUFHPR6pQ==",
+            "license": "Apache-2.0 OR MIT",
+            "dependencies": {
+                "uint8arrays": "^6.1.0"
+            }
+        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -10227,6 +10316,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/idb": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+            "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+            "license": "ISC"
         },
         "node_modules/ieee754": {
             "version": "1.2.1",
@@ -18239,6 +18334,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/steno": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/steno/-/steno-4.0.2.tgz",
+            "integrity": "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/typicode"
             }
         },
         "node_modules/stop-iteration-iterator": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
         "assert": "2.1.0",
         "better-sqlite3": "12.9.0",
         "blockstore-core": "7.0.1",
+        "blockstore-fs": "^4.0.1",
+        "blockstore-idb": "^4.0.1",
         "buffer": "6.0.3",
         "cbor": "10.0.11",
         "cborg": "4.5.8",

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -8,7 +8,8 @@ import extraLibp2pTransports from "../runtime/node/libp2p-extra-transports.js";
 import { CID } from "multiformats/cid";
 import { peerIdFromString } from "@libp2p/peer-id";
 import { bitswap } from "@helia/block-brokers";
-import { MemoryBlockstore } from "blockstore-core";
+import { createBlockstoreForLibp2pJsClient } from "../runtime/node/blockstore.js";
+import { LruBlockstore } from "./lru-blockstore.js";
 import { delegatedRoutingV1HttpApiClientContentRouting } from "@helia/delegated-routing-v1-http-api-client";
 import { NotFoundError, type AbortOptions } from "@libp2p/interface";
 import { unixfs } from "@helia/unixfs";
@@ -103,7 +104,9 @@ function getDelegatedRoutingFields(routers: string[]) {
 }
 
 export async function createLibp2pJsClientOrUseExistingOne(
-    pkcOptions: Required<Pick<ParsedPKCOptions, "httpRoutersOptions">> & NonNullable<ParsedPKCOptions["libp2pJsClientsOptions"]>[number]
+    pkcOptions: Required<Pick<ParsedPKCOptions, "httpRoutersOptions">> &
+        Pick<ParsedPKCOptions, "dataPath"> &
+        NonNullable<ParsedPKCOptions["libp2pJsClientsOptions"]>[number]
 ): Promise<Libp2pJsClient> {
     if (!pkcOptions.httpRoutersOptions?.length) throw Error("You need to have pkc.httpRouterOptions to set up helia");
     const existingClient = libp2pJsClients[pkcOptions.key];
@@ -120,6 +123,35 @@ export async function createLibp2pJsClientOrUseExistingOne(
     }
 
     creatingLibp2pJsClients[pkcOptions.key] = (async () => {
+        // A caller supplying their own heliaOptions.blockstore owns block storage entirely, so skip
+        // ours rather than opening a directory or IndexedDB database nothing will read.
+        let lruBlockstore: LruBlockstore | undefined;
+        let closeBlockstore = async () => {};
+        if (!pkcOptions.heliaOptions?.blockstore) {
+            const {
+                blockstore: childBlockstore,
+                persistent,
+                defaultMaxBytes,
+                close
+            } = await createBlockstoreForLibp2pJsClient({
+                dataPath: pkcOptions.dataPath,
+                key: pkcOptions.key
+            });
+            closeBlockstore = close;
+            // defaultMaxBytes comes from the backend we actually got: falling back to an in-memory
+            // store means the cap is a heap budget, not a disk budget, and must be far smaller.
+            lruBlockstore = new LruBlockstore(childBlockstore, {
+                maxBytes: pkcOptions.blockstoreOptions?.maxBytes ?? defaultMaxBytes,
+                lowWaterRatio: pkcOptions.blockstoreOptions?.lowWaterRatio
+            });
+            // Only a persistent backend can hold blocks we did not put this session. The scan reads
+            // every block back to learn its size, so it runs in the background: blocking PKC init on
+            // it would add the whole store's read time to the first load. Until it finishes the
+            // store may sit over its cap, because we cannot evict what we have not counted yet.
+            if (persistent)
+                lruBlockstore.rebuildIndex().catch((e) => log.error("Failed to rebuild blockstore index for key", pkcOptions.key, e));
+        }
+
         const heliaLibp2pDefaults = libp2pDefaults();
         const mergedHeliaInit = {
             libp2p: {
@@ -158,10 +190,12 @@ export async function createLibp2pJsClientOrUseExistingOne(
                     ...pkcOptions.libp2pOptions?.services
                 }
             },
-            // MemoryBlockstore: blocks lost on restart, every cold start re-fetches from network.
-            // Future optimization: blockstore-fs (Node) / blockstore-idb (browser). Not prioritized
-            // - pkc-js is browser-first and per-session usage dominates today.
-            blockstore: new MemoryBlockstore(),
+            // Persistent per runtime (blockstore-fs on node, blockstore-idb in the browser) behind a
+            // size-capped LRU. Helia never evicts on its own: every fetched block is written to the
+            // blockstore and only `helia.gc()` (pin-based, and we pin nothing) or dropping the whole
+            // instance ever removes one, so an unbounded store grows for the life of the process.
+            // See pkc-js#240 for the measurement behind the cap.
+            blockstore: lruBlockstore,
             blockBrokers: [bitswap()],
             start: false,
             ...pkcOptions.heliaOptions
@@ -757,6 +791,16 @@ export async function createLibp2pJsClientOrUseExistingOne(
                         await helia.stop();
                     } catch (e) {
                         log.error("Error stopping helia", e);
+                    }
+
+                    // helia.stop() does not touch the blockstore: blockstore-fs/idb expose
+                    // open()/close() rather than the Startable start()/stop() that helia's
+                    // start(...) helper looks for, so the file handles and IDB connection are ours
+                    // to release.
+                    try {
+                        await closeBlockstore();
+                    } catch (e) {
+                        log.error("Error closing blockstore", e);
                     }
 
                     log("Helia/libp2p-js stopped with key", pkcOptions.key, "and peer id", helia.libp2p.peerId.toString());

--- a/src/helia/lru-blockstore.ts
+++ b/src/helia/lru-blockstore.ts
@@ -1,0 +1,273 @@
+import { base32 } from "multiformats/bases/base32";
+import { CID } from "multiformats/cid";
+import * as Digest from "multiformats/hashes/digest";
+import * as raw from "multiformats/codecs/raw";
+import type { AbortOptions, AwaitIterable } from "interface-store";
+import Logger from "../logger.js";
+
+const log = Logger("pkc-js:libp2p-js:blockstore");
+
+/**
+ * The dependency tree contains more than one copy of multiformats (helia 6's internals are still on
+ * 13 while our tree is on 14), and blockstore-core ships its own nested interface-blockstore. A CID
+ * handed to us by helia is therefore not the same class as a CID we construct, and the packages'
+ * `Blockstore`/`Pair` types are not mutually assignable.
+ *
+ * This wrapper sidesteps all of it by typing structurally: the only thing it ever needs from a CID
+ * is the multihash bytes, and every backend we use (blockstore-core, blockstore-fs, blockstore-idb)
+ * addresses blocks by exactly those bytes and ignores the codec.
+ */
+export interface BlockstoreCid {
+    multihash: { bytes: Uint8Array };
+}
+
+export interface BlockstorePair {
+    cid: BlockstoreCid;
+    bytes: AwaitIterable<Uint8Array>;
+}
+
+export interface ChildBlockstore {
+    has(cid: BlockstoreCid, options?: AbortOptions): boolean | Promise<boolean>;
+    put(cid: BlockstoreCid, val: Uint8Array | AwaitIterable<Uint8Array>, options?: AbortOptions): unknown;
+    get(cid: BlockstoreCid, options?: AbortOptions): AwaitIterable<Uint8Array>;
+    delete(cid: BlockstoreCid, options?: AbortOptions): void | Promise<void>;
+    getAll(options?: AbortOptions): AwaitIterable<BlockstorePair>;
+}
+
+export interface LruBlockstoreOptions {
+    // hard ceiling on the total size of stored blocks
+    maxBytes: number;
+    // when maxBytes is reached, evict down to this fraction of it, so we do not run an eviction on
+    // every subsequent put at the boundary
+    lowWaterRatio?: number;
+}
+
+// Sum an incoming block value, which the streaming blockstore API allows to be either a single
+// Uint8Array or an (async) iterable of chunks. We have to materialize it either way: the value is
+// consumed once, so measuring it and then handing the original iterable to the child would give
+// the child an already-drained iterator.
+async function materialize(val: Uint8Array | AwaitIterable<Uint8Array>): Promise<{ chunks: Uint8Array[]; size: number }> {
+    if (val instanceof Uint8Array) return { chunks: [val], size: val.byteLength };
+    const chunks: Uint8Array[] = [];
+    let size = 0;
+    for await (const chunk of val) {
+        chunks.push(chunk);
+        size += chunk.byteLength;
+    }
+    return { chunks, size };
+}
+
+// blockstore-core keys on `base32(cid.multihash.bytes)`, blockstore-idb on the base32upper of the
+// same bytes, and blockstore-fs shards on them too, so a CID rebuilt with the raw codec addresses
+// the same block that was originally put under dag-pb or any other codec.
+function cidFromIndexKey(key: string): CID {
+    return CID.createV1(raw.code, Digest.decode(base32.decode(key)));
+}
+
+/**
+ * A size-capped LRU cache in front of any blockstore.
+ *
+ * pkc-js pins nothing: every block we hold is refetchable from the network and we are not a
+ * provider of record for any of it. So the eviction policy here is a plain cache policy rather
+ * than helia's pin-based `gc()`, which with zero pins would simply delete everything.
+ *
+ * Recency is tracked by `_sizes` insertion order (a Map iterates in insertion order, so the front
+ * is the least recently used). Reads and writes move a key to the back; `getAll` deliberately does
+ * NOT, since a full scan would otherwise flatten the LRU ordering into scan order.
+ *
+ * Nothing protects a block that an in-flight DAG walk is midway through reading. Worst case an
+ * eviction lands between two blocks of an active load and that load re-fetches the block, which is
+ * latency rather than corruption. Do not "fix" this with pins.
+ */
+export class LruBlockstore {
+    private readonly _child: ChildBlockstore;
+    private readonly _maxBytes: number;
+    private readonly _lowWaterBytes: number;
+    // base32(multihash) => block size in bytes. Insertion order is the LRU order.
+    private readonly _sizes = new Map<string, number>();
+    private _totalBytes = 0;
+    // serializes eviction runs so two concurrent puts cannot both evict down to the low water mark
+    private _evicting?: Promise<void>;
+
+    constructor(child: ChildBlockstore, options: LruBlockstoreOptions) {
+        if (!(options.maxBytes > 0)) throw Error("LruBlockstore requires a positive maxBytes");
+        const lowWaterRatio = options.lowWaterRatio ?? 0.75;
+        if (!(lowWaterRatio > 0 && lowWaterRatio <= 1)) throw Error("LruBlockstore requires lowWaterRatio in (0, 1]");
+        this._child = child;
+        this._maxBytes = options.maxBytes;
+        this._lowWaterBytes = Math.floor(options.maxBytes * lowWaterRatio);
+    }
+
+    get totalBytes() {
+        return this._totalBytes;
+    }
+
+    get blockCount() {
+        return this._sizes.size;
+    }
+
+    private _keyOf(cid: BlockstoreCid) {
+        return base32.encode(cid.multihash.bytes);
+    }
+
+    // move an already-known key to the back of the LRU order
+    private _touch(key: string) {
+        const size = this._sizes.get(key);
+        if (size === undefined) return;
+        this._sizes.delete(key);
+        this._sizes.set(key, size);
+    }
+
+    private _register(key: string, size: number) {
+        const previous = this._sizes.get(key);
+        if (previous !== undefined) {
+            this._totalBytes -= previous;
+            this._sizes.delete(key);
+        }
+        this._sizes.set(key, size);
+        this._totalBytes += size;
+    }
+
+    private _unregister(key: string) {
+        const size = this._sizes.get(key);
+        if (size === undefined) return;
+        this._sizes.delete(key);
+        this._totalBytes -= size;
+    }
+
+    async has(cid: BlockstoreCid, options?: AbortOptions) {
+        return this._child.has(cid, options);
+    }
+
+    async put(cid: BlockstoreCid, val: Uint8Array | AwaitIterable<Uint8Array>, options?: AbortOptions) {
+        const { chunks, size } = await materialize(val);
+        await this._child.put(cid, chunks, options);
+        this._register(this._keyOf(cid), size);
+        await this._evictIfNeeded();
+        return cid;
+    }
+
+    async *get(cid: BlockstoreCid, options?: AbortOptions) {
+        const key = this._keyOf(cid);
+        const known = this._sizes.has(key);
+        if (known) this._touch(key);
+        let size = 0;
+        try {
+            for await (const chunk of this._child.get(cid, options)) {
+                size += chunk.byteLength;
+                yield chunk;
+            }
+        } catch (e) {
+            // The block is gone from the child but still in our index, so the index is now lying
+            // about both the block count and the byte total. Happens when a second process sharing
+            // the same directory evicted it, or when something outside pkc-js cleaned the store.
+            // Drop it so the accounting stays honest and the cap keeps meaning what it says.
+            this._unregister(key);
+            throw e;
+        }
+        // A block already in a persistent child from a previous session is absent from the index
+        // until something reads it (or the rebuild scan reaches it), so register it now that its
+        // size is known. Only on full consumption: a caller that abandons the iterator mid-block
+        // would otherwise register a short size and drift the byte total downward.
+        if (!known) {
+            this._register(key, size);
+            await this._evictIfNeeded();
+        }
+    }
+
+    async delete(cid: BlockstoreCid, options?: AbortOptions) {
+        await this._child.delete(cid, options);
+        this._unregister(this._keyOf(cid));
+    }
+
+    // blockstore-core's BaseBlockstore would supply these in terms of put/get/delete, but extending
+    // it would pull in its nested interface-blockstore copy and that copy's incompatible Pair type.
+    async *putMany(source: AwaitIterable<{ cid: BlockstoreCid; bytes: Uint8Array | AwaitIterable<Uint8Array> }>, options?: AbortOptions) {
+        for await (const { cid, bytes } of source) {
+            await this.put(cid, bytes, options);
+            yield cid;
+        }
+    }
+
+    async *getMany(source: AwaitIterable<BlockstoreCid>, options?: AbortOptions) {
+        for await (const cid of source) yield { cid, bytes: this.get(cid, options) };
+    }
+
+    async *deleteMany(source: AwaitIterable<BlockstoreCid>, options?: AbortOptions) {
+        for await (const cid of source) {
+            await this.delete(cid, options);
+            yield cid;
+        }
+    }
+
+    async *getAll(options?: AbortOptions) {
+        // deliberately does not touch: see class docstring
+        yield* this._child.getAll(options);
+    }
+
+    private async _evictIfNeeded() {
+        if (this._totalBytes <= this._maxBytes) return;
+        // fold into an in-flight run rather than starting a second one
+        if (this._evicting) return this._evicting;
+        this._evicting = this._evict().finally(() => {
+            this._evicting = undefined;
+        });
+        return this._evicting;
+    }
+
+    private async _evict() {
+        const startBytes = this._totalBytes;
+        let evicted = 0;
+        while (this._totalBytes > this._lowWaterBytes) {
+            // Map iteration order is insertion order, so the first entry is the least recently used
+            const oldest = this._sizes.keys().next();
+            if (oldest.done === true) break;
+            const key = oldest.value;
+            const size = this._sizes.get(key) ?? 0;
+            // Drop from the index first: if the child delete fails we must not keep counting bytes
+            // for a block we have given up on, or the total drifts upward forever and every
+            // subsequent put triggers a futile eviction pass.
+            this._sizes.delete(key);
+            this._totalBytes -= size;
+            evicted++;
+            try {
+                await this._child.delete(cidFromIndexKey(key));
+            } catch (e) {
+                log.error("Failed to evict block from blockstore", key, e);
+            }
+        }
+        log(
+            `Evicted ${evicted} blocks from blockstore, ${startBytes} bytes => ${this._totalBytes} bytes (max ${this._maxBytes}, low water ${this._lowWaterBytes})`
+        );
+    }
+
+    /**
+     * Populate the index from a child that already holds blocks (a persistent backend on a second
+     * run). Sizes are only knowable by reading every block back, so this is O(store) in IO and is
+     * meant to be kicked off in the background rather than awaited before the first load. Until it
+     * finishes the store can sit over its cap, since we cannot evict what we have not counted.
+     *
+     * Resilient by design: blockstore-fs reconstructs a CID in `getAll` by decoding raw multihash
+     * bytes, which throws for any hash that is not a valid CIDv0 (i.e. anything but sha2-256).
+     * A store holding such a block would otherwise abort the whole scan, so a failure here leaves
+     * a partial index rather than propagating.
+     */
+    async rebuildIndex(options?: AbortOptions) {
+        let scanned = 0;
+        try {
+            for await (const { cid, bytes } of this._child.getAll(options)) {
+                const key = this._keyOf(cid);
+                if (this._sizes.has(key)) continue; // written during the scan; already counted
+                let size = 0;
+                for await (const chunk of bytes) size += chunk.byteLength;
+                this._register(key, size);
+                scanned++;
+            }
+        } catch (e) {
+            log.error("Failed to fully rebuild blockstore index, continuing with a partial index", e);
+        }
+        log(`Rebuilt blockstore index from ${scanned} existing blocks, ${this._totalBytes} bytes`);
+        await this._evictIfNeeded();
+        return { blocks: scanned, bytes: this._totalBytes };
+    }
+}

--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -375,7 +375,10 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         for (const clientOptions of this.libp2pJsClientsOptions) {
             const heliaNode = await createLibp2pJsClientOrUseExistingOne({
                 ...clientOptions,
-                httpRoutersOptions: this.httpRoutersOptions
+                httpRoutersOptions: this.httpRoutersOptions,
+                // where the persistent blockstore lives on node; undefined (noData, or the browser)
+                // falls back to an in-memory blockstore
+                dataPath: this.dataPath
             });
             this.clients.libp2pJsClients[clientOptions.key] = heliaNode;
         }

--- a/src/runtime/browser/blockstore.ts
+++ b/src/runtime/browser/blockstore.ts
@@ -1,0 +1,51 @@
+import { IDBBlockstore } from "blockstore-idb";
+import { MemoryBlockstore } from "blockstore-core";
+import type { Blockstore } from "interface-blockstore";
+
+export interface PkcBlockstore {
+    blockstore: Blockstore;
+    // true when blocks outlive the page, which is what makes the index rebuild worth running
+    persistent: boolean;
+    // cap to use when the caller did not set one; depends on whether we landed in IndexedDB or in memory
+    defaultMaxBytes: number;
+    close: () => Promise<void>;
+}
+
+// Measured growth is ~20MB/hour with 65 communities subscribed and updating (see pkc-js#240), so
+// 250MB is ~12h of continuous use before the first eviction: a normal tab session never evicts and
+// only a marathon or pinned tab does. It also stays well inside Chrome's per-origin quota and
+// Firefox's group limit, so we are never the reason the browser evicts the whole origin.
+export const DEFAULT_BLOCKSTORE_MAX_BYTES = 250 * 1024 * 1024;
+
+// The IndexedDB cap would be a poor memory cap: on the fallback path the blocks sit in the heap of
+// a tab that also has to render an app, so keep it well clear of a tab crash.
+export const DEFAULT_IN_MEMORY_BLOCKSTORE_MAX_BYTES = 100 * 1024 * 1024;
+
+/**
+ * Browser block storage for the libp2p-js client: blocks in IndexedDB so a refresh does not
+ * re-fetch everything from the network.
+ *
+ * The browser may evict the whole origin under storage pressure, so the store is treated as a
+ * cache that can vanish between sessions rather than as durable state. Nothing we keep here is
+ * unrecoverable: every block is refetchable from the network.
+ *
+ * If IndexedDB is unavailable (private-mode restrictions, a disabled origin, a non-DOM worker
+ * without it) we fall back to memory rather than failing PKC construction: a slower client beats
+ * no client.
+ */
+export async function createBlockstoreForLibp2pJsClient({ dataPath, key }: { dataPath?: string; key: string }): Promise<PkcBlockstore> {
+    // dataPath is a node concept, accepted here only to keep one signature across runtimes
+    void dataPath;
+    try {
+        const store = new IDBBlockstore(`pkc-js-blockstore-${key}`);
+        await store.open();
+        return { blockstore: store, persistent: true, defaultMaxBytes: DEFAULT_BLOCKSTORE_MAX_BYTES, close: () => store.close() };
+    } catch {
+        return {
+            blockstore: new MemoryBlockstore(),
+            persistent: false,
+            defaultMaxBytes: DEFAULT_IN_MEMORY_BLOCKSTORE_MAX_BYTES,
+            close: async () => {}
+        };
+    }
+}

--- a/src/runtime/node/blockstore.ts
+++ b/src/runtime/node/blockstore.ts
@@ -1,0 +1,55 @@
+import { FsBlockstore } from "blockstore-fs";
+import { MemoryBlockstore } from "blockstore-core";
+import path from "path";
+import type { Blockstore } from "interface-blockstore";
+
+export interface PkcBlockstore {
+    blockstore: Blockstore;
+    // true when blocks outlive the process, which is what makes the index rebuild worth running
+    persistent: boolean;
+    // cap to use when the caller did not set one; depends on whether we landed on disk or in memory
+    defaultMaxBytes: number;
+    close: () => Promise<void>;
+}
+
+// Measured growth is ~20MB/hour with 65 communities subscribed and updating (see pkc-js#240), so
+// 1GB is a bit over two days of continuous use before the first eviction. Desktop/CLI disk is
+// cheap and node consumers often run the kubo path anyway, so this is deliberately generous.
+export const DEFAULT_BLOCKSTORE_MAX_BYTES = 1024 * 1024 * 1024;
+
+// The disk cap would be a terrible memory cap: without a dataPath the blocks are held in the heap,
+// where a gigabyte is an out-of-memory crash rather than a cache.
+export const DEFAULT_IN_MEMORY_BLOCKSTORE_MAX_BYTES = 100 * 1024 * 1024;
+
+/**
+ * Node block storage for the libp2p-js client: blocks on disk under the pkc data directory so a
+ * restart does not re-fetch everything from the network.
+ *
+ * Falls back to memory when there is no dataPath (`noData`, or a browser-shaped consumer running
+ * under node), since there is nowhere to put a directory.
+ *
+ * Each libp2p-js client key gets its own directory. Two processes pointed at the same dataPath and
+ * the same key share one directory. Unlike the community databases (which take a proper-lock-file
+ * lock, see db-handler.ts) this is deliberately NOT locked: a lock would stop the second process
+ * from running at all, which is the wrong trade for a cache that both can safely use. Measured
+ * behaviour when shared:
+ *   - concurrent writes of the same block are safe; blockstore-fs writes via steno (temp file plus
+ *     atomic rename) and explicitly tolerates another context having created the file,
+ *   - a block one process evicts while another is reading it surfaces as a NotFoundError, which
+ *     fails that one load and self-heals on retry (the next `has` misses and refetches),
+ *   - the size cap is per process, so N processes sharing a directory can leave up to N times
+ *     maxBytes on disk.
+ */
+export async function createBlockstoreForLibp2pJsClient({ dataPath, key }: { dataPath?: string; key: string }): Promise<PkcBlockstore> {
+    if (!dataPath)
+        return {
+            blockstore: new MemoryBlockstore(),
+            persistent: false,
+            defaultMaxBytes: DEFAULT_IN_MEMORY_BLOCKSTORE_MAX_BYTES,
+            close: async () => {}
+        };
+
+    const store = new FsBlockstore(path.join(dataPath, "blockstore", key));
+    await store.open();
+    return { blockstore: store, persistent: true, defaultMaxBytes: DEFAULT_BLOCKSTORE_MAX_BYTES, close: () => store.close() };
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -100,7 +100,17 @@ export const PKCUserOptionBaseSchema = z.object({
         .object({
             key: z.string().min(1),
             libp2pOptions: z.custom<libp2pOptions>().default({}),
-            heliaOptions: z.custom<Partial<heliaOptions>>().default({})
+            heliaOptions: z.custom<Partial<heliaOptions>>().default({}),
+            // Size cap for the libp2p-js block cache. Defaults per runtime (see
+            // runtime/{node,browser}/blockstore.ts) and is ignored when heliaOptions.blockstore is
+            // supplied, since the caller then owns block storage entirely.
+            blockstoreOptions: z
+                .object({
+                    maxBytes: z.number().positive().optional(),
+                    // evict down to this fraction of maxBytes when the cap is hit
+                    lowWaterRatio: z.number().gt(0).lte(1).optional()
+                })
+                .optional()
         })
         .array()
         .max(1, "Only one libp2pJsClientOptions is allowed at the moment")

--- a/test/node-and-browser/helia/lru-blockstore-idb.test.ts
+++ b/test/node-and-browser/helia/lru-blockstore-idb.test.ts
@@ -1,0 +1,152 @@
+// Browser-side coverage for the size-capped LRU blockstore (https://github.com/pkcprotocol/pkc-js/issues/240).
+//
+// The unit tests under test/node cover the LRU over blockstore-core and blockstore-fs. This file
+// covers the backend the browser actually uses, blockstore-idb, because IndexedDB differs from both
+// in the ways most likely to break the wrapper: values come back as a single chunk rather than a
+// stream, and the store survives being closed and reopened, which is the whole point of persisting.
+//
+// Skipped outside a browser: blockstore-idb needs a real IndexedDB, and node has none.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { IDBBlockstore } from "blockstore-idb";
+import { CID } from "multiformats/cid";
+import * as raw from "multiformats/codecs/raw";
+import { sha256 } from "multiformats/hashes/sha2";
+import { LruBlockstore } from "../../../dist/node/helia/lru-blockstore.js";
+import { isRunningInBrowser } from "../../../dist/node/test/test-util.js";
+
+const describeSkipIfNotBrowser = isRunningInBrowser() ? describe : describe.skip;
+
+async function blockOf(label: string, size: number) {
+    const bytes = new Uint8Array(size).fill(label.charCodeAt(0));
+    bytes.set(new TextEncoder().encode(label).subarray(0, Math.min(label.length, size)));
+    const cid = CID.createV1(raw.code, await sha256.digest(bytes));
+    return { cid, bytes };
+}
+
+async function readSize(store: LruBlockstore, cid: CID) {
+    let size = 0;
+    for await (const chunk of store.get(cid)) size += chunk.byteLength;
+    return size;
+}
+
+describeSkipIfNotBrowser("LruBlockstore over blockstore-idb", () => {
+    const opened: IDBBlockstore[] = [];
+    let dbCounter = 0;
+
+    async function openIdb(name: string) {
+        const store = new IDBBlockstore(name);
+        await store.open();
+        opened.push(store);
+        return store;
+    }
+
+    afterEach(async () => {
+        while (opened.length) {
+            const store = opened.pop()!;
+            // close BEFORE destroy: destroy() is deleteDB(), and IndexedDB blocks a delete until
+            // every open connection to the database is closed, so destroying first deadlocks.
+            await store.close();
+            try {
+                await store.destroy();
+            } catch {
+                // best effort; the per-test database name keeps runs isolated regardless
+            }
+        }
+    });
+
+    it("accounts bytes for blocks IndexedDB returns as a single chunk", async () => {
+        const child = await openIdb(`pkc-lru-idb-accounting-${dbCounter++}`);
+        const store = new LruBlockstore(child, { maxBytes: 10_000 });
+        const a = await blockOf("a", 400);
+        const b = await blockOf("b", 600);
+
+        await store.put(a.cid, a.bytes);
+        await store.put(b.cid, b.bytes);
+
+        expect(store.totalBytes).to.equal(1000);
+        expect(store.blockCount).to.equal(2);
+        expect(await readSize(store, a.cid)).to.equal(400);
+    });
+
+    it("evicts the least recently used block and removes it from IndexedDB", async () => {
+        const child = await openIdb(`pkc-lru-idb-evict-${dbCounter++}`);
+        // low water of 630 leaves room for two of these 300 byte blocks, so exactly one eviction runs
+        const store = new LruBlockstore(child, { maxBytes: 700, lowWaterRatio: 0.9 });
+        const first = await blockOf("first", 300);
+        const second = await blockOf("second", 300);
+        await store.put(first.cid, first.bytes);
+        await store.put(second.cid, second.bytes);
+        await readSize(store, first.cid); // first becomes most recently used
+
+        const third = await blockOf("third", 300);
+        await store.put(third.cid, third.bytes);
+
+        expect(await child.has(first.cid), "re-read block should have survived").to.be.true;
+        expect(await child.has(second.cid), "least recently used block should have been evicted").to.be.false;
+        expect(await child.has(third.cid)).to.be.true;
+        expect(store.totalBytes).to.be.at.most(700);
+    });
+
+    it("keeps blocks across a close and reopen, and rebuilds the index from them", async () => {
+        // This is the behaviour that makes persistence worth having: a refresh must not re-fetch
+        // what was already verified. A fresh wrapper starts with an empty index, so the rebuild has
+        // to recover the byte total from the database itself.
+        const dbName = `pkc-lru-idb-persist-${dbCounter++}`;
+        const firstSession = await openIdb(dbName);
+        const blocks = await Promise.all([1, 2, 3].map((n) => blockOf(`block-${n}`, 200)));
+        const firstLru = new LruBlockstore(firstSession, { maxBytes: 10_000 });
+        for (const block of blocks) await firstLru.put(block.cid, block.bytes);
+        expect(firstLru.totalBytes).to.equal(600);
+        await firstSession.close();
+        opened.pop(); // reopened below; the afterEach cleanup uses the second handle
+
+        const secondSession = await openIdb(dbName);
+        const secondLru = new LruBlockstore(secondSession, { maxBytes: 10_000 });
+        expect(secondLru.totalBytes, "a fresh wrapper starts with no index").to.equal(0);
+
+        const rebuilt = await secondLru.rebuildIndex();
+        expect(rebuilt.blocks).to.equal(3);
+        expect(secondLru.totalBytes).to.equal(600);
+        for (const block of blocks) expect(await secondSession.has(block.cid)).to.be.true;
+    });
+
+    it("registers a block's size on first read when the rebuild has not reached it yet", async () => {
+        const dbName = `pkc-lru-idb-lazy-${dbCounter++}`;
+        const firstSession = await openIdb(dbName);
+        const block = await blockOf("persisted", 500);
+        await firstSession.put(block.cid, block.bytes);
+        await firstSession.close();
+        opened.pop();
+
+        const secondSession = await openIdb(dbName);
+        const lru = new LruBlockstore(secondSession, { maxBytes: 10_000 });
+        expect(lru.totalBytes).to.equal(0);
+
+        expect(await readSize(lru, block.cid)).to.equal(500);
+        expect(lru.totalBytes, "a read must account for what it touched").to.equal(500);
+        expect(lru.blockCount).to.equal(1);
+    });
+
+    it("drops a block from the index when IndexedDB no longer has it", async () => {
+        // Another tab sharing the origin can evict a block this instance still believes it holds.
+        // The read fails, and the index must stop counting the block rather than inflate the total.
+        const child = await openIdb(`pkc-lru-idb-missing-${dbCounter++}`);
+        const store = new LruBlockstore(child, { maxBytes: 10_000 });
+        const block = await blockOf("vanishing", 300);
+        await store.put(block.cid, block.bytes);
+        expect(store.totalBytes).to.equal(300);
+
+        await child.delete(block.cid); // behind the wrapper's back, as another tab would
+
+        let threw = false;
+        try {
+            await readSize(store, block.cid);
+        } catch {
+            threw = true;
+        }
+        expect(threw, "reading a block IndexedDB no longer has must fail").to.be.true;
+        expect(store.totalBytes, "index must not keep counting a block that is gone").to.equal(0);
+        expect(store.blockCount).to.equal(0);
+    });
+});

--- a/test/node/helia/lru-blockstore.unit.test.ts
+++ b/test/node/helia/lru-blockstore.unit.test.ts
@@ -1,0 +1,285 @@
+// Unit tests for the size-capped LRU blockstore added for
+// https://github.com/pkcprotocol/pkc-js/issues/240
+//
+// Helia never evicts blocks on its own: every fetched block is written to the blockstore, and only
+// `helia.gc()` (pin-based, and pkc-js pins nothing) or dropping the whole instance removes one. A
+// long-lived client therefore grew without bound. These cover the eviction policy itself plus the
+// two behaviours that are easy to get subtly wrong: recency tracking, and rebuilding the byte index
+// from a persistent backend that already holds blocks.
+
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { MemoryBlockstore } from "blockstore-core";
+import { FsBlockstore } from "blockstore-fs";
+import { CID } from "multiformats/cid";
+import * as raw from "multiformats/codecs/raw";
+import { sha256 } from "multiformats/hashes/sha2";
+import { LruBlockstore, type ChildBlockstore } from "../../../dist/node/helia/lru-blockstore.js";
+
+async function blockOf(content: string, sizeBytes?: number) {
+    const base = new TextEncoder().encode(content);
+    const bytes = sizeBytes === undefined ? base : new Uint8Array(sizeBytes).fill(base[0] ?? 1);
+    // keep the content distinct so distinct labels hash to distinct CIDs even when padded
+    if (sizeBytes !== undefined) bytes.set(base.subarray(0, Math.min(base.length, bytes.length)));
+    const cid = CID.createV1(raw.code, await sha256.digest(bytes));
+    return { cid, bytes };
+}
+
+// MemoryBlockstore.get is a sync generator while the fs/idb backends are async ones, so accept both
+async function collect(iterable: AsyncIterable<Uint8Array> | Iterable<Uint8Array>) {
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of iterable) chunks.push(chunk);
+    return chunks;
+}
+
+async function sizeOfGet(store: LruBlockstore, cid: CID) {
+    let size = 0;
+    for await (const chunk of store.get(cid)) size += chunk.byteLength;
+    return size;
+}
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+    while (tmpDirs.length) {
+        const dir = tmpDirs.pop()!;
+        await fs.promises.rm(dir, { recursive: true, force: true });
+    }
+});
+
+describe("LruBlockstore accounting", () => {
+    it("tracks total bytes and block count across put and delete", async () => {
+        const store = new LruBlockstore(new MemoryBlockstore(), { maxBytes: 10_000 });
+        const a = await blockOf("a", 100);
+        const b = await blockOf("b", 250);
+
+        await store.put(a.cid, a.bytes);
+        await store.put(b.cid, b.bytes);
+        expect(store.totalBytes).to.equal(350);
+        expect(store.blockCount).to.equal(2);
+
+        await store.delete(a.cid);
+        expect(store.totalBytes).to.equal(250);
+        expect(store.blockCount).to.equal(1);
+    });
+
+    it("does not double count a block that is put twice", async () => {
+        const store = new LruBlockstore(new MemoryBlockstore(), { maxBytes: 10_000 });
+        const a = await blockOf("a", 100);
+        await store.put(a.cid, a.bytes);
+        await store.put(a.cid, a.bytes);
+        expect(store.totalBytes).to.equal(100);
+        expect(store.blockCount).to.equal(1);
+    });
+
+    it("sums a block supplied as an async iterable of chunks without draining it before the child", async () => {
+        // The streaming blockstore API allows put() to be handed an iterable rather than a single
+        // Uint8Array. Measuring it consumes it, so the wrapper has to materialize and forward the
+        // materialized chunks - if it forwarded the original iterator the child would store nothing.
+        const child = new MemoryBlockstore();
+        const store = new LruBlockstore(child, { maxBytes: 10_000 });
+        const a = await blockOf("a", 300);
+        async function* chunks() {
+            yield a.bytes.subarray(0, 100);
+            yield a.bytes.subarray(100);
+        }
+        await store.put(a.cid, chunks());
+
+        expect(store.totalBytes).to.equal(300);
+        const readBack = await collect(child.get(a.cid));
+        expect(readBack.reduce((acc, c) => acc + c.byteLength, 0)).to.equal(300);
+    });
+});
+
+describe("LruBlockstore eviction", () => {
+    it("evicts down to the low water mark once maxBytes is exceeded", async () => {
+        const child = new MemoryBlockstore();
+        // 1000 byte cap, evict down to 500
+        const store = new LruBlockstore(child, { maxBytes: 1000, lowWaterRatio: 0.5 });
+        const blocks = await Promise.all([1, 2, 3, 4, 5].map((n) => blockOf(String(n), 300)));
+
+        // 3 x 300 = 900 is under the cap, so nothing has been evicted yet
+        for (const block of blocks.slice(0, 3)) await store.put(block.cid, block.bytes);
+        expect(store.totalBytes).to.equal(900);
+
+        // the 4th put crosses 1000 and must evict down to the low water mark, not merely to the cap
+        await store.put(blocks[3].cid, blocks[3].bytes);
+        expect(store.totalBytes).to.be.at.most(500);
+        expect(store.totalBytes).to.be.greaterThan(0);
+        // the eviction must have actually removed blocks from the child, not just from the index
+        expect(await child.has(blocks[0].cid)).to.be.false;
+
+        // headroom below the low water mark is then reusable: a further put stays under the cap
+        // without triggering another eviction
+        await store.put(blocks[4].cid, blocks[4].bytes);
+        expect(store.totalBytes).to.be.at.most(1000);
+        expect(await child.has(blocks[4].cid), "the most recent put always survives").to.be.true;
+    });
+
+    it("evicts the least recently used block, not the oldest written one", async () => {
+        const child = new MemoryBlockstore();
+        // low water of 630 leaves room for two of these three 300 byte blocks, so exactly one
+        // eviction happens and the test isolates *which* block that is
+        const store = new LruBlockstore(child, { maxBytes: 700, lowWaterRatio: 0.9 });
+        const first = await blockOf("first", 300);
+        const second = await blockOf("second", 300);
+
+        await store.put(first.cid, first.bytes);
+        await store.put(second.cid, second.bytes);
+        // read the OLDER block, making the newer one least-recently-used
+        await sizeOfGet(store, first.cid);
+
+        const third = await blockOf("third", 300);
+        await store.put(third.cid, third.bytes);
+
+        expect(await child.has(first.cid), "re-read block should have survived").to.be.true;
+        expect(await child.has(second.cid), "least recently used block should have been evicted").to.be.false;
+    });
+
+    it("does not let getAll reorder recency", async () => {
+        // A full scan touching every key would flatten LRU order into scan order, so the next
+        // eviction would drop whatever the scan happened to visit first rather than the coldest block.
+        const child = new MemoryBlockstore();
+        const store = new LruBlockstore(child, { maxBytes: 700, lowWaterRatio: 0.9 });
+        const cold = await blockOf("cold", 300);
+        const hot = await blockOf("hot", 300);
+        await store.put(cold.cid, cold.bytes);
+        await store.put(hot.cid, hot.bytes);
+        await sizeOfGet(store, cold.cid); // cold is now the most recently used
+
+        for await (const _pair of store.getAll()) {
+            // drain
+        }
+
+        const third = await blockOf("third", 300);
+        await store.put(third.cid, third.bytes);
+        expect(await child.has(cold.cid), "getAll must not have reset recency").to.be.true;
+        expect(await child.has(hot.cid)).to.be.false;
+    });
+
+    it("keeps the byte total correct when the child fails to delete during eviction", async () => {
+        // If a failed delete left the block counted, the total would drift upward forever and every
+        // later put would trigger another futile eviction pass.
+        const memory = new MemoryBlockstore();
+        const child: ChildBlockstore = {
+            has: (cid, options) => memory.has(cid as CID, options),
+            put: (cid, val, options) => memory.put(cid as CID, val, options),
+            get: (cid, options) => memory.get(cid as CID, options),
+            delete: async () => {
+                throw Error("child delete is broken");
+            },
+            getAll: (options) => memory.getAll(options)
+        };
+        const store = new LruBlockstore(child, { maxBytes: 500, lowWaterRatio: 0.5 });
+        const blocks = await Promise.all([1, 2, 3].map((n) => blockOf(String(n), 300)));
+        for (const block of blocks) await store.put(block.cid, block.bytes);
+
+        expect(store.totalBytes).to.be.at.most(500);
+        expect(store.blockCount).to.be.at.most(1);
+    });
+
+    it("serializes concurrent evictions instead of each draining to the low water mark", async () => {
+        const child = new MemoryBlockstore();
+        const store = new LruBlockstore(child, { maxBytes: 1000, lowWaterRatio: 0.5 });
+        const blocks = await Promise.all([1, 2, 3, 4, 5, 6].map((n) => blockOf(String(n), 300)));
+
+        await Promise.all(blocks.map((block) => store.put(block.cid, block.bytes)));
+
+        // Whatever the interleaving, the store must end up under the cap and must not have emptied
+        // itself: two overlapping eviction runs each draining to the low water mark would.
+        expect(store.totalBytes).to.be.at.most(1000);
+        expect(store.blockCount).to.be.greaterThan(0);
+        // the index and the child must agree
+        let childCount = 0;
+        for await (const _pair of child.getAll()) childCount++;
+        expect(childCount).to.equal(store.blockCount);
+    });
+});
+
+describe("LruBlockstore index rebuild against a persistent backend", () => {
+    async function tmpFsBlockstore() {
+        const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "pkc-lru-blockstore-"));
+        tmpDirs.push(dir);
+        const store = new FsBlockstore(dir);
+        await store.open();
+        return { dir, store };
+    }
+
+    it("counts blocks written by a previous session", async () => {
+        const { dir, store: firstRun } = await tmpFsBlockstore();
+        const blocks = await Promise.all([1, 2, 3].map((n) => blockOf(String(n), 200)));
+        const firstLru = new LruBlockstore(firstRun, { maxBytes: 10_000 });
+        for (const block of blocks) await firstLru.put(block.cid, block.bytes);
+        expect(firstLru.totalBytes).to.equal(600);
+        await firstRun.close();
+
+        // second "process": a fresh wrapper over the same directory starts with an empty index
+        const secondRun = new FsBlockstore(dir);
+        await secondRun.open();
+        const secondLru = new LruBlockstore(secondRun, { maxBytes: 10_000 });
+        expect(secondLru.totalBytes).to.equal(0);
+
+        const result = await secondLru.rebuildIndex();
+        expect(result.blocks).to.equal(3);
+        expect(secondLru.totalBytes).to.equal(600);
+        await secondRun.close();
+    });
+
+    it("evicts down to the cap when the existing store is already over it", async () => {
+        const { dir, store: firstRun } = await tmpFsBlockstore();
+        const blocks = await Promise.all([1, 2, 3, 4].map((n) => blockOf(String(n), 300)));
+        const firstLru = new LruBlockstore(firstRun, { maxBytes: 10_000 });
+        for (const block of blocks) await firstLru.put(block.cid, block.bytes);
+        await firstRun.close();
+
+        const secondRun = new FsBlockstore(dir);
+        await secondRun.open();
+        // 1200 bytes on disk, cap of 800
+        const secondLru = new LruBlockstore(secondRun, { maxBytes: 800, lowWaterRatio: 0.5 });
+        await secondLru.rebuildIndex();
+        expect(secondLru.totalBytes).to.be.at.most(400);
+        await secondRun.close();
+    });
+
+    it("registers a block's size on first read when it predates the index", async () => {
+        // The rebuild runs in the background, so reads can land before it reaches a given block.
+        // Those reads must still account for what they touched, or the cap under-counts.
+        const { dir, store: firstRun } = await tmpFsBlockstore();
+        const block = await blockOf("persisted", 400);
+        await firstRun.put(block.cid, block.bytes);
+        await firstRun.close();
+
+        const secondRun = new FsBlockstore(dir);
+        await secondRun.open();
+        const lru = new LruBlockstore(secondRun, { maxBytes: 10_000 });
+        expect(lru.totalBytes).to.equal(0);
+
+        const readSize = await sizeOfGet(lru, block.cid);
+        expect(readSize).to.equal(400);
+        expect(lru.totalBytes).to.equal(400);
+        expect(lru.blockCount).to.equal(1);
+        await secondRun.close();
+    });
+
+    it("does not register a partial size when a read is abandoned midway", async () => {
+        const { dir, store: firstRun } = await tmpFsBlockstore();
+        // large enough that the fs read stream yields more than one chunk
+        const block = await blockOf("big", 200_000);
+        await firstRun.put(block.cid, block.bytes);
+        await firstRun.close();
+
+        const secondRun = new FsBlockstore(dir);
+        await secondRun.open();
+        const lru = new LruBlockstore(secondRun, { maxBytes: 10_000_000 });
+
+        for await (const _chunk of lru.get(block.cid)) break; // abandon after the first chunk
+
+        // a partial size must not be recorded; a later full read records the real one
+        expect(lru.totalBytes, "abandoned read must not register a short size").to.equal(0);
+        const full = await sizeOfGet(lru, block.cid);
+        expect(full).to.equal(200_000);
+        expect(lru.totalBytes).to.equal(200_000);
+        await secondRun.close();
+    });
+});


### PR DESCRIPTION
Closes #240 (and completes layer 1 of #200).

## Problem

Helia never evicts blocks on its own. Every fetched block is written to the blockstore (`@helia/utils` `storage.js:79`), and only `helia.gc()` or dropping the whole instance removes one. `gc()` is pin-based and pkc-js pins nothing, so with zero pins it would simply delete everything. Net effect: the libp2p-js client's `MemoryBlockstore` grew for the life of the process, and every restart or page refresh re-fetched content that had already been verified.

Measured on `master` in headless Chromium, 65 production communities subscribed and updating for 90 minutes:

| | |
|---|---|
| growth | **0.335 MB/min = 20.1 MB/hour, linear, no plateau** |
| after 90 min | 548 blocks, 38.5MB |
| per update generation | 89KB (not the 1MB worst case; dedupe absorbs ~92%) |
| block size | p50 25.4KB, mean 73.6KB, max 262158B |

20-minute deltas were 7.1 / 6.7 / 6.0 / 7.2 MB. Nothing self-limits.

## Change

Blocks are now persisted per runtime behind a size-capped LRU:

- **`LruBlockstore`** wraps any child blockstore. Insertion-ordered `Map` is the recency list; reads and writes move a key to the back, `getAll` deliberately does not (a scan would flatten LRU order into scan order). Eviction drains to a low water mark rather than to the cap, so puts at the boundary do not each trigger a pass, and eviction runs are serialized so two concurrent puts cannot both drain.
- **Persistence**: `blockstore-fs` under `<dataPath>/blockstore/<key>` on node, `blockstore-idb` in the browser, memory when neither is available. `rebuildIndex()` recovers the byte index from an existing store in the background, since blocking init on it would add the store's entire read time to the first load.
- **Defaults are per backend**, because a cap means different things on disk and in the heap: 1GB on disk, 250MB in IndexedDB, 100MB for either memory fallback. At the measured rate that is ~2 days, ~12 hours, and ~5 hours respectively before the first eviction. Override with `libp2pJsClientsOptions[].blockstoreOptions: {maxBytes, lowWaterRatio}`.

This is the default path. The only opt-out is supplying your own `heliaOptions.blockstore`, in which case nothing here is constructed.

## Validation

Same 65-board browser workload with the cap forced to 5MB so eviction is observable in minutes:

```
141s   60 blocks  4.9MB
162s   46 blocks  3.9MB   <- evicted to the low water mark
322s   55 blocks  5.0MB
342s   44 blocks  3.9MB
```

Sawtooth between the low water mark and the cap, never above it, against the baseline's unbounded climb.

## Tests

- 12 unit tests over blockstore-core and blockstore-fs.
- 5 tests over blockstore-idb running in real Chrome.
- All 92 pre-existing helia tests still pass.

Covered: eviction drains to the low water mark and removes blocks from the child rather than only the index; the block evicted is the least recently used, not the oldest written; `getAll` does not reset recency; a put handed an async iterable is measured without being drained before the child sees it; an abandoned read does not register a short size; a failed child delete still decrements the total so it cannot drift upward; blocks survive close/reopen and `rebuildIndex` recovers the byte total; a read of a block the child no longer has drops it from the index.

## Notes for review

**Structural typing over `CID`.** The tree holds several `multiformats` copies (helia 6 internals are on 13, we are on 14) and `blockstore-core` ships a nested `interface-blockstore` whose `Pair` is not assignable to ours. `LruBlockstore` therefore types on `{multihash: {bytes}}` and implements the blockstore surface directly instead of extending `BaseBlockstore`. Every backend addresses blocks by multihash and ignores the codec, so this is sound as well as convenient.

**`FsBlockstore.getAll()` returns a different CID than was put** — a CIDv0 `Qm...` for a CIDv1 raw `bafkrei...`, because its sharding strategy decodes raw multihash bytes as a CID. Keying the index on multihash makes that harmless, but it also means `getAll` throws for any hash that is not a valid CIDv0, so `rebuildIndex` tolerates a partial scan rather than propagating.

**Two processes sharing one blockstore directory** is deliberately not locked. Measured: concurrent identical puts are safe (blockstore-fs writes via steno, temp file plus atomic rename, and explicitly tolerates another context having created the file); reading a block the other process evicted raises `NotFoundError`, which fails that one load and self-heals on retry; and the cap is per process, so N processes can leave up to N times `maxBytes` on disk. A lock would stop the second process running at all, which is the wrong trade for a cache both can safely share. The LRU unregisters a block when a read finds it missing, so the byte total stays honest when another process, another tab, or an external cleanup removes files.

**Teardown**: `helia.stop()` does not touch the blockstore, because these backends expose `open()`/`close()` rather than the Startable `start()`/`stop()` that helia's `start(...)` helper looks for. Closing them is ours to do.

**`config/vitest.config.ts`** gains an opt-in `PLAYWRIGHT_EXECUTABLE_PATH`. Playwright publishes no prebuilt chromium for some newer distros (`npx playwright install chromium` fails with "does not support chromium on ubuntu26.04-x64"), which leaves browser tests unrunnable there. Unset everywhere else, so CI keeps using playwright's own download.

## Still open

Re-fetch rate versus cap size is being measured separately (a sweep across small caps with a control that does not evict). It does not gate this change — it only refines the default. Detection is exact rather than sampled: `NetworkedStorage` writes a block only after `has()` missed, so a second put of the same key is definitionally an evict-then-refetch.
