### PR TITLE
test(crosspost): design-only test stubs for crossposts (#32)

### DIFF
--- a/test/node-and-browser/crosspost/client-consumption.test.ts
+++ b/test/node-and-browser/crosspost/client-consumption.test.ts
@@ -1,0 +1,57 @@
+// Test foundations for crossposts (issue #32).
+// Design-only scaffolding: every case is it.todo until the feature is implemented.
+// Covers: what a client may and may not conclude from a crosspost, and how it gets the rest.
+//
+// pkc-js ships tier 1 only. There is no tier-2 helper and none is needed: a client that wants the
+// referenced comment's live state builds an instance from the embedded record and updates it —
+//
+//   const original = await pkc.createComment({ cid: comment.crosspost.cid, raw: { comment: comment.crosspost.comment } });
+//   await original.update();
+//
+// which loads the CommentUpdate from the community named in the embedded record and verifies its
+// signature through the existing path. Because cid is inside CommentUpdateSignedPropertyNames and
+// the CID hashes the entire record, a valid update is that community attesting to exactly these
+// bytes, unsigned extras included.
+import { describe, it } from "vitest";
+
+describe("crosspost is exposed on the Comment instance", () => {
+    it.todo("comment.crosspost is set from CommentIpfs");
+    it.todo("comment.crosspost is set from a comment inside a page");
+    it.todo("comment.crosspost is set on the instance before publishing (deferred signing)");
+    it.todo("comment.raw.comment.crosspost matches comment.crosspost");
+    it.todo("comment.crosspost is undefined on a comment that is not a crosspost");
+    it.todo("crosspost survives toJSON / createComment round-tripping");
+});
+
+describe("building an instance for the referenced comment", () => {
+    it.todo("createComment({ cid: crosspost.cid, raw: { comment: crosspost.comment } }) returns a usable instance");
+    it.todo("the instance's community is the one named in the embedded record, not the crossposting community");
+    it.todo("calling update() on it loads the referenced comment's CommentUpdate");
+    it.todo("the loaded CommentUpdate's signature is verified against the referenced community");
+    it.todo("a CommentUpdate signed by the wrong community is rejected");
+    it.todo("a CommentUpdate whose cid does not match crosspost.cid is rejected");
+    it.todo("update() failing (community offline) does not invalidate the crosspost itself");
+});
+
+// Everything below is unsigned by the author and therefore attacker-chosen until the referenced
+// community's CommentUpdate is loaded and verified. Whoever builds the crosspost picks both the
+// bytes and the cid, so the tier-1 cid check does not constrain these.
+describe("what tier 1 does NOT establish", () => {
+    it.todo("thumbnailUrl/thumbnailUrlWidth/thumbnailUrlHeight on the embedded record are attacker-chosen at tier 1");
+    it.todo("depth on the embedded record is attacker-chosen at tier 1");
+    it.todo("previousCid on the embedded record is attacker-chosen at tier 1");
+    it.todo("pseudonymityMode on the embedded record is attacker-chosen at tier 1");
+    it.todo("'crossposted from C' is an author claim at tier 1, not a fact");
+    it.todo("the referenced community accepting the comment is not established at tier 1");
+    it.todo("karma and removal/deletion state are unavailable at tier 1 by definition");
+});
+
+// crosspost and quotedCids are both author-signed references and are not interchangeable.
+//   quotedCids: 'my text refers to these comments' — zero or many, inline, no embedding.
+//   crosspost:  'this post IS a repost of that comment' — exactly one, embedded, the post's identity.
+describe("crosspost vs quotedCids", () => {
+    it.todo("a comment can carry both crosspost and quotedCids");
+    it.todo("quotedCids does not embed anything and stays reference-only");
+    it.todo("crosspost is a single object, not an array");
+    it.todo("quotedCids validation (same-thread, exists, not pending) does not apply to crosspost.cid");
+});

--- a/test/node-and-browser/crosspost/schema.test.ts
+++ b/test/node-and-browser/crosspost/schema.test.ts
@@ -1,0 +1,64 @@
+// Test foundations for crossposts (issue #32).
+// Design-only scaffolding: every case is it.todo until the feature is implemented.
+// Covers: the `crosspost` field on CreateCommentOptionsSchema and everything derived from it.
+//
+// Shape:
+//   crosspost: { cid: CidString, comment: CommentIpfs }   // optional, the full record verbatim
+//
+// The field lives on CreateCommentOptionsSchema, which is a self-cycle: CommentIpfsSchema is
+// derived from it (CreateCommentOptions -> CommentPubsubMessagePublication ->
+// CommentPubsubMessageWithFlexibleAuthor -> CommentIpfs). A plain `z.lazy` getter is not enough
+// here (unlike CommentUpdate.replies, whose cycle runs through the pages schema) — it collapses
+// CommentSignedPropertyNames, commentPubsubKeys and CommentIpfsSchema to `any`. The cycle has to
+// be severed with an explicitly annotated z.ZodType plus a hand-declared interface, and the two
+// kept honest by a bidirectional type assertion.
+import { describe, it } from "vitest";
+
+describe("crosspost field on CreateCommentOptionsSchema", () => {
+    it.todo("crosspost is optional — a comment without it parses");
+    it.todo("crosspost requires both cid and comment — neither alone parses");
+    it.todo("crosspost.cid must be a valid CID string");
+    it.todo("crosspost.comment must be a full CommentIpfs (signature, depth, timestamp present)");
+    it.todo("an unknown key directly on crosspost (beside cid/comment) is rejected");
+});
+
+// CommentSignedPropertyNames is keys(omit(CreateCommentOptionsSchema.shape, keysToOmitFromSignedPropertyNames)),
+// and CommentIpfsReservedFields / CommentPubsubMessageReservedFields are `difference` computations
+// against the same shape. Adding the field to the shape is supposed to be enough. These cases exist
+// to catch a refactor that quietly breaks that derivation.
+describe("derived lists pick up crosspost with no hand-editing", () => {
+    it.todo("crosspost is in CommentSignedPropertyNames");
+    it.todo("crosspost is NOT in CommentPubsubMessageReservedFields");
+    it.todo("crosspost is NOT in CommentIpfsReservedFields");
+    it.todo("crosspost is in the signature.signedPropertyNames of a published crossposting comment");
+});
+
+// The embedded record is content-addressed by crosspost.cid, so ANY normalization of it breaks the
+// crosspost. This is the single most dangerous property of the design: zod's strip behavior is
+// per-schema, so a nested schema left at the default (strip) would silently delete author-signed
+// extra props on the embedded record. crosspost.comment must be loose everywhere it appears.
+describe("the embedded record is never normalized", () => {
+    it.todo("crosspost.comment is parsed loosely — unknown props on the embedded record are preserved");
+    it.todo("an embedded record carrying author-signed extra props parses and keeps them byte-for-byte");
+    it.todo("CommentIpfsSchema.strip().parse() on the outer comment does not strip inside crosspost.comment");
+    it.todo("the parse helpers return the original object, so the embedded record survives round-tripping");
+    it.todo("deterministicStringify of the parsed comment equals deterministicStringify of the input");
+});
+
+// Chains nest records. No explicit depth cap: the 40kb publication limit bounds publishing, and each
+// level of nesting eats the budget for the next.
+describe("crosspost chains (crossposting a crosspost)", () => {
+    it.todo("a comment whose crosspost.comment itself has a crosspost parses");
+    it.todo("a three-deep chain parses and each level is reachable");
+    it.todo("no artificial nesting-depth limit is enforced by the schema");
+    it.todo("a chain that would exceed 40kb cannot be published (bounded by the size limit, not a depth cap)");
+});
+
+// The recursion is severed with an annotated z.ZodType + hand-declared interface. If the interface
+// and the inferred schema type ever drift, the crosspost branch of CommentIpfs silently stops
+// matching the rest of it.
+describe("recursive type declaration stays in sync with the schema", () => {
+    it.todo("the hand-declared crosspost interface is structurally equal to z.infer<typeof CommentIpfsSchema>");
+    it.todo("CommentIpfsType retains concrete field types (has not degraded to any)");
+    it.todo("nested access through crosspost.comment.crosspost.comment is typed");
+});

--- a/test/node-and-browser/crosspost/verification.test.ts
+++ b/test/node-and-browser/crosspost/verification.test.ts
@@ -1,0 +1,65 @@
+// Test foundations for crossposts (issue #32).
+// Design-only scaffolding: every case is it.todo until the feature is implemented.
+// Covers: tier-1 verification of the embedded record — local, no network.
+//
+// Tier 1 proves who wrote the embedded content and that they *claim* it was posted to
+// crosspost.comment's community. It proves nothing about the fields the hosting community added
+// and the author never signed (depth, thumbnailUrl*, previousCid, pseudonymityMode), and nothing
+// about that community having accepted the comment at all.
+//
+//   1. CID(deterministicStringify(crosspost.comment)) === crosspost.cid
+//   2. the embedded record's author signature verifies
+//   3. the embedded record carries no reserved/runtime fields
+//
+// Placed on verifyCommentPubsubMessage rather than verifyCommentIpfs, so the one call site covers
+// both the community's acceptance path and every client fetch path (verifyCommentIpfs delegates).
+import { describe, it } from "vitest";
+
+describe("tier 1 check 1: cid matches the embedded bytes", () => {
+    it.todo("a crosspost whose cid is the hash of crosspost.comment verifies");
+    it.todo("a crosspost whose cid points at different bytes is rejected");
+    it.todo("mutating any field of crosspost.comment without updating cid is rejected");
+    it.todo("mutating cid without changing crosspost.comment is rejected");
+    it.todo("an embedded record with extra props hashes with those props included");
+    it.todo("the rejection reason is the crosspost cid-mismatch message, not a generic signature error");
+});
+
+describe("tier 1 check 2: the embedded record's author signature", () => {
+    it.todo("a valid embedded record verifies");
+    it.todo("an embedded record with a tampered content field is rejected");
+    it.todo("an embedded record signed by a different key than it claims is rejected");
+    it.todo("an embedded record whose signedPropertyNames omit a present field is rejected");
+    it.todo("the embedded record's author signature is verified independently of the outer comment's");
+    it.todo("a valid embedded record inside an outer comment with a broken signature is still rejected overall");
+});
+
+describe("tier 1 check 3: no reserved fields on the embedded record", () => {
+    it.todo("an embedded record with a CommentIpfsReservedFields key is rejected");
+    it.todo("an embedded record with a reserved author field (e.g. nameResolved) is rejected");
+    it.todo("an embedded record with legitimate CommentIpfs fields (depth, previousCid) is accepted");
+});
+
+// The embedded record belongs to a different community by construction. verifyCommentIpfs compares
+// the record's community against the instance's; that comparison must not be applied to the
+// embedded record or every crosspost from another community fails.
+describe("the embedded record is not checked against the host community", () => {
+    it.todo("communityNameFromInstance is not propagated into the embedded record's verification");
+    it.todo("a crosspost of a comment from a different community verifies");
+    it.todo("a crosspost of a comment from a community with a rotated key verifies");
+    it.todo("crossposting a comment from the host community itself is allowed (not treated as a mismatch)");
+});
+
+describe("chains verify recursively", () => {
+    it.todo("a two-level chain verifies at every level");
+    it.todo("a broken signature at the innermost level fails the whole outer comment");
+    it.todo("a cid mismatch at an intermediate level fails the whole outer comment");
+    it.todo("no depth cap is enforced during verification");
+});
+
+// The tier-1 result is what the community enforces at acceptance. It never fetches the referenced
+// community, so accepting a publication does not depend on a third party's uptime.
+describe("verification does no network I/O", () => {
+    it.todo("tier-1 verification of a crosspost makes no gateway or IPFS request");
+    it.todo("a crosspost referencing a community that is offline still verifies at tier 1");
+    it.todo("a crosspost referencing a cid that no longer exists anywhere still verifies at tier 1");
+});

--- a/test/node-and-browser/publications/comment/publish/crosspost.test.ts
+++ b/test/node-and-browser/publications/comment/publish/crosspost.test.ts
@@ -1,0 +1,54 @@
+// Test foundations for crossposts (issue #32).
+// Design-only scaffolding: every case is it.todo until the feature is implemented.
+// Covers: publishing a crosspost end to end. Mirrors quotedCids.test.ts, which is the closest
+// existing precedent for an author-signed reference field added to CreateCommentOptions.
+//
+// The crossposting comment may be a post or a reply — unlike quotedCids, which is replies-only.
+import { describe, it } from "vitest";
+
+describe("publishing a crosspost", () => {
+    it.todo("a post carrying a valid crosspost is accepted");
+    it.todo("a reply carrying a valid crosspost is accepted");
+    it.todo("crosspost is present on pubsubMessageToPublish after publishing");
+    it.todo("crosspost is present in the resulting CommentIpfs");
+    it.todo("crosspost fetched back from IPFS is byte-identical to what was published");
+    it.todo("crosspost survives a community restart and is served from pages unchanged");
+    it.todo("a crosspost of a comment from a different community is accepted");
+    it.todo("a crosspost of a comment from this same community is accepted");
+    it.todo("a comment whose only content is a crosspost (no title/content/link) — decide and pin the behavior");
+});
+
+describe("the community enforces tier 1 at acceptance", () => {
+    it.todo("a crosspost with a cid that does not match the embedded bytes is rejected");
+    it.todo("a crosspost whose embedded record has a broken author signature is rejected");
+    it.todo("a crosspost whose embedded record carries a reserved field is rejected");
+    it.todo("acceptance does not fetch the referenced community");
+    it.todo("acceptance succeeds while the referenced community is offline");
+    it.todo("the challenge failure reason is the specific crosspost message");
+});
+
+describe("chains", () => {
+    it.todo("crossposting a crosspost is accepted");
+    it.todo("a three-deep chain is accepted while under 40kb");
+    it.todo("a chain that pushes the publication over 40kb is rejected with ERR_REQUEST_PUBLICATION_OVER_ALLOWED_SIZE");
+    it.todo("the size limit is measured on the whole publication, so nesting eats the content budget");
+});
+
+// The outer comment is re-signed with an alias signer under pseudonymity; the embedded record is
+// cloned untouched, so its own signature survives.
+describe("crossposts under pseudonymityMode", () => {
+    it.todo("a crosspost published to a community with pseudonymityMode is accepted");
+    it.todo("the outer comment's signature is the alias signer's");
+    it.todo("the embedded record's author and signature are unchanged by anonymization");
+    it.todo("the embedded record still verifies at tier 1 after anonymization");
+    it.todo("originalCommentSignatureEncoded is set on the outer comment only");
+});
+
+describe("moderating a crosspost as if it were a normal comment", () => {
+    it.todo("a mod can remove a crossposting comment");
+    it.todo("a mod can lock/pin/flag a crossposting comment");
+    it.todo("an author can edit the crossposting comment's own content");
+    it.todo("editing the crossposting comment does not alter the embedded record");
+    it.todo("the crossposting comment can be voted on independently of the referenced comment");
+    it.todo("removing the crossposting comment has no effect on the referenced comment");
+});

--- a/test/node/community/features/noCrossposts.community.features.test.ts
+++ b/test/node/community/features/noCrossposts.community.features.test.ts
@@ -1,0 +1,64 @@
+// Test foundations for crossposts (issue #32).
+// Design-only scaffolding: every case is it.todo until the feature is implemented.
+// Covers: community.features.noCrossposts, which is already reserved on CommunityFeaturesSchema
+// and currently marked "Not implemented".
+//
+// noCrossposts is an INBOUND rule: it governs what this community accepts, not what other
+// communities may do with this community's comments. It is enforced by the community at
+// acceptance time, alongside the other feature toggles in checkCommentPublication.
+import { describe, it } from "vitest";
+
+describe("community.features.noCrossposts — default and propagation", () => {
+    it.todo("features is undefined on a fresh community and crossposts are allowed");
+    it.todo("noCrossposts is updated correctly in props after community.edit");
+    it.todo("noCrossposts propagates to a remote community instance");
+    it.todo("noCrossposts survives a community stop/start");
+    it.todo("noCrossposts is no longer marked 'Not implemented' in CommunityFeaturesSchema");
+    it.todo("setting noCrossposts: false is equivalent to leaving it unset");
+});
+
+describe("noCrossposts: true rejects crossposts", () => {
+    it.todo("a post carrying a crosspost is rejected");
+    it.todo("a reply carrying a crosspost is rejected");
+    it.todo("a crosspost chain is rejected");
+    it.todo("the rejection reason is the specific noCrossposts message");
+    it.todo("the rejection happens even when the crosspost is otherwise fully valid at tier 1");
+    it.todo("the rejection happens even when the crosspost references this same community");
+    it.todo("the rejected comment is not written to the db");
+    it.todo("the rejected comment's cid is not pinned/left behind in IPFS");
+});
+
+describe("noCrossposts: true still allows everything else", () => {
+    it.todo("a plain post is accepted");
+    it.todo("a plain reply is accepted");
+    it.todo("a reply carrying quotedCids is accepted (quotedCids is not a crosspost)");
+    it.todo("a post with a link is accepted");
+    it.todo("votes, edits and moderations are unaffected");
+});
+
+describe("toggling noCrossposts", () => {
+    it.todo("enabling it rejects a crosspost that was accepted moments before");
+    it.todo("disabling it re-allows crossposts");
+    it.todo("crossposts stored while it was off remain in the db after enabling it");
+    it.todo("crossposts stored while it was off are still served in pages after enabling it");
+    it.todo("crossposts stored while it was off can still be moderated, edited and voted on after enabling it");
+    it.todo("enabling it does not purge or invalidate existing crossposts");
+});
+
+describe("enforcement is community-side, not client-side", () => {
+    it.todo("a client holding a stale community record without noCrossposts is still rejected");
+    it.todo("a hand-built publication that bypasses client-side checks is still rejected");
+    it.todo("the rejection is delivered as a challenge failure, not a schema error");
+});
+
+describe("noCrossposts is inbound only", () => {
+    it.todo("a community with noCrossposts can still have its own comments crossposted elsewhere");
+    it.todo("a community without noCrossposts accepts a crosspost of a comment from a noCrossposts community");
+});
+
+describe("interaction with other features", () => {
+    it.todo("noCrossposts combined with pseudonymityMode rejects before anonymization");
+    it.todo("noCrossposts combined with requirePostLink reports the crosspost reason for a crossposting post");
+    it.todo("noCrossposts combined with noNestedReplies rejects a nested crossposting reply for the crosspost reason");
+    it.todo("a malformed crosspost is a schema error regardless of noCrossposts");
+});

--- a/test/node/crosspost/db.test.ts
+++ b/test/node/crosspost/db.test.ts
@@ -1,0 +1,49 @@
+// Test foundations for crossposts (issue #32).
+// Design-only scaffolding: every case is it.todo until the feature is implemented.
+// Covers: persistence of the crosspost field on the community side.
+//
+// crosspost is stored as a single JSON column on the comments table so the embedded record
+// round-trips verbatim. Reads need no special handling — parseDbResponses parses JSON columns
+// generically and deriveCommentIpfsFromCommentTableRow picks by keys(CommentIpfsSchema.shape).
+import { describe, it } from "vitest";
+
+describe("crosspost column on the comments table", () => {
+    it.todo("the column exists after createOrMigrateTablesIfNeeded");
+    it.todo("a comment without a crosspost stores NULL");
+    it.todo("a crossposting comment stores the full crosspost object as JSON");
+    it.todo("dbHandler.queryComment returns crosspost as an object, not a string");
+    it.todo("the returned crosspost.comment is deep-equal to what was published");
+    it.todo("a crosspost chain round-trips through the column intact");
+    it.todo("an embedded record with extra props round-trips with those props intact");
+});
+
+// This is the regression guard for the nested-strip footgun. storePublication runs
+// CommentIpfsSchema.strip().parse() before building the row; zod's strip behavior is per-schema,
+// so a nested crosspost.comment left at the default would have its unknown props silently deleted.
+// The row is what deriveCommentIpfsFromCommentTableRow reconstructs the CID from during page
+// generation, so any loss here changes the CID, breaks pages, and gets the comment purged by
+// _purgeCommentsWithInvalidSchemaOrSignature.
+describe("CID stability through the db round trip", () => {
+    it.todo("deriveCommentIpfsFromCommentTableRow reproduces the original CID for a crossposting comment");
+    it.todo("the reconstructed CommentIpfs is byte-identical to the one that was hashed");
+    it.todo("an embedded record with extra props still reproduces the original CID");
+    it.todo("a chained crosspost still reproduces the original CID");
+    it.todo("strip() on the outer comment does not remove props inside crosspost.comment");
+    it.todo("_purgeCommentsWithInvalidSchemaOrSignature does not purge a valid crossposting comment");
+    it.todo("page generation emits the crossposting comment with its crosspost intact");
+});
+
+describe("DB migration", () => {
+    it.todo("an old-schema db migrates and gains the crosspost column");
+    it.todo("existing comments migrate with crosspost NULL");
+    it.todo("migrated comments still reproduce their original CIDs");
+    it.todo("migrated comments are not purged by the post-migration signature sweep");
+    it.todo("a crossposting comment inserted before migration survives it intact");
+});
+
+describe("crosspost under pseudonymityMode in the db", () => {
+    it.todo("the stored outer comment carries the alias signature");
+    it.todo("the stored crosspost.comment carries the original author's signature");
+    it.todo("originalCommentSignatureEncoded is set for the outer comment only");
+    it.todo("the anonymized row still reproduces its CID");
+});


### PR DESCRIPTION
Test scaffolding for crossposts (#32), following the settled design on that issue. **No `src/` changes** — every case is `it.todo` until the feature is implemented.

158 cases across six files. `npx tsc --project test/tsconfig.json --noEmit` is clean and all six files run (57 todo under `local-kubo-rpc`, 101 under `remote-kubo-rpc`).

| File | Covers |
|---|---|
| `test/node-and-browser/crosspost/schema.test.ts` | derived-list membership, embedded-record preservation, chains, recursive-type sync |
| `test/node-and-browser/crosspost/verification.test.ts` | the three tier-1 checks, host-community isolation, recursive chains, no network I/O |
| `test/node-and-browser/crosspost/client-consumption.test.ts` | instance exposure, building the referenced comment, what tier 1 does not establish, crosspost vs `quotedCids` |
| `test/node-and-browser/publications/comment/publish/crosspost.test.ts` | publish end to end, community-side tier-1 enforcement, chains and the 40kb bound, pseudonymity, moderating a crosspost |
| `test/node/community/features/noCrossposts.community.features.test.ts` | default and propagation, rejection cases, what stays allowed, toggling, community-side enforcement, inbound-only semantics, feature interactions |
| `test/node/crosspost/db.test.ts` | the JSON column, CID stability through the db round trip, migration, pseudonymity |

### Design decisions these stubs pin down

Resolved while planning, beyond what the settled-design comment already covers:

- A crossposting comment **may be a reply**, not posts-only (unlike `quotedCids`, which is replies-only).
- **No nesting-depth cap.** The 40kb publication limit is the only bound on chains. The cases state this explicitly so the behavior is pinned either way.
- Crossposting a comment from the **host community itself is allowed**, and is not to be treated as a community mismatch.
- **No tier-2 helper ships.** A client that wants the referenced comment's live state does `createComment({ cid: crosspost.cid, raw: { comment: crosspost.comment } })` then `update()`, which goes through the existing verification path.

### The one group worth reading closely

`db.test.ts` > "CID stability through the db round trip" is the regression guard for the single failure mode that would read as a flake rather than a bug.

`storePublication` runs `CommentIpfsSchema.strip().parse()` before building the comments row. Zod's strip behavior is per-schema, so leaving `crosspost.comment` at the default (strip) would silently delete author-signed extra props from the embedded record. That changes the CID reconstructed by `deriveCommentIpfsFromCommentTableRow` during page generation, breaks pages, and gets the comment purged by `_purgeCommentsWithInvalidSchemaOrSignature`. `crosspost.comment` has to be loose everywhere it appears.

### Also de-risked while planning (not in this PR)

`crosspost.comment: CommentIpfsSchema` inside `CreateCommentOptionsSchema` is a true self-cycle, since `CommentIpfs` is derived from `CreateCommentOptions`. A spike found that a plain `z.lazy` getter does **not** work — it produces `TS7023`/`TS7022`/`TS2615` and collapses `CommentSignedPropertyNames`, `commentPubsubKeys` and `CommentIpfsSchema` to `any`. The `CommentUpdate.replies` getter idiom does not transfer, because that cycle runs through the pages schema rather than through the shape the pubsub schema is `.pick()`ed from. An explicitly annotated `z.ZodType` plus a hand-declared interface does work, with a bidirectional type assertion keeping the interface from drifting. That lands in Phase 1.

Full phased plan: https://github.com/pkcprotocol/pkc-js/issues/32#issuecomment-5156570022

Refs #32


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added planned coverage for crosspost publication, validation, persistence, verification, and moderation behavior.
  * Documented scenarios for recursive crossposts, comment reconstruction, CID and signature validation, and pseudonymity.
  * Added test plans for communities that disable crossposts, including runtime configuration changes and inbound activity handling.
  * Added coverage plans for schema validation, database migration, and preservation of embedded records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->