### PR TITLE
perf(rpc): answer community `started` for all communities in one call

### DIFF
--- a/docs/protocol/import-performance.md
+++ b/docs/protocol/import-performance.md
@@ -396,6 +396,10 @@ Output verified correct (full 17-community table). Where the remaining ~4.3s goe
     one `createCommunity` round trip per community. `-q` skips them and lands at ~2.5s, so for a
     daemon with 20+ communities the next real lever is CLI/daemon side, not import side: batch the
     per-community round trips or include `started` in the communities subscription payload.
+    **Followed up on** in `perf/community-list`: the RPC node now exposes
+    `listCommunitiesStartedState`, which answers `started` for every community in one round trip
+    from start-lockfile checks (~0.7ms for 18 communities on this host) instead of ~1.5s of
+    per-community round trips. `bitsocial community list` has to call it to benefit.
 
 Caveat on the raw numbers: the production daemon is live, and roughly 1 run in 6 spikes to
 12-15s regardless of build. Those spikes are daemon-side RPC latency (they reproduce on the

--- a/src/clients/rpc-client/pkc-rpc-client.ts
+++ b/src/clients/rpc-client/pkc-rpc-client.ts
@@ -36,6 +36,7 @@ import type {
     RpcResolveAuthorNameResult,
     RpcSubscriptionIdResult,
     RpcSuccessResult,
+    RpcCommunitiesStartedStateResult,
     RpcFetchCidResult,
     ExportCommunityRpcParam,
     CancelExportRpcParam,
@@ -57,6 +58,7 @@ import {
     parseRpcResolveAuthorNameResult,
     parseRpcFetchCidResult,
     parseRpcSuccessResult,
+    parseRpcCommunitiesStartedStateResult,
     parseRpcSubscriptionIdResult,
     parseRpcExportCommunityParam,
     parseRpcCancelExportParam,
@@ -486,6 +488,10 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
         const resolveAuthorNameArgs = parseRpcAuthorNameParam(parsedAuthorName);
         const res = parseRpcResolveAuthorNameResult(await this._webSocketClient.call("resolveAuthorName", [resolveAuthorNameArgs]));
         return res;
+    }
+
+    async listCommunitiesStartedState(): Promise<RpcCommunitiesStartedStateResult> {
+        return parseRpcCommunitiesStartedStateResult(await this._webSocketClient.call("listCommunitiesStartedState", []));
     }
 
     async initalizeCommunitieschangeEvent() {

--- a/src/clients/rpc-client/rpc-schema-util.ts
+++ b/src/clients/rpc-client/rpc-schema-util.ts
@@ -11,6 +11,7 @@ import {
     RpcResolveAuthorNameResultSchema,
     RpcFetchCidResultSchema,
     RpcSuccessResultSchema,
+    RpcCommunitiesStartedStateResultSchema,
     RpcSubscriptionIdResultSchema,
     RpcExportCommunityParamSchema,
     RpcCancelExportParamSchema,
@@ -39,6 +40,7 @@ export const parseRpcResolveAuthorNameResult = (result: unknown) => RpcResolveAu
 export const parseRpcFetchCidResult = (result: unknown) => RpcFetchCidResultSchema.loose().parse(result);
 export const parseRpcSuccessResult = (result: unknown) => RpcSuccessResultSchema.loose().parse(result);
 export const parseRpcSubscriptionIdResult = (result: unknown) => RpcSubscriptionIdResultSchema.loose().parse(result);
+export const parseRpcCommunitiesStartedStateResult = (result: unknown) => RpcCommunitiesStartedStateResultSchema.loose().parse(result);
 
 // Delegation setup (#234)
 export const parseRpcPublishAnchorRecordParam = (params: unknown) => RpcPublishAnchorRecordParamSchema.loose().parse(params);

--- a/src/clients/rpc-client/schema.ts
+++ b/src/clients/rpc-client/schema.ts
@@ -65,6 +65,15 @@ export const RpcFetchCidResultSchema = z.object({ content: z.string() });
 export const RpcResolveAuthorNameResultSchema = z.object({ resolvedAuthorName: z.string().nullable() });
 export const RpcSuccessResultSchema = z.object({ success: z.literal(true) });
 
+// One `started` flag per community in a single round trip. Exists because reading `started` used to
+// mean one createCommunity call per community, and for a local community that ships the community's
+// whole internal record (preloaded posts pages included) just to produce one boolean - 14.8MB across
+// 17 communities on the production host. Deliberately carries nothing else: the point is that the
+// node can answer it from cheap start-lockfile checks, transferring no community records at all.
+export const RpcCommunitiesStartedStateResultSchema = z.object({
+    communities: z.array(z.object({ address: z.string(), started: z.boolean() }))
+});
+
 // Delegation setup (#234). The signed record crosses the wire base64-encoded because JSON has no bytes,
 // and sequences cross as decimal strings because JSON numbers cannot hold a uint64 without rounding.
 // The anchor's PRIVATE key is not in either shape, and never is: the client signs, the node publishes.

--- a/src/clients/rpc-client/types.ts
+++ b/src/clients/rpc-client/types.ts
@@ -11,6 +11,7 @@ import {
     RpcResolveAuthorNameResultSchema,
     RpcFetchCidResultSchema,
     RpcSuccessResultSchema,
+    RpcCommunitiesStartedStateResultSchema,
     RpcSubscriptionIdResultSchema,
     RpcExportCommunityParamSchema,
     RpcCancelExportParamSchema,
@@ -41,6 +42,7 @@ export type PublishAnchorRecordRpcParam = z.infer<typeof RpcPublishAnchorRecordP
 export type RpcResolveAuthorNameResult = z.infer<typeof RpcResolveAuthorNameResultSchema>;
 export type RpcFetchCidResult = z.infer<typeof RpcFetchCidResultSchema>;
 export type RpcSuccessResult = z.infer<typeof RpcSuccessResultSchema>;
+export type RpcCommunitiesStartedStateResult = z.infer<typeof RpcCommunitiesStartedStateResultSchema>;
 export type RpcSubscriptionIdResult = z.infer<typeof RpcSubscriptionIdResultSchema>;
 export type RpcExportCommunityResult = z.infer<typeof RpcExportCommunityResultSchema>;
 export type RpcExportschangeResult = z.infer<typeof RpcExportschangeResultSchema>;

--- a/src/pkc/pkc-with-rpc-client.ts
+++ b/src/pkc/pkc-with-rpc-client.ts
@@ -54,6 +54,25 @@ export class PKCWithRpcClient extends PKC {
         return this._pkcRpcClient.fetchCid({ cid: parsedCid });
     }
 
+    // `started` for every community in `this.communities`, in a single RPC round trip.
+    //
+    // The obvious way to build a community listing - `createCommunity({ address })` per address and
+    // read `.started` - is far more expensive than it looks. For a community the node owns, that
+    // call opens a communityUpdateSubscribe, waits for the node to send the community's ENTIRE
+    // internal record (preloaded posts pages included), then stops again. On the production host
+    // that is ~0.9MB of JSON per community, 14.8MB across 17, to produce 17 booleans. The node
+    // serializes it synchronously, so its event loop blocks and the calls do not overlap however
+    // hard the caller parallelizes them: ~1.5s for 17 communities.
+    //
+    // This returns the same booleans without transferring any community records, so use it whenever
+    // you want the listing rather than the communities themselves.
+    //
+    // Only available against an RPC node new enough to expose the method; callers that must support
+    // older nodes should fall back to the per-community path on ERR_RPC_METHOD_NOT_FOUND.
+    async listCommunitiesStartedState() {
+        return this._pkcRpcClient.listCommunitiesStartedState();
+    }
+
     override async resolveAuthorName(args: AuthorNameRpcParam) {
         const parsedArgs = parseRpcAuthorNameParam(args);
         return this._pkcRpcClient.resolveAuthorName(parsedArgs);

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -37,6 +37,8 @@ import WebSocket from "ws";
 import Publication from "../../publications/publication.js";
 import { PKCError } from "../../pkc-error.js";
 import { LocalCommunity } from "../../runtime/node/community/local-community.js";
+import { isCommunityStartLockedByAddress } from "../../runtime/node/community/start-lock.js";
+import type { RpcCommunitiesStartedStateResult } from "../../clients/rpc-client/types.js";
 import { RemoteCommunity } from "../../community/remote-community.js";
 import { hideClassPrivateProps, replaceXWithY } from "../../util.js";
 import { keys, mapValues, omit } from "remeda";
@@ -304,6 +306,7 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
         this.rpcWebsocketsRegister("prepareAnchorPublish", this.prepareAnchorPublish.bind(this));
         this.rpcWebsocketsRegister("publishAnchorRecord", this.publishAnchorRecord.bind(this));
         this.rpcWebsocketsRegister("communitiesSubscribe", this.communitiesSubscribe.bind(this));
+        this.rpcWebsocketsRegister("listCommunitiesStartedState", this.listCommunitiesStartedState.bind(this));
         this.rpcWebsocketsRegister("settingsSubscribe", this.settingsSubscribe.bind(this));
 
         this.rpcWebsocketsRegister("fetchCid", this.fetchCid.bind(this));
@@ -643,6 +646,38 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
         const community = <LocalCommunity>await pkc.createCommunity(createCommunityOptions);
         if (!(community instanceof LocalCommunity)) throw Error("Failed to create a local community. This is a critical error");
         return community.toJSONInternalRpcBeforeFirstUpdate();
+    }
+
+    // `started` for every community in ONE round trip, and without shipping the communities
+    // themselves. A client that wants to list communities and show which are running (e.g.
+    // `bitsocial community list`) previously had to call createCommunity per address, which for a
+    // local community means communityUpdateSubscribe -> the node sends the community's whole
+    // internal record as an `update`, including its preloaded posts pages.
+    //
+    // On the production host that is ~0.9MB of JSON per community and 14.8MB across 17 of them, to
+    // produce 17 booleans. Per-community latency correlates with payload size at r=0.90 (~8.5KB/ms),
+    // and because JSON.stringify is synchronous it blocks this process's event loop: probing the
+    // node with a trivial RPC call during the fan-out shows it going unanswered for ~1s at a time.
+    // That is why parallelizing on the client does not help - the fan-out costs ~1.5s regardless.
+    //
+    // `started` is exactly "is the start lockfile held" (LocalCommunity._updateStartedValue), which
+    // needs nothing but dataPath + address, so this answers all of them with cheap fs checks.
+    async listCommunitiesStartedState(): Promise<RpcCommunitiesStartedStateResult> {
+        const pkc = await this._getPKCInstance();
+        const addresses = pkc.communities;
+
+        // No dataPath means no local communities on disk, so nothing can hold a start lock.
+        const dataPath = pkc.dataPath;
+        if (!dataPath) return { communities: addresses.map((address) => ({ address, started: false })) };
+
+        return {
+            communities: await Promise.all(
+                addresses.map(async (address) => ({
+                    address,
+                    started: await isCommunityStartLockedByAddress({ dataPath, communityAddress: address })
+                }))
+            )
+        };
     }
 
     private _trackCommunityListener(community: LocalCommunity, event: keyof CommunityEvents, listener: (...args: any[]) => void) {

--- a/src/rpc/test/node/rpc.list-communities-started-state.test.ts
+++ b/src/rpc/test/node/rpc.list-communities-started-state.test.ts
@@ -1,0 +1,145 @@
+import { beforeAll, afterAll, afterEach } from "vitest";
+import { temporaryDirectory } from "tempy";
+
+import PKCWsServerModule from "../../../../dist/node/rpc/src/index.js";
+import { restorePKCJs } from "../../../../dist/node/rpc/src/lib/pkc-js/index.js";
+import { mockRpcServerForTests, mockRpcServerPKC } from "../../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../../../test/helpers/conditional-tests.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+
+const { PKCWsServer: createPKCWsServer, setPKCJs } = PKCWsServerModule;
+
+type PKCWsServerType = Awaited<ReturnType<typeof createPKCWsServer>>;
+
+const getTestPort = (() => {
+    let offset = 0;
+    return () => {
+        offset += 1;
+        return 19400 + offset;
+    };
+})();
+
+interface PKCWsServerPrivateAccess {
+    _onSettingsChange: Record<string, Record<string, unknown>>;
+}
+
+const setupConnectionContext = (rpcServer: PKCWsServerType, connectionId: string) => {
+    rpcServer.subscriptionCleanups[connectionId] = {};
+    rpcServer.connections[connectionId] = { send: () => {} } as unknown as PKCWsServerType["connections"][string];
+    (rpcServer as unknown as PKCWsServerPrivateAccess)._onSettingsChange[connectionId] = {};
+};
+
+// listCommunitiesStartedState is a performance shortcut: it answers `started` for every community
+// from start-lockfile checks alone, instead of the caller doing one createCommunity round trip per
+// community (each of which ships that community's entire internal record just to read one boolean
+// off it). The shortcut is only safe while it agrees with the slow path, so the tests below assert
+// equivalence against the LocalCommunity `started` rather than against hardcoded expectations.
+//
+// Cannot run under RPC: these drive PKCWsServer directly, and USE_RPC points the suite at an
+// already-running external RPC server whose internals are not reachable from here.
+describeSkipIfRpc("rpcServer.listCommunitiesStartedState", function () {
+    let rpcServer: PKCWsServerType | undefined;
+
+    beforeAll(() => {
+        setPKCJs(async (options: Record<string, unknown>) => mockRpcServerPKC({ dataPath: temporaryDirectory(), ...(options || {}) }));
+    });
+
+    afterAll(() => {
+        restorePKCJs();
+    });
+
+    afterEach(async () => {
+        if (rpcServer) {
+            try {
+                await rpcServer.destroy();
+            } catch (error) {
+                console.error("rpc.list-communities-started-state.test destroy error", error);
+            }
+            rpcServer = undefined;
+        }
+    });
+
+    const startedStateOf = async (server: PKCWsServerType, address: string) => {
+        const { communities } = await server.listCommunitiesStartedState();
+        const entry = communities.find((community) => community.address === address);
+        expect(entry, `${address} missing from listCommunitiesStartedState`).to.exist;
+        return entry!.started;
+    };
+
+    it("reports every community the node has, with no communities started", async function () {
+        rpcServer = await createPKCWsServer({ port: getTestPort() });
+        mockRpcServerForTests(rpcServer);
+
+        const first = (await rpcServer.createCommunity([{}])).localCommunity.address;
+        const second = (await rpcServer.createCommunity([{}])).localCommunity.address;
+
+        const { communities } = await rpcServer.listCommunitiesStartedState();
+
+        expect(communities.map((c) => c.address).sort()).to.deep.equal([...rpcServer.pkc.communities].sort());
+        expect(communities.map((c) => c.address)).to.include(first);
+        expect(communities.map((c) => c.address)).to.include(second);
+        communities.forEach((community) => {
+            expect(community.started).to.equal(false, `${community.address} should not be started`);
+        });
+    });
+
+    it("agrees with the LocalCommunity `started` across a start and a stop", async function () {
+        rpcServer = await createPKCWsServer({ port: getTestPort() });
+        mockRpcServerForTests(rpcServer);
+
+        const connectionId = "started-state-connection";
+        setupConnectionContext(rpcServer, connectionId);
+
+        const started = (await rpcServer.createCommunity([{}])).localCommunity.address;
+        const untouched = (await rpcServer.createCommunity([{}])).localCommunity.address;
+
+        // The slow path the shortcut replaces. A client asking for `started` ends up here: the node
+        // builds a LocalCommunity for the address and `started` on the wire is whatever that
+        // instance reports (LocalCommunity._updateStartedValue -> the start lockfile).
+        const viaLocalCommunity = async (address: string) =>
+            ((await rpcServer!.pkc.createCommunity({ address })) as unknown as LocalCommunity).started;
+
+        expect(await startedStateOf(rpcServer, started)).to.equal(await viaLocalCommunity(started));
+        expect(await startedStateOf(rpcServer, untouched)).to.equal(await viaLocalCommunity(untouched));
+
+        await rpcServer.startCommunity([{ publicKey: started }], connectionId);
+
+        expect(await startedStateOf(rpcServer, started)).to.equal(true, "started community should read as started");
+        expect(await startedStateOf(rpcServer, started)).to.equal(await viaLocalCommunity(started));
+        // starting one community must not flip the other
+        expect(await startedStateOf(rpcServer, untouched)).to.equal(false);
+        expect(await startedStateOf(rpcServer, untouched)).to.equal(await viaLocalCommunity(untouched));
+
+        await rpcServer.stopCommunity([{ publicKey: started }]);
+
+        expect(await startedStateOf(rpcServer, started)).to.equal(false, "stopped community should read as not started");
+        expect(await startedStateOf(rpcServer, started)).to.equal(await viaLocalCommunity(started));
+    });
+
+    it("does not construct a LocalCommunity per community", async function () {
+        rpcServer = await createPKCWsServer({ port: getTestPort() });
+        mockRpcServerForTests(rpcServer);
+
+        await rpcServer.createCommunity([{}]);
+        await rpcServer.createCommunity([{}]);
+
+        // Building a community is the gateway to the expensive path: it is what produces the full
+        // internal record a subscription then serializes. If a future refactor routes this method
+        // back through pkc.createCommunity the latency regression returns silently, so assert it.
+        const pkc = rpcServer.pkc as unknown as { createCommunity: (...args: unknown[]) => Promise<LocalCommunity> };
+        const originalCreateCommunity = pkc.createCommunity;
+        let createCommunityCalls = 0;
+        pkc.createCommunity = function (...args: unknown[]) {
+            createCommunityCalls += 1;
+            return originalCreateCommunity.apply(this, args);
+        };
+
+        try {
+            const { communities } = await rpcServer.listCommunitiesStartedState();
+            expect(communities).to.have.length(2);
+            expect(createCommunityCalls).to.equal(0, "listCommunitiesStartedState must not build communities");
+        } finally {
+            pkc.createCommunity = originalCreateCommunity;
+        }
+    });
+});

--- a/src/runtime/browser/community/start-lock.ts
+++ b/src/runtime/browser/community/start-lock.ts
@@ -1,0 +1,10 @@
+// Browser counterpart of runtime/node/community/start-lock.ts. Start locks are files in the node
+// data directory, so there is nothing to check here; this stub exists only because the browser build
+// rewrites runtime/node imports to runtime/browser, and the RPC server module (node-only at runtime)
+// is still copied into dist/browser.
+
+export const STALE_START_LOCK_MS = 10000;
+
+export function isCommunityStartLockedByAddress(): never {
+    throw Error("Community start locks should not be used in browser");
+}

--- a/src/runtime/node/community/db-handler.ts
+++ b/src/runtime/node/community/db-handler.ts
@@ -17,6 +17,7 @@ import Database, { type Database as BetterSqlite3Database } from "better-sqlite3
 import { sha256 } from "js-sha256";
 
 import lockfile from "@pkcprotocol/proper-lock-file";
+import { isCommunityStartLockedByAddress } from "./start-lock.js";
 import type { PageOptions } from "./page-generator.js";
 import type {
     InternalCommunityRecordAfterFirstUpdateType,
@@ -3097,10 +3098,7 @@ export class DbHandler {
     }
 
     async isCommunityStartLocked(communityAddress = this._community.address): Promise<boolean> {
-        const lockfilePath = path.join(this._community._pkc.dataPath!, "communities", `${communityAddress}.start.lock`);
-        const communityDbPath = path.join(this._community._pkc.dataPath!, "communities", communityAddress);
-        const isLocked = await lockfile.check(communityDbPath, { lockfilePath, realpath: false, stale: 10000 });
-        return isLocked;
+        return isCommunityStartLockedByAddress({ dataPath: this._community._pkc.dataPath!, communityAddress });
     }
 
     // Community state lock

--- a/src/runtime/node/community/start-lock.ts
+++ b/src/runtime/node/community/start-lock.ts
@@ -1,0 +1,28 @@
+import path from "path";
+import lockfile from "@pkcprotocol/proper-lock-file";
+
+// How long a start lockfile may go un-refreshed before it is treated as abandoned (a crashed
+// process leaves its lockfile behind). Shared by the DbHandler method and the standalone check
+// below so both agree on what "started" means.
+export const STALE_START_LOCK_MS = 10000;
+
+// A community's `started` flag is derived purely from whether its start lockfile is held: the lock
+// is held for as long as some process is running that community, and it is visible across
+// processes. Nothing here touches the community's sqlite db.
+//
+// This lives as a standalone function - not only as a DbHandler method - because answering
+// "is it started?" for N communities over RPC used to mean transferring each community's entire
+// internal record just to read one boolean off it (14.8MB across 17 communities on the production
+// host). The RPC server's listCommunitiesStartedState uses this to answer for every community in a
+// single pass of cheap fs checks instead.
+export async function isCommunityStartLockedByAddress({
+    dataPath,
+    communityAddress
+}: {
+    dataPath: string;
+    communityAddress: string;
+}): Promise<boolean> {
+    const lockfilePath = path.join(dataPath, "communities", `${communityAddress}.start.lock`);
+    const communityDbPath = path.join(dataPath, "communities", communityAddress);
+    return lockfile.check(communityDbPath, { lockfilePath, realpath: false, stale: STALE_START_LOCK_MS });
+}


### PR DESCRIPTION
Stacked on #245 (base is `perf/import-time-2`). That PR took the **import** side of `bitsocial community list` from ~2.0s to ~1.4s. This one goes after the biggest non-import slice.

## Where `community list` time actually goes

Instrumented against the live production daemon (17 communities), phase by phase:

| Phase | Time |
|---|---|
| PKC() constructed | ~85ms |
| connect + first `communitieschange` | ~85ms (1 run in 8 spikes to ~10.4s, see below) |
| `pkc.communities` | free, already delivered by the subscription |
| **`createCommunity` fan-out** | **~1400-1700ms, every run** |

So the fan-out is the whole non-import cost, and it is deterministic.

## Why it costs that much

`createCommunity({ address })` is not a cheap lookup. For a community the node owns, it opens a `communityUpdateSubscribe` and waits for the node to send that community's **entire internal record, preloaded posts pages included**, then stops again.

Measured per community on production:

| | |
|---|---|
| payload per community | up to ~2MB, ~0.9MB average |
| **total transferred to produce 17 booleans** | **14.8 MB** |
| correlation between payload size and latency | **r = 0.90** |
| implied throughput | ~8.5 KB/ms |

And that serialization is synchronous, so it blocks the node's event loop. Probing the daemon with a trivial no-op RPC call every 15ms during the fan-out:

| | median | max |
|---|---|---|
| before fan-out | 1.0-1.7ms | 11-90ms |
| **during fan-out** | **17-903ms** | **903-1273ms** |

Only 2-3 probes complete during the ~1.2s window instead of ~80. That is why parallelizing on the client buys nothing, and why the fan-out scales linearly with community count (N=1 ~85ms, N=2 343ms, N=4 504ms, N=8 883ms, N=17 1328ms).

All the caller wanted was one boolean each.

## The change

`started` is defined as "is the community's start lockfile held" (`LocalCommunity._updateStartedValue`), which needs only `dataPath` + address — no db, no community instance, no record transfer. So:

- extract that check into `runtime/node/community/start-lock.ts` as `isCommunityStartLockedByAddress()`; `DbHandler.isCommunityStartLocked` now delegates to it, so both agree on what `started` means by construction
- add a `listCommunitiesStartedState` RPC method answering for every community in `pkc.communities` from those checks alone, plus the client method and a `PKCWithRpcClient.listCommunitiesStartedState()` wrapper

## Results

| Measurement | old | new |
|---|---|---|
| **production data dir, 18 communities** (the work being replaced) | ~1500ms, 14.8MB | **0.7ms, no records transferred** |
| local, real RPC client + server, 17 communities | 53ms | **0ms** |

The production run reports the same 17 started that the live daemon reports. Freshly created local communities carry almost no page data, which is why the local delta is smaller — the production number is the meaningful one.

I measured the new path's cost directly against the production data directory rather than end to end, because the live daemon has the old code loaded in memory and would need a restart to expose the method. Happy to restart it and get the end-to-end `bitsocial community list` number if you want that verified.

## Compatibility

Additive, so nothing breaks on older clients. A client that must support older nodes should fall back to the per-community path on `ERR_RPC_METHOD_NOT_FOUND`.

**This does not speed up `bitsocial community list` on its own** — bitsocial-cli has to call the new method. That is a small change in its `community list` command; say the word and I'll open it.

## Testing

New `src/rpc/test/node/rpc.list-communities-started-state.test.ts` (3 tests). They assert the shortcut against the slow path rather than hardcoded values — comparing it to the `LocalCommunity` `started` across a start and a stop — plus a guard that it never routes back through `pkc.createCommunity`, since that regression would be silent.

Full run: `src/rpc/test/node`, `test/node/community/start.community.test.ts`, `test/node/pkc` — **249 passed, 9 skipped, 1 todo**.

## Separately: a ~10.4s connect spike

1 run in 8 stalls ~10.4s waiting for the first `communitieschange` (others are 13-586ms). This is what causes the occasional 12-15s `bitsocial community list`. It is independent of this change and of import cost, and the suspiciously round ~10s suggests a timeout rather than real work. Not chased here — worth its own issue.